### PR TITLE
Fix printing in `PGOTO_ERROR` and `PGOTO_ERROR_VOID`

### DIFF
--- a/src/commons/utils/include/pdc_private.h
+++ b/src/commons/utils/include/pdc_private.h
@@ -138,12 +138,14 @@ extern pbool_t err_occurred;
 #define PGOTO_ERROR(ret_val, ...)                                                                            \
     do {                                                                                                     \
         LOG_ERROR(__VA_ARGS__);                                                                              \
+        LOG_JUST_PRINT("\n");                                                                                \
         PGOTO_DONE(ret_val);                                                                                 \
     } while (0)
 
 #define PGOTO_ERROR_VOID(...)                                                                                \
     do {                                                                                                     \
         LOG_ERROR(__VA_ARGS__);                                                                              \
+        LOG_JUST_PRINT("\n");                                                                                \
         PGOTO_DONE_VOID;                                                                                     \
     } while (0)
 


### PR DESCRIPTION
Print new line by default in `PGOTO_ERROR` and `PGOTO_ERROR_VOID`.

# Checklist:
- [x] New and existing unit tests pass locally with my changes
