### PR TITLE
add option to choose interface

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,4 +33,4 @@ jobs:
           sudo sh -c 'echo "`ipconfig getifaddr en0` PDC" >> /etc/hosts'
           sudo scutil --set HostName PDC
           export HG_TRANSPORT="sockets"
-          ctest -L serial
+          ctest -L serial --output-on-failure

--- a/.github/workflows/ubuntu-cache.yml
+++ b/.github/workflows/ubuntu-cache.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Test PDC
         working-directory: build
-        run: ctest -L serial
+        run: ctest -L serial --output-on-failure

--- a/.github/workflows/ubuntu-no-cache.yaml
+++ b/.github/workflows/ubuntu-no-cache.yaml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Test PDC
         working-directory: build
-        run: ctest -L serial
+        run: ctest -L serial --output-on-failure

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -1354,7 +1354,11 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
 {
     perr_t ret_value = SUCCEED;
     char   na_info_string[NA_STRING_INFO_LEN];
+<<<<<<< HEAD
     char * hostname;
+=======
+    char*  hostname;
+>>>>>>> c74a2853 (free hostname)
     int    local_server_id;
     /* Set the default mercury transport
      * but enable overriding that to any of:
@@ -1379,11 +1383,9 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
         hg_transport = default_hg_transport;
     }
     if ((hostname = getenv("HG_HOST")) == NULL) {
-        hostname = malloc(HOSTNAME_LEN);
+        hostname = PDC_malloc(HOSTNAME_LEN);
         memset(hostname, 0, HOSTNAME_LEN);
         gethostname(hostname, HOSTNAME_LEN - 1);
-    } else {
-        find_hostname = false;
     }
     sprintf(na_info_string, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_client_mpi_rank_g == 0) {
@@ -1391,8 +1393,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
         fflush(stdout);
     }
 
-    if (find_hostname)
-        free(hostname);
+    free(hostname);
 
 // gni starts here
 #ifdef PDC_HAS_CRAY_DRC

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -43,6 +43,7 @@
 #include "pdc_transforms_common.h"
 #include "pdc_client_connect.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 #include "mercury.h"
 #include "mercury_macros.h"
@@ -1354,11 +1355,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
 {
     perr_t ret_value = SUCCEED;
     char   na_info_string[NA_STRING_INFO_LEN];
-<<<<<<< HEAD
     char * hostname;
-=======
-    char *hostname;
->>>>>>> c74a2853 (free hostname)
     int    local_server_id;
     /* Set the default mercury transport
      * but enable overriding that to any of:

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -1357,7 +1357,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
 <<<<<<< HEAD
     char * hostname;
 =======
-    char*  hostname;
+    char *hostname;
 >>>>>>> c74a2853 (free hostname)
     int    local_server_id;
     /* Set the default mercury transport

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -1354,7 +1354,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
 {
     perr_t ret_value = SUCCEED;
     char   na_info_string[NA_STRING_INFO_LEN];
-    char   hostname[HOSTNAME_LEN];
+    char*  hostname;
     int    local_server_id;
     /* Set the default mercury transport
      * but enable overriding that to any of:
@@ -1378,11 +1378,14 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
     if ((hg_transport = getenv("HG_TRANSPORT")) == NULL) {
         hg_transport = default_hg_transport;
     }
-    memset(hostname, 0, sizeof(hostname));
-    gethostname(hostname, sizeof(hostname));
+    if ((hostname = getenv("HG_HOST")) == NULL) {
+        hostname = malloc(HOSTNAME_LEN);
+        memset(hostname, 0, HOSTNAME_LEN);
+        gethostname(hostname, HOSTNAME_LEN - 1);
+    }
     sprintf(na_info_string, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_client_mpi_rank_g == 0) {
-        LOG_INFO("==PDC_CLIENT: using %.7s\n", na_info_string);
+        LOG_INFO("==PDC_CLIENT: using %s\n", na_info_string);
         fflush(stdout);
     }
 

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -1382,12 +1382,17 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
         hostname = malloc(HOSTNAME_LEN);
         memset(hostname, 0, HOSTNAME_LEN);
         gethostname(hostname, HOSTNAME_LEN - 1);
+    } else {
+        find_hostname = false;
     }
     sprintf(na_info_string, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_client_mpi_rank_g == 0) {
         LOG_INFO("==PDC_CLIENT: using %s\n", na_info_string);
         fflush(stdout);
     }
+
+    if (find_hostname)
+        free(hostname);
 
 // gni starts here
 #ifdef PDC_HAS_CRAY_DRC

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -1354,7 +1354,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
 {
     perr_t ret_value = SUCCEED;
     char   na_info_string[NA_STRING_INFO_LEN];
-    char*  hostname;
+    char * hostname;
     int    local_server_id;
     /* Set the default mercury transport
      * but enable overriding that to any of:

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -783,7 +783,11 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     int                 i         = 0;
     char                self_addr_string[ADDR_MAX];
     char                na_info_string[NA_STRING_INFO_LEN];
+<<<<<<< HEAD
     char *              hostname;
+=======
+    char*               hostname;
+>>>>>>> c74a2853 (free hostname)
     struct hg_init_info init_info = {0};
 
     /* Set the default mercury transport
@@ -821,15 +825,12 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
         hostname = PDC_malloc(HOSTNAME_LEN);
         memset(hostname, 0, HOSTNAME_LEN);
         gethostname(hostname, HOSTNAME_LEN - 1);
-    } else {
-        find_hostname = false;
     }
     snprintf(na_info_string, NA_STRING_INFO_LEN, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_server_rank_g == 0)
         LOG_INFO("==PDC_SERVER[%d]: using %s\n", pdc_server_rank_g, na_info_string);
 
-    if (find_hostname)
-        free(hostname);
+    free(hostname);
 
     // Clean up all the tmp files etc
     HG_Cleanup();

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -786,7 +786,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
 <<<<<<< HEAD
     char *              hostname;
 =======
-    char*               hostname;
+    char *hostname;
 >>>>>>> c74a2853 (free hostname)
     struct hg_init_info init_info = {0};
 

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -783,7 +783,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     int                 i         = 0;
     char                self_addr_string[ADDR_MAX];
     char                na_info_string[NA_STRING_INFO_LEN];
-    char*               hostname;
+    char *              hostname;
     struct hg_init_info init_info = {0};
 
     /* Set the default mercury transport

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -783,11 +783,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     int                 i         = 0;
     char                self_addr_string[ADDR_MAX];
     char                na_info_string[NA_STRING_INFO_LEN];
-<<<<<<< HEAD
     char *              hostname;
-=======
-    char *hostname;
->>>>>>> c74a2853 (free hostname)
     struct hg_init_info init_info = {0};
 
     /* Set the default mercury transport

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -818,13 +818,18 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
         hg_transport = default_hg_transport;
     }
     if ((hostname = getenv("HG_HOST")) == NULL) {
-        hostname = malloc(HOSTNAME_LEN);
+        hostname = PDC_malloc(HOSTNAME_LEN);
         memset(hostname, 0, HOSTNAME_LEN);
         gethostname(hostname, HOSTNAME_LEN - 1);
+    } else {
+        find_hostname = false;
     }
     snprintf(na_info_string, NA_STRING_INFO_LEN, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_server_rank_g == 0)
         LOG_INFO("==PDC_SERVER[%d]: using %s\n", pdc_server_rank_g, na_info_string);
+
+    if (find_hostname)
+        free(hostname);
 
     // Clean up all the tmp files etc
     HG_Cleanup();

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -783,7 +783,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     int                 i         = 0;
     char                self_addr_string[ADDR_MAX];
     char                na_info_string[NA_STRING_INFO_LEN];
-    char                hostname[HOSTNAME_LEN];
+    char*               hostname;
     struct hg_init_info init_info = {0};
 
     /* Set the default mercury transport
@@ -817,11 +817,14 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     if ((hg_transport = getenv("HG_TRANSPORT")) == NULL) {
         hg_transport = default_hg_transport;
     }
-    memset(hostname, 0, HOSTNAME_LEN);
-    gethostname(hostname, HOSTNAME_LEN - 1);
+    if ((hostname = getenv("HG_HOST")) == NULL) {
+        hostname = malloc(HOSTNAME_LEN);
+        memset(hostname, 0, HOSTNAME_LEN);
+        gethostname(hostname, HOSTNAME_LEN - 1);
+    }
     snprintf(na_info_string, NA_STRING_INFO_LEN, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_server_rank_g == 0)
-        LOG_INFO("==PDC_SERVER[%d]: using %.7s\n", pdc_server_rank_g, na_info_string);
+        LOG_INFO("==PDC_SERVER[%d]: using %s\n", pdc_server_rank_g, na_info_string);
 
     // Clean up all the tmp files etc
     HG_Cleanup();

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -58,6 +58,7 @@
 #include "pdc_server_region_cache.h"
 #include "pdc_server_region_transfer_metadata_query.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 #ifdef PDC_HAS_CRAY_DRC
 #include <rdmacred.h>


### PR DESCRIPTION
# Description

Add an option to overwrite the network interface used by PDC. In machines with multiple possible interfaces and for localhost development in Linux/MacOS, the loopback interface does not properly respond to Mercury/libfabric. This allows the user to specify an IP (and hence the interface) that PDC should use instead.

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
