### PR TITLE
fix MAX_CACHE_SIZE compilation issue

### DIFF
--- a/src/server/pdc_server_region/pdc_server_region_cache.c
+++ b/src/server/pdc_server_region/pdc_server_region_cache.c
@@ -5,7 +5,7 @@
 
 #ifdef PDC_SERVER_CACHE_MAX_SIZE
 #define MAX_CACHE_SIZE PDC_SERVER_CACHE_MAX_GB * 1024 * 1024 * 1024
-else
+#else
 #define MAX_CACHE_SIZE 34359738368
 #endif
 
@@ -15,7 +15,7 @@ else
 #define PDC_CACHE_FLUSH_TIME_INT 30
 #endif
 
-    typedef struct pdc_region_cache {
+typedef struct pdc_region_cache {
     struct pdc_region_info * region_cache_info;
     struct pdc_region_cache *next;
 } pdc_region_cache;


### PR DESCRIPTION
This is a quick fix to unblock NERSC-CI from the MAX_CACHE_SIZE compilation issue. 