### PR TITLE
Update requirements.txt for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
+sphinx==6.2.1
+sphinx-rtd-theme==1.2.2
 sphinxemoji
 breathe


### PR DESCRIPTION
Update requirements.txt for readthedocs since due to changes on their side, these dependencies should now be explicitly stated in the requirements.txt file.