### PR TITLE
Add `pdc_logger.h` to installation

### DIFF
--- a/src/commons/CMakeLists.txt
+++ b/src/commons/CMakeLists.txt
@@ -74,6 +74,7 @@ install(
     ${PDC_SOURCE_DIR}/src/commons/utils/include/pdc_id_pkg.h
     ${PDC_SOURCE_DIR}/src/commons/utils/include/pdc_malloc.h
     ${PDC_SOURCE_DIR}/src/commons/utils/include/pdc_linkedlist.h
+    ${PDC_SOURCE_DIR}/src/commons/logging/include/pdc_logger.h
   DESTINATION
     ${PDC_INSTALL_INCLUDE_DIR}
   COMPONENT


### PR DESCRIPTION
# Related Issues / Pull Requests

This Resolves: https://github.com/hpc-io/pdc/issues/244#issue-2970939434

# Description

Add `pdc_logger.h` to installation include directory.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] New and existing unit tests pass locally with my changes
