### PR TITLE
Fix region transfer with object static partitioning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ perlmutter-no-cache-build:
         SUPERCOMPUTER: "perlmutter"
         MERCURY_DIR: "/global/cfs/cdirs/${PDC_PROJECT}/pdc-perlmutter/mercury/install"
     script:
-        - module load libfabric/1.15.2.0
+        - module load libfabric
         - module list
         - mkdir -p ${PDC_BUILD_PATH}/perlmutter/no-cache
         - cd ${PDC_BUILD_PATH}/perlmutter/no-cache
@@ -51,7 +51,7 @@ perlmutter-cache-build:
         SUPERCOMPUTER: "perlmutter"
         MERCURY_DIR: "/global/cfs/cdirs/${PDC_PROJECT}/pdc-perlmutter/mercury/install"
     script:
-        - module load libfabric/1.15.2.0
+        - module load libfabric
         - module list
         - mkdir -p ${PDC_BUILD_PATH}/perlmutter/cache
         - cd ${PDC_BUILD_PATH}/perlmutter/cache
@@ -374,7 +374,7 @@ perlmutter-metrics-build:
         SUPERCOMPUTER: "perlmutter"
         MERCURY_DIR: "/global/cfs/cdirs/${PDC_PROJECT}/pdc-perlmutter/mercury/install"
     script:
-        - module load libfabric/1.15.2.0
+        - module load libfabric
         - module list
         - mkdir -p ${PDC_BUILD_PATH}/perlmutter/metrics
         - cd ${PDC_BUILD_PATH}/perlmutter/metrics

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -433,6 +433,7 @@ static_region_partition(char *buf, int ndim, uint64_t unit, pdc_access_t access_
     }
     // Use the remainder theorem to split along one dimension of regions.
     s = obj_dims[split_dim] / pdc_server_num_g;
+    if (s == 0) s = 1;
     x = pdc_server_num_g - obj_dims[split_dim] % pdc_server_num_g;
 
     *data_server_ids = (uint32_t *)malloc(sizeof(uint32_t) * pdc_server_num_g);

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -433,7 +433,8 @@ static_region_partition(char *buf, int ndim, uint64_t unit, pdc_access_t access_
     }
     // Use the remainder theorem to split along one dimension of regions.
     s = obj_dims[split_dim] / pdc_server_num_g;
-    if (s == 0) s = 1;
+    if (s == 0)
+        s = 1;
     x = pdc_server_num_g - obj_dims[split_dim] % pdc_server_num_g;
 
     *data_server_ids = (uint32_t *)malloc(sizeof(uint32_t) * pdc_server_num_g);


### PR DESCRIPTION
# Related Issues / Pull Requests

#215 

# Description
Fix a bug when all dim lengths of an object are smaller than the number of servers when object static partitioning (default) is used.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
