### PR TITLE
Spack Package Build - conformed to flake8

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -1,17 +1,25 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 
 class Pdc(CMakePackage):
-    """Proactive Data Containers (PDC) software provides an object-centric API and a runtime system with a set of 
-       data object management services. These services allow placing data in the memory and storage hierarchy, 
-       performing data movement asynchronously, and providing scalable metadata operations to find data objects."""
+    """Proactive Data Containers (PDC) software provides an object-centric
+    API and a runtime system with a set of data object management services.
+    These services allow placing data in the memory and storage hierarchy,
+    performing data movement asynchronously, and providing scalable
+    metadata operations to find data objects."""
 
     homepage = "https://pdc.readthedocs.io/en/latest/"
-    url      = "https://github.com/hpc-io/pdc/archive/refs/tags/0.1.tar.gz"
+    url = "https://github.com/hpc-io/pdc/archive/refs/tags/0.1.tar.gz"
 
     maintainers = ['houjun', 'sbyna']
 
-    version('0.1', sha256='24787806a30cd1cda1fed17220a62e768bdba5de56877f2ea7126279ff2a4f69')
+    version('0.1',
+            sha256='24787806a30cd1cda1fed17220a62e768bdba5de56877f2ea7126279ff2a4f69')
 
     conflicts('%clang')
     depends_on('libfabric@1.11.2')

--- a/spack/package.py
+++ b/spack/package.py
@@ -14,12 +14,11 @@ class Pdc(CMakePackage):
     metadata operations to find data objects."""
 
     homepage = "https://pdc.readthedocs.io/en/latest/"
-    url = "https://github.com/hpc-io/pdc/archive/refs/tags/0.1.tar.gz"
+    url      = "https://github.com/hpc-io/pdc/archive/refs/tags/0.1.tar.gz"
 
     maintainers = ['houjun', 'sbyna']
 
-    version('0.1',
-            sha256='24787806a30cd1cda1fed17220a62e768bdba5de56877f2ea7126279ff2a4f69')
+    version('0.1', sha256='24787806a30cd1cda1fed17220a62e768bdba5de56877f2ea7126279ff2a4f69')
 
     conflicts('%clang')
     depends_on('libfabric@1.11.2')


### PR DESCRIPTION
- Added Spack license
- Added 2 blank lines after imports
- Made docstring shorter per line (less than 88 characters)
- Removed trailing whitespace