### PR TITLE
Change .clang-format to use Language: C instead of Cpp

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 ---
-Language:        Cpp
+Language:        C
 BasedOnStyle:  LLVM
 AlignConsecutiveAssignments: true
 #llvm11: AlignConsecutiveBitFields: false


### PR DESCRIPTION
If `Language` is set to `Cpp`  it results in the following error:

```
clang-format -i -style=file src/api/pdc.c
Configuration file(s) do(es) not support C: /home/nlewi26/src/work_space/source/pdc/.clang-format
```

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
