### PR TITLE
Check the return value of `PDC_Client_init` in `PDC_init`

### DIFF
--- a/src/api/pdc.c
+++ b/src/api/pdc.c
@@ -108,7 +108,8 @@ PDCinit(const char *pdc_name)
         PGOTO_ERROR(FAIL, "PDC region transfer init error");
 
     // PDC Client Server connection init
-    PDC_Client_init();
+    if (PDC_Client_init() < 0)
+        PGOTO_ERROR(FAIL, "PDC client init error");
 #ifdef PDC_TIMING
     PDC_timing_init();
 #endif

--- a/src/api/pdc.c
+++ b/src/api/pdc.c
@@ -109,7 +109,7 @@ PDCinit(const char *pdc_name)
 
     // PDC Client Server connection init
     if (PDC_Client_init() < 0)
-        PGOTO_ERROR(FAIL, "PDC client init error");
+        PGOTO_ERROR(0, "PDC client init error");
 #ifdef PDC_TIMING
     PDC_timing_init();
 #endif


### PR DESCRIPTION
# What changes are proposed in this pull request?

`PDC_init` was not checking the return value of `PDC_Client_init`.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes