### PR TITLE
Fix install in Spack

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -25,7 +25,7 @@ class Pdc(CMakePackage):
     version('develop', branch='develop')
 
     conflicts('%clang')
-    depends_on('libfabric')
+    depends_on('libfabric@1.11.2')
     depends_on('mercury')
     depends_on('mpi')
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -14,14 +14,18 @@ class Pdc(CMakePackage):
     metadata operations to find data objects."""
 
     homepage = "https://pdc.readthedocs.io/en/latest/"
-    url      = "https://github.com/hpc-io/pdc/archive/refs/tags/0.1.tar.gz"
+    git      = "https://github.com/hpc-io/pdc.git"
 
     maintainers = ['houjun', 'sbyna']
 
-    version('0.1', sha256='24787806a30cd1cda1fed17220a62e768bdba5de56877f2ea7126279ff2a4f69')
+    version('0.2', tag='0.2')
+    version('0.1', tag='0.1')
+    
+    version('stable', branch='stable')
+    version('develop', branch='develop')
 
     conflicts('%clang')
-    depends_on('libfabric@1.11.2')
+    depends_on('libfabric')
     depends_on('mercury')
     depends_on('mpi')
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -432,6 +432,7 @@ install(
   FILES
     ${PDC_BINARY_DIR}/bin/pdc_server.exe
     ${PDC_BINARY_DIR}/bin/close_server
+  PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
   DESTINATION
     ${CMAKE_INSTALL_PREFIX}/bin
 )


### PR DESCRIPTION
PDC installation using spack was not giving the correct permissions to run the executable. This fixes it and also includes additional versions to make it easier to test new features with VOL-PDC, for instance. If approved, the PR needs to be 