### PR TITLE
Update documentation for Perlmutter

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -168,3 +168,19 @@ Run 64 client processes that concurrently create 1000 objects in total:
 
 	srun -N 4 -n 64 -c 2 --mem=25600 --cpu_bind=cores --gres=craynetwork:1 --overlap ./bin/create_obj_scale -r 1000
 
+PDC on Perlmutter
+---------------------------
+
+For job allocation on Perlmutter make sure you are using the most recent version of Cray MPICH (8.1.17). You can verify that with `echo $CRAY_MPICH_VERSION`. You also need to export `FI_CXI_DEFAULT_VNI` environment variable to a unique value for each concurrent srun command that shares a node, otherwise you will receive "MPI OFI Address already in use".
+
+.. code-block:: Bash
+
+	export FI_CXI_DEFAULT_VNI=0
+	srun --overlap --exact --cpu-bind=sockets,verbose -u -n 2 -c 1 ./bin/pdc_server.exe &
+	
+.. code-block:: Bash
+
+	export FI_CXI_DEFAULT_VNI=1
+	srun --overlap --exact --cpu-bind=sockets,verbose -u -n 2 -c 1 ./bin/create_obj_scale -r 1000
+
+Notice the distinct values for `FI_CXI_DEFAULT_VNI`.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -171,7 +171,7 @@ Run 64 client processes that concurrently create 1000 objects in total:
 PDC on Perlmutter
 ---------------------------
 
-For job allocation on Perlmutter make sure you are using the most recent version of Cray MPICH (8.1.17). You can verify that with `echo $CRAY_MPICH_VERSION`. You also need to export `FI_CXI_DEFAULT_VNI` environment variable to a unique value for each concurrent srun command that shares a node, otherwise you will receive "MPI OFI Address already in use".
+For job allocation on Perlmutter make sure you are using the most recent version of Cray MPICH (8.1.17). You can verify that with ``echo $CRAY_MPICH_VERSION``. You also need to export ``FI_CXI_DEFAULT_VNI`` environment variable to a unique value for each concurrent srun command that shares a node, otherwise you will receive "MPI OFI Address already in use".
 
 .. code-block:: Bash
 


### PR DESCRIPTION
Update documentation for Perlmutter to avoid the 'MPI OFI Address already in use' error.