### PR TITLE
Use `PDC_malloc`, `PDC_free`, `PDC_calloc`, and `PDC_realloc`

### DIFF
--- a/.github/workflows/ubuntu-cache.yml
+++ b/.github/workflows/ubuntu-cache.yml
@@ -2,10 +2,10 @@ name: Ubuntu (cache)
 
 on:
   pull_request:
-    branches: [ stable, develop ]
+    branches: [ stable, develop, pdc_malloc_free_calloc ]
 
   push:
-    branches: [ stable, develop ]
+    branches: [ stable, develop, pdc_malloc_free_calloc ]
 
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu-cache.yml
+++ b/.github/workflows/ubuntu-cache.yml
@@ -2,10 +2,10 @@ name: Ubuntu (cache)
 
 on:
   pull_request:
-    branches: [ stable, develop, pdc_malloc_free_calloc ]
+    branches: [ stable, develop ]
 
   push:
-    branches: [ stable, develop, pdc_malloc_free_calloc ]
+    branches: [ stable, develop ]
 
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu-no-cache.yaml
+++ b/.github/workflows/ubuntu-no-cache.yaml
@@ -2,10 +2,10 @@ name: Ubuntu (no-cache)
 
 on:
   pull_request:
-    branches: [ stable, develop, pdc_malloc_free_calloc ]
+    branches: [ stable, develop ]
 
   push:
-    branches: [ stable, develop, pdc_malloc_free_calloc ]
+    branches: [ stable, develop ]
 
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu-no-cache.yaml
+++ b/.github/workflows/ubuntu-no-cache.yaml
@@ -2,10 +2,10 @@ name: Ubuntu (no-cache)
 
 on:
   pull_request:
-    branches: [ stable, develop ]
+    branches: [ stable, develop, pdc_malloc_free_calloc ]
 
   push:
-    branches: [ stable, develop ]
+    branches: [ stable, develop, pdc_malloc_free_calloc ]
 
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Proactive Data Containers (PDC) software provides an object-focused data managem
 
 Full documentation of PDC with installation instructions, code examples for using PDC API, and research publications are available at [pdc.readthedocs.io](https://pdc.readthedocs.io)
 
-More information and publications on PDC is available at https://sdm.lbl.gov/pdc
+More information and publications on PDC are available at https://sdm.lbl.gov/pdc
 
 If you use PDC in your research, please use the following citations:
 

--- a/examples/read_write_col_perf.c
+++ b/examples/read_write_col_perf.c
@@ -117,6 +117,7 @@ main(int argc, char **argv)
 
     char hostname[256];
     gethostname(hostname, 256);
+    strcpy(hostname, "eno1");
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);

--- a/examples/read_write_col_perf.c
+++ b/examples/read_write_col_perf.c
@@ -117,7 +117,6 @@ main(int argc, char **argv)
 
     char hostname[256];
     gethostname(hostname, 256);
-    strcpy(hostname, "eno1");
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);

--- a/examples/read_write_perf.c
+++ b/examples/read_write_perf.c
@@ -111,6 +111,7 @@ main(int argc, char **argv)
 #endif
     char hostname[256];
     gethostname(hostname, 256);
+    strcpy(hostname, "eno1");
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);

--- a/examples/read_write_perf.c
+++ b/examples/read_write_perf.c
@@ -111,7 +111,6 @@ main(int argc, char **argv)
 #endif
     char hostname[256];
     gethostname(hostname, 256);
-    strcpy(hostname, "eno1");
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);

--- a/src/api/pdc.c
+++ b/src/api/pdc.c
@@ -130,8 +130,8 @@ PDC_class__close(struct _pdc_class *p)
     PDC_timing_finalize();
 #endif
 
-    free(p->name);
-    p = (struct _pdc_class *)(intptr_t)PDC_free(p);
+    p->name = (char *)PDC_free(p->name);
+    p       = (struct _pdc_class *)(intptr_t)PDC_free(p);
 
     FUNC_LEAVE(ret_value);
 }

--- a/src/api/pdc_analysis/pdc_analysis.c
+++ b/src/api/pdc_analysis/pdc_analysis.c
@@ -62,7 +62,7 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
     int                     ret_value = 0;
     int                     k, d_offset;
     size_t                  i, element_size = 0;
-    char *                  data             = NULL;
+    char                   *data             = NULL;
     size_t                  sliceCount       = 1;
     size_t                  elementsPerSlice = 1;
     size_t                  elementsPerBlock;
@@ -71,8 +71,8 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
     size_t                  skipCount   = 0;
     size_t                  totalElements;
     struct pdc_region_info *region_info = NULL;
-    struct _pdc_obj_info *  object_info = PDC_obj_get_info(objectId);
-    struct _pdc_obj_prop *  obj_prop_ptr;
+    struct _pdc_obj_info   *object_info = PDC_obj_get_info(objectId);
+    struct _pdc_obj_prop   *obj_prop_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -309,7 +309,7 @@ PDCobj_data_iter_create(pdcid_t obj_id, pdcid_t reg_id)
 char *
 PDC_get_argv0_()
 {
-    char *       ret_value          = NULL;
+    char        *ret_value          = NULL;
     static char *_argv0             = NULL;
     char         fullPath[PATH_MAX] = {
         0,
@@ -318,9 +318,9 @@ PDC_get_argv0_()
         0,
     };
     pid_t  mypid = getpid();
-    char * next;
-    char * procpath = NULL;
-    FILE * shellcmd = NULL;
+    char  *next;
+    char  *procpath = NULL;
+    FILE  *shellcmd = NULL;
     size_t cmdLength;
 
     FUNC_ENTER(NULL);
@@ -416,18 +416,18 @@ perr_t
 PDCobj_analysis_register(char *func, pdcid_t iterIn, pdcid_t iterOut)
 {
     perr_t ret_value                              = SUCCEED; /* Return value */
-    void * ftnHandle                              = NULL;
+    void  *ftnHandle                              = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)               = NULL;
     struct _pdc_region_analysis_ftn_info *thisFtn = NULL;
-    struct _pdc_iterator_info *           i_in = NULL, *i_out = NULL;
+    struct _pdc_iterator_info            *i_in = NULL, *i_out = NULL;
     pdcid_t                               meta_id_in = 0, meta_id_out = 0;
     pdcid_t                               local_id_in = 0, local_id_out = 0;
-    char *                                thisApp        = NULL;
-    char *                                colonsep       = NULL;
-    char *                                analyislibrary = NULL;
-    char *                                applicationDir = NULL;
-    char *                                userdefinedftn = NULL;
-    char *                                loadpath       = NULL;
+    char                                 *thisApp        = NULL;
+    char                                 *colonsep       = NULL;
+    char                                 *analyislibrary = NULL;
+    char                                 *applicationDir = NULL;
+    char                                 *userdefinedftn = NULL;
+    char                                 *loadpath       = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -538,8 +538,8 @@ PDCobj_data_getNextBlock(pdcid_t iter, void **nextBlock, size_t *dims)
     size_t                     ret_value = 0;
     struct _pdc_iterator_info *thisIter  = NULL;
     size_t                     current_total, remaining, offset;
-    struct _pdc_obj_info *     object_info;
-    struct _pdc_obj_prop *     obj_prop_ptr;
+    struct _pdc_obj_info      *object_info;
+    struct _pdc_obj_prop      *obj_prop_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -557,7 +557,7 @@ PDCobj_data_getNextBlock(pdcid_t iter, void **nextBlock, size_t *dims)
         if (thisIter->srcStart == NULL) {
             if (execution_locus == SERVER_MEMORY) {
                 if ((thisIter->srcNext = PDC_Server_get_region_data_ptr(thisIter->objectId)) == NULL)
-                    thisIter->srcNext = malloc(thisIter->totalElements * thisIter->element_size);
+                    thisIter->srcNext = PDC_malloc(thisIter->totalElements * thisIter->element_size);
                 if ((thisIter->srcStart = thisIter->srcNext) == NULL)
                     PGOTO_ERROR(0, "==PDC_ANALYSIS_SERVER: Unable to allocate iterator storage");
 

--- a/src/api/pdc_analysis/pdc_analysis.c
+++ b/src/api/pdc_analysis/pdc_analysis.c
@@ -62,7 +62,7 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
     int                     ret_value = 0;
     int                     k, d_offset;
     size_t                  i, element_size = 0;
-    char                   *data             = NULL;
+    char *                  data             = NULL;
     size_t                  sliceCount       = 1;
     size_t                  elementsPerSlice = 1;
     size_t                  elementsPerBlock;
@@ -71,8 +71,8 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
     size_t                  skipCount   = 0;
     size_t                  totalElements;
     struct pdc_region_info *region_info = NULL;
-    struct _pdc_obj_info   *object_info = PDC_obj_get_info(objectId);
-    struct _pdc_obj_prop   *obj_prop_ptr;
+    struct _pdc_obj_info *  object_info = PDC_obj_get_info(objectId);
+    struct _pdc_obj_prop *  obj_prop_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -309,7 +309,7 @@ PDCobj_data_iter_create(pdcid_t obj_id, pdcid_t reg_id)
 char *
 PDC_get_argv0_()
 {
-    char        *ret_value          = NULL;
+    char *       ret_value          = NULL;
     static char *_argv0             = NULL;
     char         fullPath[PATH_MAX] = {
         0,
@@ -318,9 +318,9 @@ PDC_get_argv0_()
         0,
     };
     pid_t  mypid = getpid();
-    char  *next;
-    char  *procpath = NULL;
-    FILE  *shellcmd = NULL;
+    char * next;
+    char * procpath = NULL;
+    FILE * shellcmd = NULL;
     size_t cmdLength;
 
     FUNC_ENTER(NULL);
@@ -416,18 +416,18 @@ perr_t
 PDCobj_analysis_register(char *func, pdcid_t iterIn, pdcid_t iterOut)
 {
     perr_t ret_value                              = SUCCEED; /* Return value */
-    void  *ftnHandle                              = NULL;
+    void * ftnHandle                              = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)               = NULL;
     struct _pdc_region_analysis_ftn_info *thisFtn = NULL;
-    struct _pdc_iterator_info            *i_in = NULL, *i_out = NULL;
+    struct _pdc_iterator_info *           i_in = NULL, *i_out = NULL;
     pdcid_t                               meta_id_in = 0, meta_id_out = 0;
     pdcid_t                               local_id_in = 0, local_id_out = 0;
-    char                                 *thisApp        = NULL;
-    char                                 *colonsep       = NULL;
-    char                                 *analyislibrary = NULL;
-    char                                 *applicationDir = NULL;
-    char                                 *userdefinedftn = NULL;
-    char                                 *loadpath       = NULL;
+    char *                                thisApp        = NULL;
+    char *                                colonsep       = NULL;
+    char *                                analyislibrary = NULL;
+    char *                                applicationDir = NULL;
+    char *                                userdefinedftn = NULL;
+    char *                                loadpath       = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -538,8 +538,8 @@ PDCobj_data_getNextBlock(pdcid_t iter, void **nextBlock, size_t *dims)
     size_t                     ret_value = 0;
     struct _pdc_iterator_info *thisIter  = NULL;
     size_t                     current_total, remaining, offset;
-    struct _pdc_obj_info      *object_info;
-    struct _pdc_obj_prop      *obj_prop_ptr;
+    struct _pdc_obj_info *     object_info;
+    struct _pdc_obj_prop *     obj_prop_ptr;
 
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_analysis/pdc_analysis.c
+++ b/src/api/pdc_analysis/pdc_analysis.c
@@ -101,7 +101,8 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
             }
         }
         iter->totalElements = 1;
-        if ((iter->srcDims = (size_t *)calloc(obj_prop_ptr->obj_prop_pub->ndim, sizeof(size_t))) != NULL) {
+        if ((iter->srcDims = (size_t *)PDC_calloc(obj_prop_ptr->obj_prop_pub->ndim, sizeof(size_t))) !=
+            NULL) {
             iter->ndim = obj_prop_ptr->obj_prop_pub->ndim;
             for (i = 0; i < iter->ndim; i++) {
                 iter->srcDims[i] = (size_t)obj_prop_ptr->obj_prop_pub->dims[i];
@@ -460,7 +461,7 @@ PDCobj_analysis_register(char *func, pdcid_t iterIn, pdcid_t iterOut)
     thisFtn->ftnPtr = (int (*)())ftnPtr;
     thisFtn->n_args = 2;
     /* Allocate for iterator ids and region ids */
-    if ((thisFtn->object_id = (pdcid_t *)calloc(4, sizeof(pdcid_t))) != NULL) {
+    if ((thisFtn->object_id = (pdcid_t *)PDC_calloc(4, sizeof(pdcid_t))) != NULL) {
         thisFtn->object_id[0] = iterIn;
         thisFtn->object_id[1] = iterOut;
     }

--- a/src/api/pdc_analysis/pdc_analysis.c
+++ b/src/api/pdc_analysis/pdc_analysis.c
@@ -62,7 +62,7 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
     int                     ret_value = 0;
     int                     k, d_offset;
     size_t                  i, element_size = 0;
-    char *                  data             = NULL;
+    char                   *data             = NULL;
     size_t                  sliceCount       = 1;
     size_t                  elementsPerSlice = 1;
     size_t                  elementsPerBlock;
@@ -71,8 +71,8 @@ iterator_init(pdcid_t objectId, pdcid_t reg_id, int blocks, struct _pdc_iterator
     size_t                  skipCount   = 0;
     size_t                  totalElements;
     struct pdc_region_info *region_info = NULL;
-    struct _pdc_obj_info *  object_info = PDC_obj_get_info(objectId);
-    struct _pdc_obj_prop *  obj_prop_ptr;
+    struct _pdc_obj_info   *object_info = PDC_obj_get_info(objectId);
+    struct _pdc_obj_prop   *obj_prop_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -308,7 +308,7 @@ PDCobj_data_iter_create(pdcid_t obj_id, pdcid_t reg_id)
 char *
 PDC_get_argv0_()
 {
-    char *       ret_value          = NULL;
+    char        *ret_value          = NULL;
     static char *_argv0             = NULL;
     char         fullPath[PATH_MAX] = {
         0,
@@ -317,9 +317,9 @@ PDC_get_argv0_()
         0,
     };
     pid_t  mypid = getpid();
-    char * next;
-    char * procpath = NULL;
-    FILE * shellcmd = NULL;
+    char  *next;
+    char  *procpath = NULL;
+    FILE  *shellcmd = NULL;
     size_t cmdLength;
 
     FUNC_ENTER(NULL);
@@ -336,13 +336,13 @@ PDC_get_argv0_()
         procpath = strdup(fullPath);
         shellcmd = fopen(procpath, "r");
         if (shellcmd == NULL) {
-            free(procpath);
+            procpath = (char *)PDC_free(procpath);
             PGOTO_ERROR(NULL, "fopen failed!");
         }
         else {
             cmdLength = fread(fullPath, 1, sizeof(fullPath), shellcmd);
             if (procpath)
-                free(procpath);
+                procpath = (char *)PDC_free(procpath);
             if (cmdLength > 0) {
                 _argv0 = strdup(fullPath);
                 /* truncate the cmdline if any whitespace (space or tab) */
@@ -366,7 +366,7 @@ PDC_get_argv0_()
                 /* Get rid of the copy (strdup) of fullPath now in _argv0.
                  * and replace it with the next (modified/fully_qualified?) version.
                  */
-                free(_argv0);
+                _argv0 = (char *)PDC_free(_argv0);
                 _argv0 = next;
             }
         }
@@ -415,18 +415,18 @@ perr_t
 PDCobj_analysis_register(char *func, pdcid_t iterIn, pdcid_t iterOut)
 {
     perr_t ret_value                              = SUCCEED; /* Return value */
-    void * ftnHandle                              = NULL;
+    void  *ftnHandle                              = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)               = NULL;
     struct _pdc_region_analysis_ftn_info *thisFtn = NULL;
-    struct _pdc_iterator_info *           i_in = NULL, *i_out = NULL;
+    struct _pdc_iterator_info            *i_in = NULL, *i_out = NULL;
     pdcid_t                               meta_id_in = 0, meta_id_out = 0;
     pdcid_t                               local_id_in = 0, local_id_out = 0;
-    char *                                thisApp        = NULL;
-    char *                                colonsep       = NULL;
-    char *                                analyislibrary = NULL;
-    char *                                applicationDir = NULL;
-    char *                                userdefinedftn = NULL;
-    char *                                loadpath       = NULL;
+    char                                 *thisApp        = NULL;
+    char                                 *colonsep       = NULL;
+    char                                 *analyislibrary = NULL;
+    char                                 *applicationDir = NULL;
+    char                                 *userdefinedftn = NULL;
+    char                                 *loadpath       = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -497,11 +497,11 @@ PDCobj_analysis_register(char *func, pdcid_t iterIn, pdcid_t iterOut)
 
 done:
     if (applicationDir)
-        free(applicationDir);
+        applicationDir = (char *)PDC_free(applicationDir);
     if (userdefinedftn)
-        free(userdefinedftn);
+        userdefinedftn = (char *)PDC_free(userdefinedftn);
     if (loadpath)
-        free(loadpath);
+        loadpath = (char *)PDC_free(loadpath);
 
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -537,8 +537,8 @@ PDCobj_data_getNextBlock(pdcid_t iter, void **nextBlock, size_t *dims)
     size_t                     ret_value = 0;
     struct _pdc_iterator_info *thisIter  = NULL;
     size_t                     current_total, remaining, offset;
-    struct _pdc_obj_info *     object_info;
-    struct _pdc_obj_prop *     obj_prop_ptr;
+    struct _pdc_obj_info      *object_info;
+    struct _pdc_obj_prop      *obj_prop_ptr;
 
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_analysis/pdc_analysis_and_transforms_connect.c
+++ b/src/api/pdc_analysis/pdc_analysis_and_transforms_connect.c
@@ -27,7 +27,7 @@
 #include "pdc_analysis_pkg.h"
 #include "pdc_transforms_common.h"
 
-static hg_context_t      *send_context_g     = NULL;
+static hg_context_t *     send_context_g     = NULL;
 static hg_atomic_int32_t *atomic_work_todo_g = NULL;
 
 /* Forward References:: */
@@ -51,12 +51,12 @@ PDC_Client_send_iter_recv_id(pdcid_t iter_id, pdcid_t *meta_id)
 {
     uint64_t                   ret_value = SUCCEED;
     struct _pdc_iterator_info *thisIter  = NULL;
-    struct _pdc_my_rpc_state  *my_rpc_state_p;
+    struct _pdc_my_rpc_state * my_rpc_state_p;
     obj_data_iterator_in_t     in;
     hg_return_t                hg_ret;
     int                        server_id = 0;
     int                        n_retry   = 0;
-    struct _pdc_obj_info      *object_info;
+    struct _pdc_obj_info *     object_info;
 
     FUNC_ENTER(NULL);
     if (atomic_work_todo_g == NULL) {
@@ -172,11 +172,11 @@ PDC_Client_register_obj_analysis(struct _pdc_region_analysis_ftn_info *thisFtn, 
     uint32_t                   server_id = 0;
     hg_return_t                hg_ret;
     analysis_ftn_in_t          in;
-    struct _pdc_my_rpc_state  *my_rpc_state_p;
+    struct _pdc_my_rpc_state * my_rpc_state_p;
     struct _pdc_iterator_info *thisIter;
     int                        n_retry      = 0;
     int                        input_server = -1, output_server = -1;
-    struct _pdc_obj_info      *obj_prop;
+    struct _pdc_obj_info *     obj_prop;
 
     FUNC_ENTER(NULL);
     if (atomic_work_todo_g == NULL) {
@@ -293,7 +293,7 @@ PDC_Client_register_region_transform(const char *func, const char *loadpath,
     uint32_t                  server_id = 0;
     hg_return_t               hg_ret;
     transform_ftn_in_t        in;
-    struct _pdc_obj_info     *object_info = NULL;
+    struct _pdc_obj_info *    object_info = NULL;
     struct _pdc_my_rpc_state *my_rpc_state_p;
 
     FUNC_ENTER(NULL);

--- a/src/api/pdc_analysis/pdc_analysis_and_transforms_connect.c
+++ b/src/api/pdc_analysis/pdc_analysis_and_transforms_connect.c
@@ -63,7 +63,7 @@ PDC_Client_send_iter_recv_id(pdcid_t iter_id, pdcid_t *meta_id)
         hg_atomic_init32(atomic_work_todo_g, 0);
     }
 
-    my_rpc_state_p = (struct _pdc_my_rpc_state *)calloc(1, sizeof(struct _pdc_my_rpc_state));
+    my_rpc_state_p = (struct _pdc_my_rpc_state *)PDC_calloc(1, sizeof(struct _pdc_my_rpc_state));
     if (my_rpc_state_p == NULL)
         PGOTO_ERROR(FAIL, "PDC_Client_send_iter_recv_id(): Could not allocate my_rpc_state");
 
@@ -183,7 +183,7 @@ PDC_Client_register_obj_analysis(struct _pdc_region_analysis_ftn_info *thisFtn, 
         hg_atomic_init32(atomic_work_todo_g, 0);
     }
 
-    my_rpc_state_p = (struct _pdc_my_rpc_state *)calloc(1, sizeof(struct _pdc_my_rpc_state));
+    my_rpc_state_p = (struct _pdc_my_rpc_state *)PDC_calloc(1, sizeof(struct _pdc_my_rpc_state));
     if (my_rpc_state_p == NULL)
         PGOTO_ERROR(FAIL, "PDC_Client_register_obj_analysis(): Could not allocate my_rpc_state");
 
@@ -301,7 +301,7 @@ PDC_Client_register_region_transform(const char *func, const char *loadpath,
         hg_atomic_init32(atomic_work_todo_g, 0);
     }
 
-    my_rpc_state_p = (struct _pdc_my_rpc_state *)calloc(1, sizeof(struct _pdc_my_rpc_state));
+    my_rpc_state_p = (struct _pdc_my_rpc_state *)PDC_calloc(1, sizeof(struct _pdc_my_rpc_state));
     if (my_rpc_state_p == NULL)
         PGOTO_ERROR(FAIL, "Could not allocate my_rpc_state");
 

--- a/src/api/pdc_analysis/pdc_analysis_and_transforms_connect.c
+++ b/src/api/pdc_analysis/pdc_analysis_and_transforms_connect.c
@@ -27,7 +27,7 @@
 #include "pdc_analysis_pkg.h"
 #include "pdc_transforms_common.h"
 
-static hg_context_t *     send_context_g     = NULL;
+static hg_context_t      *send_context_g     = NULL;
 static hg_atomic_int32_t *atomic_work_todo_g = NULL;
 
 /* Forward References:: */
@@ -51,12 +51,12 @@ PDC_Client_send_iter_recv_id(pdcid_t iter_id, pdcid_t *meta_id)
 {
     uint64_t                   ret_value = SUCCEED;
     struct _pdc_iterator_info *thisIter  = NULL;
-    struct _pdc_my_rpc_state * my_rpc_state_p;
+    struct _pdc_my_rpc_state  *my_rpc_state_p;
     obj_data_iterator_in_t     in;
     hg_return_t                hg_ret;
     int                        server_id = 0;
     int                        n_retry   = 0;
-    struct _pdc_obj_info *     object_info;
+    struct _pdc_obj_info      *object_info;
 
     FUNC_ENTER(NULL);
     if (atomic_work_todo_g == NULL) {
@@ -130,7 +130,7 @@ PDC_Client_send_iter_recv_id(pdcid_t iter_id, pdcid_t *meta_id)
 done:
     fflush(stdout);
     HG_Destroy(my_rpc_state_p->handle);
-    free(my_rpc_state_p);
+    my_rpc_state_p = (struct _pdc_my_rpc_state *)PDC_free(my_rpc_state_p);
 
     FUNC_LEAVE(ret_value);
 }
@@ -172,11 +172,11 @@ PDC_Client_register_obj_analysis(struct _pdc_region_analysis_ftn_info *thisFtn, 
     uint32_t                   server_id = 0;
     hg_return_t                hg_ret;
     analysis_ftn_in_t          in;
-    struct _pdc_my_rpc_state * my_rpc_state_p;
+    struct _pdc_my_rpc_state  *my_rpc_state_p;
     struct _pdc_iterator_info *thisIter;
     int                        n_retry      = 0;
     int                        input_server = -1, output_server = -1;
-    struct _pdc_obj_info *     obj_prop;
+    struct _pdc_obj_info      *obj_prop;
 
     FUNC_ENTER(NULL);
     if (atomic_work_todo_g == NULL) {
@@ -250,7 +250,7 @@ PDC_Client_register_obj_analysis(struct _pdc_region_analysis_ftn_info *thisFtn, 
 done:
     fflush(stdout);
     HG_Destroy(my_rpc_state_p->handle);
-    free(my_rpc_state_p);
+    my_rpc_state_p = (struct _pdc_my_rpc_state *)PDC_free(my_rpc_state_p);
 
     FUNC_LEAVE(ret_value);
 }
@@ -293,7 +293,7 @@ PDC_Client_register_region_transform(const char *func, const char *loadpath,
     uint32_t                  server_id = 0;
     hg_return_t               hg_ret;
     transform_ftn_in_t        in;
-    struct _pdc_obj_info *    object_info = NULL;
+    struct _pdc_obj_info     *object_info = NULL;
     struct _pdc_my_rpc_state *my_rpc_state_p;
 
     FUNC_ENTER(NULL);
@@ -345,7 +345,7 @@ done:
     if (object_info)
         PDC_free_obj_info(object_info);
     HG_Destroy(my_rpc_state_p->handle);
-    free(my_rpc_state_p);
+    my_rpc_state_p = (struct _pdc_my_rpc_state *)PDC_free(my_rpc_state_p);
 
     FUNC_LEAVE(ret_value);
 }

--- a/src/api/pdc_analysis/pdc_analysis_common.c
+++ b/src/api/pdc_analysis/pdc_analysis_common.c
@@ -34,6 +34,7 @@
 #include "pdc_analysis_and_transforms_common.h"
 #include "pdc_client_server_common.h"
 #include "pdc_analysis_pkg.h"
+#include "pdc_malloc.h"
 #include "pdc_region.h"
 #include "pdc_server_analysis.h"
 #include "pdc_logger.h"
@@ -41,7 +42,7 @@
 size_t            analysis_registry_size  = 0;
 size_t            transform_registry_size = 0;
 hg_atomic_int32_t registered_transform_ftn_count_g;
-int *             i_cache_freed          = NULL;
+int              *i_cache_freed          = NULL;
 size_t            iterator_cache_entries = CACHE_SIZE;
 hg_atomic_int32_t i_cache_index;
 hg_atomic_int32_t i_free_index;
@@ -57,7 +58,7 @@ compare_gt(int *a, int b)
 {
     return (*a) > (b);
 }
-struct _pdc_region_analysis_ftn_info ** pdc_region_analysis_registry  = NULL;
+struct _pdc_region_analysis_ftn_info  **pdc_region_analysis_registry  = NULL;
 struct _pdc_region_transform_ftn_info **pdc_region_transform_registry = NULL;
 
 #ifndef IS_PDC_SERVER
@@ -103,7 +104,8 @@ pdc_analysis_registry_init_(size_t newSize)
         if (new_registry) {
             size_t copysize = analysis_registry_size * sizeof(void *);
             memcpy(new_registry, pdc_region_analysis_registry, copysize);
-            free(pdc_region_analysis_registry);
+            pdc_region_analysis_registry =
+                (struct _pdc_region_analysis_ftn_info **)PDC_free(pdc_region_analysis_registry);
             pdc_region_analysis_registry = new_registry;
             analysis_registry_size       = newSize;
             PGOTO_DONE(newSize);
@@ -138,7 +140,8 @@ pdc_transform_registry_init_(size_t newSize)
         if (new_registry) {
             copysize = transform_registry_size * sizeof(void *);
             memcpy(new_registry, pdc_region_transform_registry, copysize);
-            free(pdc_region_transform_registry);
+            pdc_region_transform_registry =
+                (struct _pdc_region_transform_ftn_info **)PDC_free(pdc_region_transform_registry);
             pdc_region_transform_registry = new_registry;
             transform_registry_size       = newSize;
             PGOTO_DONE(newSize);
@@ -161,11 +164,13 @@ pdc_analysis_registry_finalize_()
     if ((pdc_region_analysis_registry != NULL) && (analysis_registry_size > 0)) {
         while (hg_atomic_get32(&i) > 0) {
             if (pdc_region_analysis_registry[i - 1])
-                free(pdc_region_analysis_registry[i - 1]);
+                pdc_region_analysis_registry[i - 1] =
+                    (struct _pdc_region_analysis_ftn_info *)PDC_free(pdc_region_analysis_registry[i - 1]);
             pdc_region_analysis_registry[i - 1] = NULL;
             hg_atomic_decr32(&i);
         }
-        free(pdc_region_analysis_registry);
+        pdc_region_analysis_registry =
+            (struct _pdc_region_analysis_ftn_info **)PDC_free(pdc_region_analysis_registry);
         analysis_registry_size = 0;
         hg_atomic_init32(&registered_analysis_ftn_count_g, 0);
     }
@@ -243,7 +248,7 @@ PDCiter_get_nextId(void)
 {
     int                        ret_value              = 0;
     size_t                     nextId                 = 0;
-    int *                      previous_i_cache_freed = 0;
+    int                       *previous_i_cache_freed = 0;
     int                        next_free              = 0;
     struct _pdc_iterator_info *previous_state;
 
@@ -281,8 +286,8 @@ PDCiter_get_nextId(void)
         i_cache_freed = (int *)calloc(iterator_cache_entries * 2, sizeof(int));
         memcpy(i_cache_freed, previous_i_cache_freed, iterator_cache_entries * sizeof(int));
         iterator_cache_entries *= 2;
-        free(previous_i_cache_freed);
-        free(previous_state);
+        previous_i_cache_freed = (int *)PDC_free(previous_i_cache_freed);
+        previous_state         = (struct _pdc_iterator_info *)PDC_free(previous_state);
     }
 
     ret_value = nextId;
@@ -423,8 +428,8 @@ PDC_get_ftnPtr_(const char *ftn, const char *loadpath, void **ftnPtr)
 {
     int          ret_value  = 0;
     static void *appHandle  = NULL;
-    void *       ftnHandle  = NULL;
-    char *       this_error = NULL;
+    void        *ftnHandle  = NULL;
+    char        *this_error = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -457,7 +462,7 @@ HG_TEST_RPC_CB(analysis_ftn, handle)
     int                                   nulliter_count = 0;
     pdcid_t                               iterIn = -1, iterOut = -1;
     pdcid_t                               registrationId = -1;
-    void *                                ftnHandle      = NULL;
+    void                                 *ftnHandle      = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)                      = NULL;
     int result;
 
@@ -601,9 +606,11 @@ PDC_free_analysis_registry()
 
     if (pdc_region_analysis_registry && (registered_analysis_ftn_count_g > 0)) {
         for (index = 0; index < registered_analysis_ftn_count_g; index++) {
-            free(pdc_region_analysis_registry[index]);
+            pdc_region_analysis_registry[index] =
+                (struct _pdc_region_analysis_ftn_info *)PDC_free(pdc_region_analysis_registry[index]);
         }
-        free(pdc_region_analysis_registry);
+        pdc_region_analysis_registry =
+            (struct _pdc_region_analysis_ftn_info **)PDC_free(pdc_region_analysis_registry);
         pdc_region_analysis_registry = NULL;
     }
 
@@ -619,9 +626,11 @@ PDC_free_transform_registry()
 
     if (pdc_region_transform_registry && (registered_transform_ftn_count_g > 0)) {
         for (index = 0; index < registered_transform_ftn_count_g; index++) {
-            free(pdc_region_transform_registry[index]);
+            pdc_region_transform_registry[index] =
+                (struct _pdc_region_transform_ftn_info *)PDC_free(pdc_region_transform_registry[index]);
         }
-        free(pdc_region_transform_registry);
+        pdc_region_transform_registry =
+            (struct _pdc_region_transform_ftn_info **)PDC_free(pdc_region_transform_registry);
         pdc_region_transform_registry = NULL;
     }
 
@@ -635,7 +644,7 @@ PDC_free_iterator_cache()
     FUNC_ENTER(NULL);
 
     if (PDC_Block_iterator_cache != NULL)
-        free(PDC_Block_iterator_cache);
+        PDC_Block_iterator_cache = (struct _pdc_iterator_info *)PDC_free(PDC_Block_iterator_cache);
     PDC_Block_iterator_cache = NULL;
 
     FUNC_LEAVE_VOID;

--- a/src/api/pdc_analysis/pdc_analysis_common.c
+++ b/src/api/pdc_analysis/pdc_analysis_common.c
@@ -42,7 +42,7 @@
 size_t            analysis_registry_size  = 0;
 size_t            transform_registry_size = 0;
 hg_atomic_int32_t registered_transform_ftn_count_g;
-int              *i_cache_freed          = NULL;
+int *             i_cache_freed          = NULL;
 size_t            iterator_cache_entries = CACHE_SIZE;
 hg_atomic_int32_t i_cache_index;
 hg_atomic_int32_t i_free_index;
@@ -58,7 +58,7 @@ compare_gt(int *a, int b)
 {
     return (*a) > (b);
 }
-struct _pdc_region_analysis_ftn_info  **pdc_region_analysis_registry  = NULL;
+struct _pdc_region_analysis_ftn_info ** pdc_region_analysis_registry  = NULL;
 struct _pdc_region_transform_ftn_info **pdc_region_transform_registry = NULL;
 
 #ifndef IS_PDC_SERVER
@@ -248,7 +248,7 @@ PDCiter_get_nextId(void)
 {
     int                        ret_value              = 0;
     size_t                     nextId                 = 0;
-    int                       *previous_i_cache_freed = 0;
+    int *                      previous_i_cache_freed = 0;
     int                        next_free              = 0;
     struct _pdc_iterator_info *previous_state;
 
@@ -428,8 +428,8 @@ PDC_get_ftnPtr_(const char *ftn, const char *loadpath, void **ftnPtr)
 {
     int          ret_value  = 0;
     static void *appHandle  = NULL;
-    void        *ftnHandle  = NULL;
-    char        *this_error = NULL;
+    void *       ftnHandle  = NULL;
+    char *       this_error = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -462,7 +462,7 @@ HG_TEST_RPC_CB(analysis_ftn, handle)
     int                                   nulliter_count = 0;
     pdcid_t                               iterIn = -1, iterOut = -1;
     pdcid_t                               registrationId = -1;
-    void                                 *ftnHandle      = NULL;
+    void *                                ftnHandle      = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)                      = NULL;
     int result;
 

--- a/src/api/pdc_analysis/pdc_analysis_common.c
+++ b/src/api/pdc_analysis/pdc_analysis_common.c
@@ -91,7 +91,7 @@ pdc_analysis_registry_init_(size_t newSize)
     FUNC_ENTER(NULL);
 
     if (pdc_region_analysis_registry == NULL) {
-        new_registry = (struct _pdc_region_analysis_ftn_info **)calloc(sizeof(void *), newSize);
+        new_registry = (struct _pdc_region_analysis_ftn_info **)PDC_calloc(sizeof(void *), newSize);
         if (new_registry) {
             hg_atomic_init32(&registered_analysis_ftn_count_g, 0);
             pdc_region_analysis_registry = new_registry;
@@ -100,7 +100,7 @@ pdc_analysis_registry_init_(size_t newSize)
         }
     }
     else if (newSize > analysis_registry_size) {
-        new_registry = (struct _pdc_region_analysis_ftn_info **)calloc(sizeof(void *), newSize);
+        new_registry = (struct _pdc_region_analysis_ftn_info **)PDC_calloc(sizeof(void *), newSize);
         if (new_registry) {
             size_t copysize = analysis_registry_size * sizeof(void *);
             memcpy(new_registry, pdc_region_analysis_registry, copysize);
@@ -127,7 +127,7 @@ pdc_transform_registry_init_(size_t newSize)
     FUNC_ENTER(NULL);
 
     if (pdc_region_transform_registry == NULL) {
-        new_registry = (struct _pdc_region_transform_ftn_info **)calloc(sizeof(void *), newSize);
+        new_registry = (struct _pdc_region_transform_ftn_info **)PDC_calloc(sizeof(void *), newSize);
         if (new_registry) {
             hg_atomic_init32(&registered_transform_ftn_count_g, 0);
             pdc_region_transform_registry = new_registry;
@@ -136,7 +136,7 @@ pdc_transform_registry_init_(size_t newSize)
         }
     }
     else if (newSize > transform_registry_size) {
-        new_registry = (struct _pdc_region_transform_ftn_info **)calloc(sizeof(void *), newSize);
+        new_registry = (struct _pdc_region_transform_ftn_info **)PDC_calloc(sizeof(void *), newSize);
         if (new_registry) {
             copysize = transform_registry_size * sizeof(void *);
             memcpy(new_registry, pdc_region_transform_registry, copysize);
@@ -255,12 +255,12 @@ PDCiter_get_nextId(void)
     FUNC_ENTER(NULL);
 
     if (PDC_Block_iterator_cache == NULL) {
-        PDC_Block_iterator_cache =
-            (struct _pdc_iterator_info *)calloc(iterator_cache_entries, sizeof(struct _pdc_iterator_info));
+        PDC_Block_iterator_cache = (struct _pdc_iterator_info *)PDC_calloc(iterator_cache_entries,
+                                                                           sizeof(struct _pdc_iterator_info));
         if (PDC_Block_iterator_cache == NULL)
             PGOTO_ERROR(-1, "calloc failed");
 
-        i_cache_freed = (int *)calloc(iterator_cache_entries, sizeof(int));
+        i_cache_freed = (int *)PDC_calloc(iterator_cache_entries, sizeof(int));
         /* Index 0 is NOT-USED other than to indicate an empty iterator */
         hg_atomic_init32(&i_cache_index, 1);
         hg_atomic_init32(&i_free_index, 0);
@@ -279,11 +279,11 @@ PDCiter_get_nextId(void)
         /* Realloc the cache and free list */
         previous_i_cache_freed   = i_cache_freed;
         previous_state           = PDC_Block_iterator_cache;
-        PDC_Block_iterator_cache = (struct _pdc_iterator_info *)calloc(iterator_cache_entries * 2,
-                                                                       sizeof(struct _pdc_iterator_info));
+        PDC_Block_iterator_cache = (struct _pdc_iterator_info *)PDC_calloc(iterator_cache_entries * 2,
+                                                                           sizeof(struct _pdc_iterator_info));
         memcpy(PDC_Block_iterator_cache, previous_state,
                iterator_cache_entries * sizeof(struct _pdc_iterator_info));
-        i_cache_freed = (int *)calloc(iterator_cache_entries * 2, sizeof(int));
+        i_cache_freed = (int *)PDC_calloc(iterator_cache_entries * 2, sizeof(int));
         memcpy(i_cache_freed, previous_i_cache_freed, iterator_cache_entries * sizeof(int));
         iterator_cache_entries *= 2;
         previous_i_cache_freed = (int *)PDC_free(previous_i_cache_freed);
@@ -497,11 +497,11 @@ HG_TEST_RPC_CB(analysis_ftn, handle)
          * Otherwise, go ahead and register...
          */
         if (nulliter_count < 2) {
-            if ((thisFtn = (struct _pdc_region_analysis_ftn_info *)calloc(
+            if ((thisFtn = (struct _pdc_region_analysis_ftn_info *)PDC_calloc(
                      sizeof(struct _pdc_region_analysis_ftn_info), 1)) != NULL) {
                 thisFtn->ftnPtr    = (int (*)())ftnPtr;
                 thisFtn->n_args    = 2;
-                thisFtn->object_id = (pdcid_t *)calloc(2, sizeof(pdcid_t));
+                thisFtn->object_id = (pdcid_t *)PDC_calloc(2, sizeof(pdcid_t));
                 registrationId     = PDC_add_analysis_ptr_to_registry_(thisFtn);
                 out.remote_ftn_id  = registrationId;
             }

--- a/src/api/pdc_analysis/pdc_analysis_common.c
+++ b/src/api/pdc_analysis/pdc_analysis_common.c
@@ -42,7 +42,7 @@
 size_t            analysis_registry_size  = 0;
 size_t            transform_registry_size = 0;
 hg_atomic_int32_t registered_transform_ftn_count_g;
-int              *i_cache_freed          = NULL;
+int *             i_cache_freed          = NULL;
 size_t            iterator_cache_entries = CACHE_SIZE;
 hg_atomic_int32_t i_cache_index;
 hg_atomic_int32_t i_free_index;
@@ -58,7 +58,7 @@ compare_gt(int *a, int b)
 {
     return (*a) > (b);
 }
-struct _pdc_region_analysis_ftn_info  **pdc_region_analysis_registry  = NULL;
+struct _pdc_region_analysis_ftn_info ** pdc_region_analysis_registry  = NULL;
 struct _pdc_region_transform_ftn_info **pdc_region_transform_registry = NULL;
 
 #ifndef IS_PDC_SERVER
@@ -247,7 +247,7 @@ PDCiter_get_nextId(void)
 {
     int                        ret_value              = 0;
     size_t                     nextId                 = 0;
-    int                       *previous_i_cache_freed = 0;
+    int *                      previous_i_cache_freed = 0;
     int                        next_free              = 0;
     struct _pdc_iterator_info *previous_state;
 
@@ -427,8 +427,8 @@ PDC_get_ftnPtr_(const char *ftn, const char *loadpath, void **ftnPtr)
 {
     int          ret_value  = 0;
     static void *appHandle  = NULL;
-    void        *ftnHandle  = NULL;
-    char        *this_error = NULL;
+    void *       ftnHandle  = NULL;
+    char *       this_error = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -461,7 +461,7 @@ HG_TEST_RPC_CB(analysis_ftn, handle)
     int                                   nulliter_count = 0;
     pdcid_t                               iterIn = -1, iterOut = -1;
     pdcid_t                               registrationId = -1;
-    void                                 *ftnHandle      = NULL;
+    void *                                ftnHandle      = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)                      = NULL;
     int result;
 

--- a/src/api/pdc_analysis/pdc_analysis_common.c
+++ b/src/api/pdc_analysis/pdc_analysis_common.c
@@ -42,7 +42,7 @@
 size_t            analysis_registry_size  = 0;
 size_t            transform_registry_size = 0;
 hg_atomic_int32_t registered_transform_ftn_count_g;
-int *             i_cache_freed          = NULL;
+int              *i_cache_freed          = NULL;
 size_t            iterator_cache_entries = CACHE_SIZE;
 hg_atomic_int32_t i_cache_index;
 hg_atomic_int32_t i_free_index;
@@ -58,7 +58,7 @@ compare_gt(int *a, int b)
 {
     return (*a) > (b);
 }
-struct _pdc_region_analysis_ftn_info ** pdc_region_analysis_registry  = NULL;
+struct _pdc_region_analysis_ftn_info  **pdc_region_analysis_registry  = NULL;
 struct _pdc_region_transform_ftn_info **pdc_region_transform_registry = NULL;
 
 #ifndef IS_PDC_SERVER
@@ -166,7 +166,6 @@ pdc_analysis_registry_finalize_()
             if (pdc_region_analysis_registry[i - 1])
                 pdc_region_analysis_registry[i - 1] =
                     (struct _pdc_region_analysis_ftn_info *)PDC_free(pdc_region_analysis_registry[i - 1]);
-            pdc_region_analysis_registry[i - 1] = NULL;
             hg_atomic_decr32(&i);
         }
         pdc_region_analysis_registry =
@@ -248,7 +247,7 @@ PDCiter_get_nextId(void)
 {
     int                        ret_value              = 0;
     size_t                     nextId                 = 0;
-    int *                      previous_i_cache_freed = 0;
+    int                       *previous_i_cache_freed = 0;
     int                        next_free              = 0;
     struct _pdc_iterator_info *previous_state;
 
@@ -428,8 +427,8 @@ PDC_get_ftnPtr_(const char *ftn, const char *loadpath, void **ftnPtr)
 {
     int          ret_value  = 0;
     static void *appHandle  = NULL;
-    void *       ftnHandle  = NULL;
-    char *       this_error = NULL;
+    void        *ftnHandle  = NULL;
+    char        *this_error = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -462,7 +461,7 @@ HG_TEST_RPC_CB(analysis_ftn, handle)
     int                                   nulliter_count = 0;
     pdcid_t                               iterIn = -1, iterOut = -1;
     pdcid_t                               registrationId = -1;
-    void *                                ftnHandle      = NULL;
+    void                                 *ftnHandle      = NULL;
     int (*ftnPtr)(pdcid_t, pdcid_t)                      = NULL;
     int result;
 
@@ -611,7 +610,6 @@ PDC_free_analysis_registry()
         }
         pdc_region_analysis_registry =
             (struct _pdc_region_analysis_ftn_info **)PDC_free(pdc_region_analysis_registry);
-        pdc_region_analysis_registry = NULL;
     }
 
     FUNC_LEAVE_VOID;
@@ -631,7 +629,6 @@ PDC_free_transform_registry()
         }
         pdc_region_transform_registry =
             (struct _pdc_region_transform_ftn_info **)PDC_free(pdc_region_transform_registry);
-        pdc_region_transform_registry = NULL;
     }
 
     FUNC_LEAVE_VOID;
@@ -645,7 +642,6 @@ PDC_free_iterator_cache()
 
     if (PDC_Block_iterator_cache != NULL)
         PDC_Block_iterator_cache = (struct _pdc_iterator_info *)PDC_free(PDC_Block_iterator_cache);
-    PDC_Block_iterator_cache = NULL;
 
     FUNC_LEAVE_VOID;
 }

--- a/src/api/pdc_analysis/pdc_hist_pkg.c
+++ b/src/api/pdc_analysis/pdc_hist_pkg.c
@@ -2,11 +2,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 #define MACRO_SAMPLE_MIN_MAX(TYPE, n, data, sample_pct, min, max)                                            \
     ({                                                                                                       \
         uint64_t i, sample_n, iter = 0;                                                                      \
-        TYPE *   ldata = (TYPE *)data;                                                                       \
+        TYPE    *ldata = (TYPE *)data;                                                                       \
         (min)          = ldata[0];                                                                           \
         (max)          = ldata[0];                                                                           \
         sample_n       = (n) * (sample_pct);                                                                 \
@@ -123,7 +124,7 @@ PDC_create_hist(pdc_var_type_t dtype, int nbin, double min, double max)
     bin_incr = floor_power_of_2((max - min) / (nbin - 2)); // Excluding first and last bin (open ended)
     nbin     = ceil((max - min) / bin_incr);
 
-    hist        = (pdc_histogram_t *)malloc(sizeof(pdc_histogram_t));
+    hist        = (pdc_histogram_t *)PDC_malloc(sizeof(pdc_histogram_t));
     hist->incr  = bin_incr;
     hist->dtype = dtype;
     hist->range = (double *)calloc(sizeof(double), nbin * 2);
@@ -162,7 +163,7 @@ done:
     ({                                                                                                       \
         uint64_t i;                                                                                          \
         int      lo, mid = 0, hi;                                                                            \
-        TYPE *   ldata = (TYPE *)(_data);                                                                    \
+        TYPE    *ldata = (TYPE *)(_data);                                                                    \
         if ((hist)->incr > 0) {                                                                              \
             for (i = 0; i < (n); i++) {                                                                      \
                 if (ldata[i] < (hist)->range[1]) {                                                           \
@@ -292,9 +293,9 @@ PDC_free_hist(pdc_histogram_t *hist)
     if (NULL == hist)
         PGOTO_DONE_VOID;
 
-    free(hist->range);
-    free(hist->bin);
-    free(hist);
+    hist->range = (double *)PDC_free(hist->range);
+    hist->bin   = (uint64_t *)PDC_free(hist->bin);
+    hist        = (pdc_histogram_t *)PDC_free(hist);
 
 done:
     fflush(stdout);
@@ -337,7 +338,7 @@ PDC_dup_hist(pdc_histogram_t *hist)
         PGOTO_DONE(NULL);
 
     nbin       = hist->nbin;
-    res        = (pdc_histogram_t *)malloc(sizeof(pdc_histogram_t));
+    res        = (pdc_histogram_t *)PDC_malloc(sizeof(pdc_histogram_t));
     res->dtype = hist->dtype;
     res->nbin  = nbin;
     res->range = (double *)calloc(sizeof(double), nbin * 2);

--- a/src/api/pdc_analysis/pdc_hist_pkg.c
+++ b/src/api/pdc_analysis/pdc_hist_pkg.c
@@ -127,8 +127,8 @@ PDC_create_hist(pdc_var_type_t dtype, int nbin, double min, double max)
     hist        = (pdc_histogram_t *)PDC_malloc(sizeof(pdc_histogram_t));
     hist->incr  = bin_incr;
     hist->dtype = dtype;
-    hist->range = (double *)calloc(sizeof(double), nbin * 2);
-    hist->bin   = (uint64_t *)calloc(sizeof(uint64_t), nbin);
+    hist->range = (double *)PDC_calloc(sizeof(double), nbin * 2);
+    hist->bin   = (uint64_t *)PDC_calloc(sizeof(uint64_t), nbin);
     hist->nbin  = nbin;
 
     min_bin = floor(min);
@@ -341,8 +341,8 @@ PDC_dup_hist(pdc_histogram_t *hist)
     res        = (pdc_histogram_t *)PDC_malloc(sizeof(pdc_histogram_t));
     res->dtype = hist->dtype;
     res->nbin  = nbin;
-    res->range = (double *)calloc(sizeof(double), nbin * 2);
-    res->bin   = (uint64_t *)calloc(sizeof(uint64_t), nbin);
+    res->range = (double *)PDC_calloc(sizeof(double), nbin * 2);
+    res->bin   = (uint64_t *)PDC_calloc(sizeof(uint64_t), nbin);
     res->incr  = hist->incr;
 
     memcpy(res->range, hist->range, sizeof(double) * nbin * 2);
@@ -435,10 +435,10 @@ PDC_copy_hist(pdc_histogram_t *to, pdc_histogram_t *from)
     to->incr  = from->incr;
     to->dtype = from->dtype;
     if (NULL == to->range)
-        to->range = (double *)calloc(sizeof(double), nbin * 2);
+        to->range = (double *)PDC_calloc(sizeof(double), nbin * 2);
     memcpy(to->range, from->range, sizeof(double) * nbin * 2);
     if (NULL == to->bin)
-        to->bin = (uint64_t *)calloc(sizeof(uint64_t), nbin);
+        to->bin = (uint64_t *)PDC_calloc(sizeof(uint64_t), nbin);
     memcpy(to->bin, from->bin, sizeof(uint64_t) * nbin);
     to->nbin = from->nbin;
 

--- a/src/api/pdc_analysis/pdc_hist_pkg.c
+++ b/src/api/pdc_analysis/pdc_hist_pkg.c
@@ -7,7 +7,7 @@
 #define MACRO_SAMPLE_MIN_MAX(TYPE, n, data, sample_pct, min, max)                                            \
     ({                                                                                                       \
         uint64_t i, sample_n, iter = 0;                                                                      \
-        TYPE    *ldata = (TYPE *)data;                                                                       \
+        TYPE *   ldata = (TYPE *)data;                                                                       \
         (min)          = ldata[0];                                                                           \
         (max)          = ldata[0];                                                                           \
         sample_n       = (n) * (sample_pct);                                                                 \
@@ -163,7 +163,7 @@ done:
     ({                                                                                                       \
         uint64_t i;                                                                                          \
         int      lo, mid = 0, hi;                                                                            \
-        TYPE    *ldata = (TYPE *)(_data);                                                                    \
+        TYPE *   ldata = (TYPE *)(_data);                                                                    \
         if ((hist)->incr > 0) {                                                                              \
             for (i = 0; i < (n); i++) {                                                                      \
                 if (ldata[i] < (hist)->range[1]) {                                                           \

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -95,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int *             debug_server_id_count = NULL;
+static int              *debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -111,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t *  send_class_g       = NULL;
+static hg_class_t   *send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -126,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART *                 dart_g;
+static DART                  *dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -390,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char * p;
-    FILE * na_config = NULL;
+    char  *p;
+    FILE  *na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -474,7 +474,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int *               rpc_return;
+    int                *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -530,7 +530,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int *           rpc_return;
+    int            *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -558,7 +558,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int *              rpc_return;
+    int               *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -942,7 +942,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char *                         target_addr_string;
+    char                          *target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1217,14 +1217,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void *              buf = NULL;
-    void **             ids_buf;
+    void               *buf = NULL;
+    void              **ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t *          ids_buf_sizes;
+    uint64_t           *ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t *    meta_ptr;
-    uint64_t *          u64_arr_ptr;
+    pdc_metadata_t     *meta_ptr;
+    uint64_t           *u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1326,7 +1326,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char *      ret_value = NULL;
+    char       *ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1364,13 +1364,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char *              default_hg_transport = "ofi+tcp";
-    char *              hg_transport;
+    char               *default_hg_transport = "ofi+tcp";
+    char               *hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -1565,7 +1565,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char *   tmp_dir;
+    char    *tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1762,16 +1762,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
-    struct bulk_args_t *          bulk_args;
-    void *                        recv_meta;
+    const struct hg_info         *hg_info            = NULL;
+    struct bulk_args_t           *bulk_args;
+    void                         *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -2181,7 +2181,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2402,7 +2402,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop *         delete_prop;
+    struct _pdc_obj_prop          *delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2462,7 +2462,7 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t *                     metadata_query_handle;
+    hg_handle_t                      *metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
@@ -2769,7 +2769,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop *         create_prop = NULL;
+    struct _pdc_obj_prop          *create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2930,7 +2930,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
+    } // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2959,7 +2959,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    }     // End pdc_client_mpi_size_g < pdc_server_num_g
+    } // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3142,7 +3142,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t *                          hg_class;
+    hg_class_t                           *hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3268,7 +3268,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t *                                      hg_class;
+    hg_class_t                                       *hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3332,7 +3332,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t *                                     hg_class;
+    hg_class_t                                      *hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3397,7 +3397,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t *                               hg_class;
+    hg_class_t                                *hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3473,7 +3473,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t *                      hg_class;
+    hg_class_t                       *hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3709,12 +3709,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t * hg_class;
+    hg_class_t  *hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void **                  data_ptrs = NULL;
-    size_t *                 data_size = NULL;
+    void                   **data_ptrs = NULL;
+    size_t                  *data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -4098,11 +4098,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char *                  shm_base      = NULL; // base address, from mmap()
-    char *                  shm_addr      = NULL;
+    char                   *shm_base      = NULL; // base address, from mmap()
+    char                   *shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t *    read_info     = NULL;
-    struct pdc_request *    elt           = NULL;
+    client_read_info_t     *read_info     = NULL;
+    struct pdc_request     *elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4193,8 +4193,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char *                         shm_base; // base address, from mmap()
-    char *                         shm_addr;
+    char                          *shm_base; // base address, from mmap()
+    char                          *shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4329,8 +4329,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
 
     FUNC_ENTER(NULL);
 
@@ -4462,8 +4462,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -4564,9 +4564,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
-    void *                         buf;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
+    void                          *buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -4622,7 +4622,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-        // close and shm_unlink?
+    // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -4834,7 +4834,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t *      meta;
+    pdc_metadata_t       *meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5065,7 +5065,7 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5091,7 +5091,7 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5119,7 +5119,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info *  info;
+    struct _pdc_id_info   *info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5374,12 +5374,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes, total_size;
+    uint64_t                *buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request *                   request;
+    struct pdc_request                    *request;
 
     FUNC_ENTER(NULL);
 
@@ -5666,7 +5666,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            ret_value = NULL;
+    region_list_t             *ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5692,7 +5692,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            new_region;
+    region_list_t             *new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -5759,7 +5759,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                            HG_BULK_READ_ONLY, &bulk_handle);
+                               HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -5792,7 +5792,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void *                 buf = NULL;
+    void                  *buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -5904,8 +5904,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char *         fname, *prev_fname;
-    FILE *         fp_read = NULL;
+    char          *fname, *prev_fname;
+    FILE          *fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -6006,15 +6006,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes = NULL, total_size;
+    uint64_t                *buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char ***                 obj_names_by_server          = NULL;
-    char **                  obj_names_by_server_2d       = NULL;
+    char                  ***obj_names_by_server          = NULL;
+    char                   **obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request **                  requests, *request;
+    struct pdc_request                   **requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6237,12 +6237,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char **                 all_names = my_obj_names;
-    char *                  local_names_1d, *all_names_1d = NULL;
-    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char                  **all_names = my_obj_names;
+    char                   *local_names_1d, *all_names_1d = NULL;
+    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6533,7 +6533,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        }     // ndim=2
+        } // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -6604,8 +6604,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -6712,8 +6712,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info *     obj_prop;
-    struct _pdc_cont_info *    cont_prop;
+    struct _pdc_obj_info      *obj_prop;
+    struct _pdc_cont_info     *cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -6773,12 +6773,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void *              buf = NULL;
+    void               *buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t *          ids_buf_sizes;
-    void **             ids_buf;
-    uint64_t *          u64_arr_ptr;
+    uint64_t           *ids_buf_sizes;
+    void              **ids_buf;
+    uint64_t           *u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -6831,14 +6831,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          bulk_arg;
+    struct bulk_args_t           *bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
+    const struct hg_info         *hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7016,8 +7016,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7259,7 +7259,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info *  id_info = NULL;
+    struct _pdc_id_info   *id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7365,7 +7365,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info * obj_prop;
+    struct _pdc_obj_info  *obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -7498,7 +7498,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7526,10 +7526,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t *                     target_servers = NULL;
+    uint32_t                      *target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t *             query_xfer;
+    pdc_query_xfer_t              *query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -7617,12 +7617,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7703,7 +7703,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7775,11 +7775,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7851,9 +7851,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time = server_call_count_g[i] > 0
-                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                  : 0.0;
+        double avg_srv_time  = server_call_count_g[i] > 0
+                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                   : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -7993,7 +7993,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8002,8 +8002,8 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args;
-    void *                recv_meta;
+    struct bulk_args_t   *bulk_args;
+    void                 *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -8172,7 +8172,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
     struct bulk_args_t *lookup_args =
         (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t       ret_value            = 0;
-    hg_handle_t *  dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
     int            num_requests         = 0;
     uint32_t       total_n_meta         = 0;
     dart_op_type_t op_type              = dart_in->op_type;
@@ -8236,9 +8236,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char *         k_query = get_key(query_string, '=');
-    char *         v_query = get_value(query_string, '=');
-    char *         tok     = NULL;
+    char          *k_query = get_key(query_string, '=');
+    char          *v_query = get_value(query_string, '=');
+    char          *tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -436,7 +436,8 @@ PDC_Client_read_server_addr_from_file()
     }
 
     // Allocate $pdc_server_info_g
-    pdc_server_info_g = (struct _pdc_server_info *)calloc(sizeof(struct _pdc_server_info), pdc_server_num_g);
+    pdc_server_info_g =
+        (struct _pdc_server_info *)PDC_calloc(sizeof(struct _pdc_server_info), pdc_server_num_g);
 
     i = 0;
     while (i < pdc_server_num_g) {
@@ -1241,13 +1242,13 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     if (hg_cb_info->ret == HG_SUCCESS) {
         if (bulk_args->is_id == 1) {
             bulk_sgnum    = HG_Bulk_get_segment_count(local_bulk_handle);
-            ids_buf       = (void **)calloc(sizeof(void *), bulk_sgnum);
-            ids_buf_sizes = (uint64_t *)calloc(sizeof(uint64_t), bulk_sgnum);
+            ids_buf       = (void **)PDC_calloc(sizeof(void *), bulk_sgnum);
+            ids_buf_sizes = (uint64_t *)PDC_calloc(sizeof(uint64_t), bulk_sgnum);
             HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, bulk_sgnum, ids_buf,
                            ids_buf_sizes, &actual_cnt);
 
             u64_arr_ptr        = ((uint64_t **)(ids_buf))[0];
-            bulk_args->obj_ids = (uint64_t *)calloc(sizeof(uint64_t), n_meta);
+            bulk_args->obj_ids = (uint64_t *)PDC_calloc(sizeof(uint64_t), n_meta);
             for (i = 0; i < n_meta; i++) {
                 bulk_args->obj_ids[i] = *u64_arr_ptr;
                 u64_arr_ptr++;
@@ -1257,7 +1258,7 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
             HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, &buf, buf_sizes,
                            &actual_cnt);
             meta_ptr            = (pdc_metadata_t *)(buf);
-            bulk_args->meta_arr = (pdc_metadata_t **)calloc(sizeof(pdc_metadata_t *), n_meta);
+            bulk_args->meta_arr = (pdc_metadata_t **)PDC_calloc(sizeof(pdc_metadata_t *), n_meta);
             for (i = 0; i < n_meta; i++) {
                 bulk_args->meta_arr[i] = meta_ptr;
                 meta_ptr++;
@@ -1669,18 +1670,13 @@ PDC_Client_init()
         srand(time(NULL));
 
         /* Initialize DART space */
-        dart_g = (DART *)calloc(1, sizeof(DART));
+        dart_g = (DART *)PDC_calloc(1, sizeof(DART));
         dart_space_init(dart_g, pdc_server_num_g);
 
-        server_time_total_g = (int64_t *)calloc(pdc_server_num_g, sizeof(int64_t));
-        server_call_count_g = (int64_t *)calloc(pdc_server_num_g, sizeof(int64_t));
-        server_mem_usage_g  = (int64_t *)calloc(pdc_server_num_g, sizeof(int64_t));
+        server_time_total_g = (int64_t *)PDC_calloc(pdc_server_num_g, sizeof(int64_t));
+        server_call_count_g = (int64_t *)PDC_calloc(pdc_server_num_g, sizeof(int64_t));
+        server_mem_usage_g  = (int64_t *)PDC_calloc(pdc_server_num_g, sizeof(int64_t));
     }
-
-    /* if (hg_progress_flag_g == -1) { */
-    /*     hg_progress_flag_g = 0; */
-    /*     pthread_create(&hg_progress_tid_g, NULL, hg_progress_fn, send_context_g); */
-    /* } */
 
 done:
     fflush(stdout);
@@ -1795,7 +1791,7 @@ metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
         PGOTO_DONE(ret_value);
     }
     else
-        client_lookup_args->meta_arr = (pdc_metadata_t **)calloc(n_meta, sizeof(pdc_metadata_t *));
+        client_lookup_args->meta_arr = (pdc_metadata_t **)PDC_calloc(n_meta, sizeof(pdc_metadata_t *));
 
     // We have received the bulk handle from server (server uses hg_respond)
     // Use this to initiate a bulk transfer
@@ -1808,7 +1804,7 @@ metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
     bulk_args->nbytes = HG_Bulk_get_size(origin_bulk_handle);
     bulk_args->n_meta = client_lookup_args->n_meta;
 
-    recv_meta = (void *)calloc(sizeof(pdc_metadata_t), n_meta);
+    recv_meta = (void *)PDC_calloc(sizeof(pdc_metadata_t), n_meta);
 
     /* Create a new bulk handle to read the data */
     HG_Bulk_create(hg_info->hg_class, 1, (void **)&recv_meta, (hg_size_t *)&bulk_args->nbytes,
@@ -1941,7 +1937,7 @@ PDC_partial_query(int is_list_all, int user_id, const char *app_name, const char
         }
         else {
             out_size += sizeof(pdc_metadata_t *) * (lookup_args.n_meta);
-            *out = (pdc_metadata_t **)realloc(*out, out_size);
+            *out = (pdc_metadata_t **)PDC_realloc(*out, out_size);
         }
 
         *n_res += lookup_args.n_meta;
@@ -2025,7 +2021,7 @@ PDC_Client_query_tag(const char *tags, int *n_res, pdc_metadata_t ***out)
         }
         else {
             out_size += sizeof(pdc_metadata_t *) * ((lookup_args.n_meta));
-            *out = (pdc_metadata_t **)realloc(*out, out_size);
+            *out = (pdc_metadata_t **)PDC_realloc(*out, out_size);
         }
 
         *n_res += (lookup_args.n_meta);
@@ -2597,7 +2593,7 @@ PDC_Client_query_metadata_name_timestep_agg(const char *obj_name, int time_step,
         PGOTO_ERROR(FAIL, "==PDC_CLIENT[%d]: - ERROR with query [%s]", pdc_client_mpi_rank_g, obj_name);
 
     if (pdc_client_mpi_rank_g != 0)
-        *out = (pdc_metadata_t *)calloc(1, sizeof(pdc_metadata_t));
+        *out = (pdc_metadata_t *)PDC_calloc(1, sizeof(pdc_metadata_t));
 
     MPI_Bcast(*out, sizeof(pdc_metadata_t), MPI_CHAR, 0, PDC_CLIENT_COMM_WORLD_g);
     MPI_Bcast(metadata_server_id, 1, MPI_UINT32_T, 0, PDC_CLIENT_COMM_WORLD_g);
@@ -5407,7 +5403,7 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
         PGOTO_ERROR(FAIL, "Could not create handle");
 
     total_size = 0;
-    buf_sizes  = (uint64_t *)calloc(sizeof(uint64_t), nobj);
+    buf_sizes  = (uint64_t *)PDC_calloc(sizeof(uint64_t), nobj);
     for (i = 0; i < nobj; i++) {
         buf_sizes[i] = strlen(obj_names[i]) + 1;
         total_size += buf_sizes[i];
@@ -5419,7 +5415,7 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
-    request               = (struct pdc_request *)calloc(1, sizeof(struct pdc_request));
+    request               = (struct pdc_request *)PDC_calloc(1, sizeof(struct pdc_request));
     request->server_id    = server_id;
     request->access_type  = PDC_READ;
     request->n_buf_arr    = nobj;
@@ -5469,9 +5465,9 @@ PDC_Client_complete_read_request(int nbuf, struct pdc_request *req)
 
     FUNC_ENTER(NULL);
 
-    *req->buf_arr     = (void **)calloc(nbuf, sizeof(void *));
-    req->shm_fd_arr   = (int *)calloc(nbuf, sizeof(int));
-    req->shm_base_arr = (char **)calloc(nbuf, sizeof(char *));
+    *req->buf_arr     = (void **)PDC_calloc(nbuf, sizeof(void *));
+    req->shm_fd_arr   = (int *)PDC_calloc(nbuf, sizeof(int));
+    req->shm_base_arr = (char **)PDC_calloc(nbuf, sizeof(char *));
 
     for (i = 0; i < nbuf; i++) {
         /* open the shared memory segment as if it was a file */
@@ -5538,7 +5534,7 @@ PDC_Client_query_read_complete(char *shm_addrs, int size, int n_shm, int seq_id)
     if (request == NULL)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT[%d]: cannot find previous request", pdc_client_mpi_rank_g);
 
-    request->shm_addr_arr = (char **)calloc(n_shm, sizeof(char *));
+    request->shm_addr_arr = (char **)PDC_calloc(n_shm, sizeof(char *));
     cnt                   = 0;
     for (i = 0; i < size - 1; i++) {
 
@@ -5624,38 +5620,7 @@ done:
     fflush(stdout);
     FUNC_LEAVE(ret_value);
 }
-/*
-perr_t
-PDC_Client_attach_metadata_to_local_obj(const char *obj_name, uint64_t obj_id, uint64_t cont_id,
-                                        uint32_t data_server_id, struct _pdc_obj_info *obj_info)
-{
-    perr_t ret_value = SUCCEED;
 
-    FUNC_ENTER(NULL);
-
-    obj_info->metadata                              = (pdc_metadata_t *)calloc(1, sizeof(pdc_metadata_t));
-    ((pdc_metadata_t *)obj_info->metadata)->user_id = obj_info->obj_pt->user_id;
-    if (NULL != obj_info->obj_pt->app_name)
-        strcpy(((pdc_metadata_t *)obj_info->metadata)->app_name, obj_info->obj_pt->app_name);
-    if (NULL != obj_name)
-        strcpy(((pdc_metadata_t *)obj_info->metadata)->obj_name, obj_name);
-    ((pdc_metadata_t *)obj_info->metadata)->time_step      = obj_info->obj_pt->time_step;
-    ((pdc_metadata_t *)obj_info->metadata)->obj_id         = obj_id;
-    ((pdc_metadata_t *)obj_info->metadata)->cont_id        = cont_id;
-    ((pdc_metadata_t *)obj_info->metadata)->data_server_id = data_server_id;
-    if (NULL != obj_info->obj_pt->tags)
-        strcpy(((pdc_metadata_t *)obj_info->metadata)->tags, obj_info->obj_pt->tags);
-    if (NULL != obj_info->obj_pt->data_loc)
-
-        strcpy(((pdc_metadata_t *)obj_info->metadata)->data_location, obj_info->obj_pt->data_loc);
-    ((pdc_metadata_t *)obj_info->metadata)->ndim = obj_info->obj_pt->obj_prop_pub->ndim;
-    if (NULL != obj_info->obj_pt->obj_prop_pub->dims)
-        memcpy(((pdc_metadata_t *)obj_info->metadata)->dims, obj_info->obj_pt->obj_prop_pub->dims,
-               sizeof(uint64_t) * obj_info->obj_pt->obj_prop_pub->ndim);
-
-    FUNC_LEAVE(ret_value);
-}
-*/
 perr_t
 PDC_Client_send_client_shm_info(uint32_t server_id, char *shm_addr, uint64_t size)
 {
@@ -5742,7 +5707,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 
     // If not found, create and insert one to the read list
     if (NULL == io_list_target) {
-        io_list_target         = (pdc_data_server_io_list_t *)calloc(1, sizeof(pdc_data_server_io_list_t));
+        io_list_target = (pdc_data_server_io_list_t *)PDC_calloc(1, sizeof(pdc_data_server_io_list_t));
         io_list_target->obj_id = storage_meta->obj_id;
         io_list_target->total  = 0;
         io_list_target->count  = 0;
@@ -5756,7 +5721,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
     io_list_target->total++;
     io_list_target->count++;
 
-    new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+    new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&storage_meta->region_transfer, new_region);
     strcpy(new_region->shm_addr, storage_meta->storage_location);
     new_region->offset        = storage_meta->offset;
@@ -5920,7 +5885,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
 
 #else
     // send to node local server
-    all_region_storage_meta_1d = (region_storage_meta_t *)calloc(nobj, sizeof(region_storage_meta_t));
+    all_region_storage_meta_1d = (region_storage_meta_t *)PDC_calloc(nobj, sizeof(region_storage_meta_t));
     for (i = 0; i < nobj; i++)
         memcpy(&all_region_storage_meta_1d[i], all_storage_meta[i], sizeof(region_storage_meta_t));
 
@@ -5949,7 +5914,7 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 
     FUNC_ENTER(NULL);
 
-    *buf_arr = (void **)calloc(sizeof(void *), nobj);
+    *buf_arr = (void **)PDC_calloc(sizeof(void *), nobj);
 
     cache_count_g = 0;
     cache_total_g = nobj * cache_percentage_g / 100;
@@ -6060,14 +6025,14 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
         PGOTO_ERROR(FAIL, "==PDC_CLIENT[%d]: invalid input", pdc_client_mpi_rank_g);
 
     // One request to each metadata server
-    requests = (struct pdc_request **)calloc(sizeof(struct pdc_request *), pdc_server_num_g);
+    requests = (struct pdc_request **)PDC_calloc(sizeof(struct pdc_request *), pdc_server_num_g);
 
-    obj_names_by_server             = (char ***)calloc(sizeof(char **), pdc_server_num_g);
-    n_obj_name_by_server            = (int *)calloc(sizeof(int), pdc_server_num_g);
-    obj_names_server_seq_mapping    = (int **)calloc(sizeof(int *), pdc_server_num_g);
-    obj_names_server_seq_mapping_1d = (int *)calloc(sizeof(int), nobj * pdc_server_num_g);
+    obj_names_by_server             = (char ***)PDC_calloc(sizeof(char **), pdc_server_num_g);
+    n_obj_name_by_server            = (int *)PDC_calloc(sizeof(int), pdc_server_num_g);
+    obj_names_server_seq_mapping    = (int **)PDC_calloc(sizeof(int *), pdc_server_num_g);
+    obj_names_server_seq_mapping_1d = (int *)PDC_calloc(sizeof(int), nobj * pdc_server_num_g);
     for (i = 0; i < pdc_server_num_g; i++) {
-        obj_names_by_server[i]          = (char **)calloc(sizeof(char *), nobj);
+        obj_names_by_server[i]          = (char **)PDC_calloc(sizeof(char *), nobj);
         obj_names_server_seq_mapping[i] = obj_names_server_seq_mapping_1d + i * nobj;
     }
 
@@ -6101,7 +6066,7 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
             PGOTO_ERROR(FAIL, "Could not create handle");
 
         total_size = 0;
-        buf_sizes  = (uint64_t *)calloc(sizeof(uint64_t), n_obj_name_by_server[server_id]);
+        buf_sizes  = (uint64_t *)PDC_calloc(sizeof(uint64_t), n_obj_name_by_server[server_id]);
         for (i = 0; i < n_obj_name_by_server[server_id]; i++) {
             buf_sizes[i] = strlen(obj_names_by_server[server_id][i]) + 1;
             total_size += buf_sizes[i];
@@ -6113,7 +6078,7 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
         if (hg_ret != HG_SUCCESS)
             PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
-        requests[server_id] = (struct pdc_request *)calloc(1, sizeof(struct pdc_request));
+        requests[server_id] = (struct pdc_request *)PDC_calloc(1, sizeof(struct pdc_request));
 
         requests[server_id]->server_id   = server_id;
         requests[server_id]->access_type = PDC_READ;
@@ -6147,7 +6112,7 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     // Now we have all the storage meta stored in the requests structure
     // Reorgaze them and fill the output buffer
-    (*all_storage_meta) = (region_storage_meta_t **)calloc(sizeof(region_storage_meta_t *), nobj);
+    (*all_storage_meta) = (region_storage_meta_t **)PDC_calloc(sizeof(region_storage_meta_t *), nobj);
     for (iter = 0; iter < pdc_server_num_g; iter++) {
         request = requests[iter];
         if (request == NULL || request->storage_meta == NULL)
@@ -6289,7 +6254,7 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
     FUNC_ENTER(NULL);
 
 #ifdef ENABLE_MPI
-    local_names_1d = (char *)calloc(my_nobj, max_name_len);
+    local_names_1d = (char *)PDC_calloc(my_nobj, max_name_len);
     for (i = 0; i < my_nobj; i++) {
         if (strlen(my_obj_names[i]) > max_name_len)
             LOG_ERROR("==PDC_CLIENT[%2d]: object name longer than %lu [%s]!\n", pdc_client_mpi_rank_g,
@@ -6317,7 +6282,7 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
     }
 
     if (pdc_client_same_node_rank_g == 0) {
-        all_names    = (char **)calloc(sizeof(char *), ntotal_obj);
+        all_names    = (char **)PDC_calloc(sizeof(char *), ntotal_obj);
         all_names_1d = (char *)PDC_malloc(ntotal_obj * max_name_len);
         for (i = 0; i < ntotal_obj; i++)
             all_names[i] = all_names_1d + i * max_name_len;
@@ -6336,7 +6301,8 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
         ret_value = PDC_Client_query_multi_storage_info(ntotal_obj, all_names, &all_storage_meta);
 
         // Copy the result to the result array for scatter
-        // res_storage_meta_1d = (region_storage_meta_t *)calloc(sizeof(region_storage_meta_t), ntotal_obj);
+        // res_storage_meta_1d = (region_storage_meta_t *)PDC_calloc(sizeof(region_storage_meta_t),
+        // ntotal_obj);
         res_storage_meta_1d = (region_storage_meta_t *)PDC_malloc(sizeof(region_storage_meta_t) * ntotal_obj);
         for (i = 0; i < ntotal_obj; i++)
             memcpy(&res_storage_meta_1d[i], all_storage_meta[i], sizeof(region_storage_meta_t));
@@ -6349,8 +6315,8 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
 #endif
 
     // allocate space for storage meta results
-    my_storage_meta    = (region_storage_meta_t **)calloc(sizeof(region_storage_meta_t *), my_nobj);
-    my_storage_meta_1d = (region_storage_meta_t *)calloc(sizeof(region_storage_meta_t), my_nobj);
+    my_storage_meta    = (region_storage_meta_t **)PDC_calloc(sizeof(region_storage_meta_t *), my_nobj);
+    my_storage_meta_1d = (region_storage_meta_t *)PDC_calloc(sizeof(region_storage_meta_t), my_nobj);
     for (i = 0; i < my_nobj; i++)
         my_storage_meta[i] = &(my_storage_meta_1d[i]);
 
@@ -6823,13 +6789,13 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
 
     if (hg_cb_info->ret == HG_SUCCESS) {
         bulk_sgnum    = HG_Bulk_get_segment_count(local_bulk_handle);
-        ids_buf       = (void **)calloc(sizeof(void *), bulk_sgnum);
-        ids_buf_sizes = (uint64_t *)calloc(sizeof(uint64_t), bulk_sgnum);
+        ids_buf       = (void **)PDC_calloc(sizeof(void *), bulk_sgnum);
+        ids_buf_sizes = (uint64_t *)PDC_calloc(sizeof(uint64_t), bulk_sgnum);
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, bulk_sgnum, ids_buf,
                        ids_buf_sizes, &actual_cnt);
 
         u64_arr_ptr        = ((uint64_t **)(ids_buf))[0];
-        bulk_args->obj_ids = (uint64_t *)calloc(sizeof(uint64_t), n_meta);
+        bulk_args->obj_ids = (uint64_t *)PDC_calloc(sizeof(uint64_t), n_meta);
         for (int i = 0; i < n_meta; i++) {
             bulk_args->obj_ids[i] = *u64_arr_ptr;
             u64_arr_ptr++;
@@ -6838,7 +6804,7 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
         // HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, &buf, buf_sizes,
         //                &actual_cnt);
 
-        // bulk_args->obj_ids = (uint64_t *)calloc(sizeof(uint64_t), n_meta);
+        // bulk_args->obj_ids = (uint64_t *)PDC_calloc(sizeof(uint64_t), n_meta);
         // memcpy(bulk_args->obj_ids, buf, sizeof(uint64_t) * n_meta);
     }
     else
@@ -6971,7 +6937,7 @@ PDC_Client_query_kvtag_server(uint32_t server_id, const pdc_kvtag_t *kvtag, int 
     hg_ret = HG_Create(send_context_g, pdc_server_info_g[server_id].addr, query_kvtag_register_id_g,
                        &query_kvtag_server_handle);
 
-    bulk_arg = (struct bulk_args_t *)calloc(1, sizeof(struct bulk_args_t));
+    bulk_arg = (struct bulk_args_t *)PDC_calloc(1, sizeof(struct bulk_args_t));
     if (query_kvtag_server_handle == NULL)
         PGOTO_ERROR(FAIL, "==CLIENT[%d]: Error with query_kvtag_server_handle", pdc_client_mpi_rank_g);
 
@@ -7029,7 +6995,7 @@ PDC_Client_query_kvtag(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_ids)
             *pdc_ids = temp_ids;
         }
         else if (nmeta > 0) {
-            *pdc_ids = (uint64_t *)realloc(*pdc_ids, sizeof(uint64_t) * (*n_res + nmeta));
+            *pdc_ids = (uint64_t *)PDC_realloc(*pdc_ids, sizeof(uint64_t) * (*n_res + nmeta));
             memcpy(*pdc_ids + (*n_res), temp_ids, nmeta * sizeof(uint64_t));
             temp_ids = (uint64_t *)PDC_free(temp_ids);
         }
@@ -7575,7 +7541,7 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
         PGOTO_ERROR(FAIL, "==CLIENT[%d]: ERROR with PDC_serialize_query", pdc_client_mpi_rank_g);
 
     // Find unique server IDs that has metadata of the queried objects
-    target_servers = (uint32_t *)calloc(pdc_server_num_g, sizeof(uint32_t));
+    target_servers = (uint32_t *)PDC_calloc(pdc_server_num_g, sizeof(uint32_t));
     PDC_get_server_from_query(query, target_servers, &ntarget);
     query_xfer->n_unique_obj = ntarget;
     query_xfer->query_id     = gen_query_id();
@@ -7583,7 +7549,7 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
     query_xfer->manager      = target_servers[0];
     query_xfer->get_op       = (int)get_op;
 
-    result           = (struct _pdc_query_result_list *)calloc(1, sizeof(struct _pdc_query_result_list));
+    result           = (struct _pdc_query_result_list *)PDC_calloc(1, sizeof(struct _pdc_query_result_list));
     result->query_id = query_xfer->query_id;
     DL_APPEND(pdcquery_result_list_head_g, result);
 
@@ -7840,8 +7806,8 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
         {
             if (result_elt->query_id == query_id) {
                 if (result_elt->data_arr == NULL) {
-                    result_elt->data_arr      = calloc(sizeof(void *), pdc_server_num_g);
-                    result_elt->data_arr_size = calloc(sizeof(uint64_t *), pdc_server_num_g);
+                    result_elt->data_arr      = PDC_calloc(sizeof(void *), pdc_server_num_g);
+                    result_elt->data_arr_size = PDC_calloc(sizeof(uint64_t *), pdc_server_num_g);
                 }
 
                 result_elt->data_arr[seq_id] = malloc(bulk_args->nbytes);
@@ -8090,7 +8056,7 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     /* LOG_INFO("nbytes=%u\n", bulk_args->nbytes); */
 
     if (client_lookup_args->is_id == 1) {
-        recv_meta = (void *)calloc(n_meta, sizeof(uint64_t));
+        recv_meta = (void *)PDC_calloc(n_meta, sizeof(uint64_t));
     }
     else {
         // throw an error
@@ -8205,12 +8171,13 @@ uint64_t
 dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
                         dart_perform_one_server_in_t *dart_in, Set *output_set)
 {
-    struct bulk_args_t *lookup_args = (struct bulk_args_t *)calloc(num_servers, sizeof(struct bulk_args_t));
-    uint64_t            ret_value   = 0;
-    hg_handle_t        *dart_request_handles = (hg_handle_t *)calloc(num_servers, sizeof(hg_handle_t));
-    int                 num_requests         = 0;
-    uint32_t            total_n_meta         = 0;
-    dart_op_type_t      op_type              = dart_in->op_type;
+    struct bulk_args_t *lookup_args =
+        (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
+    uint64_t       ret_value            = 0;
+    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    int            num_requests         = 0;
+    uint32_t       total_n_meta         = 0;
+    dart_op_type_t op_type              = dart_in->op_type;
 
     dart_in->src_client_id = pdc_client_mpi_rank_g;
 
@@ -8326,7 +8293,7 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     *n_res = set_num_entries(result_set);
     // println("num_ids = %d", num_ids);
     if (*n_res > 0) {
-        *out               = (uint64_t *)calloc(*n_res, sizeof(uint64_t));
+        *out               = (uint64_t *)PDC_calloc(*n_res, sizeof(uint64_t));
         uint64_t **set_arr = (uint64_t **)set_to_array(result_set);
         for (i = 0; i < *n_res; i++) {
             (*out)[i] = set_arr[i][0];
@@ -8516,7 +8483,7 @@ PDC_Client_query_kvtag_col(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_
             *pdc_ids = temp_ids;
         }
         else if (nmeta > 0) {
-            *pdc_ids = (uint64_t *)realloc(*pdc_ids, sizeof(uint64_t) * (*n_res + nmeta));
+            *pdc_ids = (uint64_t *)PDC_realloc(*pdc_ids, sizeof(uint64_t) * (*n_res + nmeta));
             memcpy(*pdc_ids + (*n_res), temp_ids, nmeta * sizeof(uint64_t));
             temp_ids = (uint64_t *)PDC_free(temp_ids);
         }
@@ -8537,7 +8504,7 @@ _standard_all_gather_result(int query_sent, int *n_res, uint64_t **pdc_ids, MPI_
     double stime = 0.0, duration = 0.0;
     stime = MPI_Wtime();
 
-    int *all_nmeta_array = (int *)calloc(pdc_client_mpi_size_g, sizeof(int));
+    int *all_nmeta_array = (int *)PDC_calloc(pdc_client_mpi_size_g, sizeof(int));
     MPI_Allgather(n_res, 1, MPI_INT, all_nmeta_array, 1, MPI_INT, world_comm);
 
     duration = MPI_Wtime() - stime;
@@ -8547,7 +8514,7 @@ _standard_all_gather_result(int query_sent, int *n_res, uint64_t **pdc_ids, MPI_
                 pdc_client_mpi_rank_g, duration * 1000.0);
     }
 
-    disp   = (int *)calloc(pdc_client_mpi_size_g, sizeof(int));
+    disp   = (int *)PDC_calloc(pdc_client_mpi_size_g, sizeof(int));
     ntotal = 0;
     for (i = 0; i < pdc_client_mpi_size_g; i++) {
         disp[i] = ntotal;
@@ -8594,7 +8561,7 @@ _customized_all_gather_result(int query_sent, int *n_res, uint64_t **pdc_ids, MP
 
     int  n_sent_ranks  = sub_comm_color == 1 ? sub_comm_size : pdc_client_mpi_size_g - sub_comm_size;
     int  sub_n_obj_len = n_sent_ranks + 1; // the last element is the first rank who sent the query.
-    int *sub_n_obj_arr = (int *)calloc(sub_n_obj_len, sizeof(int));
+    int *sub_n_obj_arr = (int *)PDC_calloc(sub_n_obj_len, sizeof(int));
     // FIXME: how to get the global rank number of the first rank who sent the query?
     // currently, we use 0, since each time when PDC_Client_query_kvtag_col runs, it is always using the
     // first N ranks to send the query, where N is the number of servers.
@@ -8622,8 +8589,8 @@ _customized_all_gather_result(int query_sent, int *n_res, uint64_t **pdc_ids, MP
     // Let's calculate the total number of results, and the displacement for each client.
     MPI_Barrier(world_comm);
 
-    all_nmeta = (int *)calloc(pdc_client_mpi_size_g, sizeof(int));
-    disp      = (int *)calloc(pdc_client_mpi_size_g, sizeof(int));
+    all_nmeta = (int *)PDC_calloc(pdc_client_mpi_size_g, sizeof(int));
+    disp      = (int *)PDC_calloc(pdc_client_mpi_size_g, sizeof(int));
     ntotal    = 0;
     for (i = 0; i < sub_n_obj_len - 1; i++) {
         all_nmeta[i] = sub_n_obj_arr[i];
@@ -8703,7 +8670,7 @@ PDC_Client_query_kvtag_mpi(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_
     *n_res = set_num_entries(result_set);
     // println("num_ids = %d", num_ids);
     if (*n_res > 0) {
-        *pdc_ids           = (uint64_t *)calloc(*n_res, sizeof(uint64_t));
+        *pdc_ids           = (uint64_t *)PDC_calloc(*n_res, sizeof(uint64_t));
         uint64_t **set_arr = (uint64_t **)set_to_array(result_set);
         for (i = 0; i < *n_res; i++) {
             (*pdc_ids)[i] = set_arr[i][0];
@@ -8735,7 +8702,7 @@ _standard_bcast_result(int root, int *n_res, uint64_t **out, MPI_Comm world_comm
     }
 
     if (pdc_client_mpi_rank_g != root) {
-        *out = (uint64_t *)calloc(*n_res, sizeof(uint64_t));
+        *out = (uint64_t *)PDC_calloc(*n_res, sizeof(uint64_t));
     }
 
     // broadcast the result to all other ranks
@@ -8807,7 +8774,7 @@ _customized_bcast_result(int first_sender_global_rank, int num_groups, int sende
     // root for WORLD_COMM. Let's perform BCAST for the array data. for those ranks that are not the root,
     // allocate memory for the object IDs.
     if (*out == NULL) {
-        *out = (uint64_t *)calloc(*n_res, sizeof(uint64_t));
+        *out = (uint64_t *)PDC_calloc(*n_res, sizeof(uint64_t));
     }
 
     MPI_Bcast(*out, *n_res, MPI_UINT64_T, first_sender_global_rank, world_comm);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -95,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int              *debug_server_id_count = NULL;
+static int *             debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -111,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t   *send_class_g       = NULL;
+static hg_class_t *  send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -126,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART                  *dart_g;
+static DART *                 dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -390,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char  *p;
-    FILE  *na_config = NULL;
+    char * p;
+    FILE * na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -474,7 +474,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int                *rpc_return;
+    int *               rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -530,7 +530,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int            *rpc_return;
+    int *           rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -558,7 +558,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int               *rpc_return;
+    int *              rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -942,7 +942,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char                          *target_addr_string;
+    char *                         target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1217,14 +1217,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void               *buf = NULL;
-    void              **ids_buf;
+    void *              buf = NULL;
+    void **             ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t           *ids_buf_sizes;
+    uint64_t *          ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t     *meta_ptr;
-    uint64_t           *u64_arr_ptr;
+    pdc_metadata_t *    meta_ptr;
+    uint64_t *          u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1326,7 +1326,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char       *ret_value = NULL;
+    char *      ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1355,7 +1355,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
 {
     perr_t  ret_value = SUCCEED;
     char    na_info_string[NA_STRING_INFO_LEN];
-    char   *hostname;
+    char *  hostname;
     pbool_t free_hostname = false;
     int     local_server_id;
     /* Set the default mercury transport
@@ -1365,13 +1365,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char               *default_hg_transport = "ofi+tcp";
-    char               *hg_transport;
+    char *              default_hg_transport = "ofi+tcp";
+    char *              hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char             *auth_key;
+    char *            auth_key;
     int               rc;
 #endif
 
@@ -1571,7 +1571,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char    *tmp_dir;
+    char *   tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1768,16 +1768,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *client_lookup_args;
+    struct bulk_args_t *          client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info         *hg_info            = NULL;
-    struct bulk_args_t           *bulk_args;
-    void                         *recv_meta;
+    const struct hg_info *        hg_info            = NULL;
+    struct bulk_args_t *          bulk_args;
+    void *                        recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -2187,7 +2187,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_obj_info *         obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2408,7 +2408,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop          *delete_prop;
+    struct _pdc_obj_prop *         delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2468,7 +2468,7 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t                      *metadata_query_handle;
+    hg_handle_t *                     metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
@@ -2775,7 +2775,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop          *create_prop = NULL;
+    struct _pdc_obj_prop *         create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2936,7 +2936,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    } // End pdc_client_mpi_size_g >= pdc_server_num_g
+    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2965,7 +2965,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    } // End pdc_client_mpi_size_g < pdc_server_num_g
+    }     // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3148,7 +3148,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t                           *hg_class;
+    hg_class_t *                          hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3274,7 +3274,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t                                       *hg_class;
+    hg_class_t *                                      hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3338,7 +3338,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t                                      *hg_class;
+    hg_class_t *                                     hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3403,7 +3403,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t                                *hg_class;
+    hg_class_t *                               hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3479,7 +3479,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t                       *hg_class;
+    hg_class_t *                      hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3715,12 +3715,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t  *hg_class;
+    hg_class_t * hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void                   **data_ptrs = NULL;
-    size_t                  *data_size = NULL;
+    void **                  data_ptrs = NULL;
+    size_t *                 data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -4104,11 +4104,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char                   *shm_base      = NULL; // base address, from mmap()
-    char                   *shm_addr      = NULL;
+    char *                  shm_base      = NULL; // base address, from mmap()
+    char *                  shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t     *read_info     = NULL;
-    struct pdc_request     *elt           = NULL;
+    client_read_info_t *    read_info     = NULL;
+    struct pdc_request *    elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4199,8 +4199,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char                          *shm_base; // base address, from mmap()
-    char                          *shm_addr;
+    char *                         shm_base; // base address, from mmap()
+    char *                         shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4335,8 +4335,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
 
     FUNC_ENTER(NULL);
 
@@ -4468,8 +4468,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -4570,9 +4570,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
-    void                          *buf;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
+    void *                         buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -4628,7 +4628,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-    // close and shm_unlink?
+        // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -4840,7 +4840,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t       *meta;
+    pdc_metadata_t *      meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5071,7 +5071,7 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t            *obj_ids;
+    uint64_t *           obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5097,7 +5097,7 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t            *obj_ids;
+    uint64_t *           obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5125,7 +5125,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info   *info;
+    struct _pdc_id_info *  info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5380,12 +5380,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t                *buf_sizes, total_size;
+    uint64_t *               buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request                    *request;
+    struct pdc_request *                   request;
 
     FUNC_ENTER(NULL);
 
@@ -5672,7 +5672,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t             *ret_value = NULL;
+    region_list_t *            ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5698,7 +5698,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t             *new_region;
+    region_list_t *            new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -5765,7 +5765,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                               HG_BULK_READ_ONLY, &bulk_handle);
+                            HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -5798,7 +5798,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void                  *buf = NULL;
+    void *                 buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -5910,8 +5910,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char          *fname, *prev_fname;
-    FILE          *fp_read = NULL;
+    char *         fname, *prev_fname;
+    FILE *         fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -6012,15 +6012,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t                *buf_sizes = NULL, total_size;
+    uint64_t *               buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char                  ***obj_names_by_server          = NULL;
-    char                   **obj_names_by_server_2d       = NULL;
+    char ***                 obj_names_by_server          = NULL;
+    char **                  obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request                   **requests, *request;
+    struct pdc_request **                  requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6243,12 +6243,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char                  **all_names = my_obj_names;
-    char                   *local_names_1d, *all_names_1d = NULL;
-    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char **                 all_names = my_obj_names;
+    char *                  local_names_1d, *all_names_1d = NULL;
+    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6539,7 +6539,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        } // ndim=2
+        }     // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -6610,8 +6610,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info          *obj_prop;
-    struct _pdc_cont_info         *cont_prop;
+    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_cont_info *        cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -6718,8 +6718,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info      *obj_prop;
-    struct _pdc_cont_info     *cont_prop;
+    struct _pdc_obj_info *     obj_prop;
+    struct _pdc_cont_info *    cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -6779,12 +6779,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void               *buf = NULL;
+    void *              buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t           *ids_buf_sizes;
-    void              **ids_buf;
-    uint64_t           *u64_arr_ptr;
+    uint64_t *          ids_buf_sizes;
+    void **             ids_buf;
+    uint64_t *          u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -6837,14 +6837,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *bulk_arg;
+    struct bulk_args_t *          bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info         *hg_info            = NULL;
+    const struct hg_info *        hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7022,8 +7022,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info          *obj_prop;
-    struct _pdc_cont_info         *cont_prop;
+    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_cont_info *        cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7265,7 +7265,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info   *id_info = NULL;
+    struct _pdc_id_info *  id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7371,7 +7371,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info  *obj_prop;
+    struct _pdc_obj_info * obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -7504,7 +7504,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7532,10 +7532,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t                      *target_servers = NULL;
+    uint32_t *                     target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t              *query_xfer;
+    pdc_query_xfer_t *             query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -7623,12 +7623,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void                          *buf;
+    void *                         buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7709,7 +7709,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_obj_info *         obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7781,11 +7781,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void                          *buf;
+    void *                         buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7857,9 +7857,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time  = server_call_count_g[i] > 0
-                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                   : 0.0;
+        double avg_srv_time = server_call_count_g[i] > 0
+                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                  : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -7999,7 +7999,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *client_lookup_args;
+    struct bulk_args_t *          client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8008,8 +8008,8 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t   *bulk_args;
-    void                 *recv_meta;
+    struct bulk_args_t *  bulk_args;
+    void *                recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -8178,7 +8178,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
     struct bulk_args_t *lookup_args =
         (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t       ret_value            = 0;
-    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t *  dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
     int            num_requests         = 0;
     uint32_t       total_n_meta         = 0;
     dart_op_type_t op_type              = dart_in->op_type;
@@ -8242,9 +8242,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char          *k_query = get_key(query_string, '=');
-    char          *v_query = get_value(query_string, '=');
-    char          *tok     = NULL;
+    char *         k_query = get_key(query_string, '=');
+    char *         v_query = get_value(query_string, '=');
+    char *         tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -95,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int *             debug_server_id_count = NULL;
+static int              *debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -111,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t *  send_class_g       = NULL;
+static hg_class_t   *send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -126,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART *                 dart_g;
+static DART                  *dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -390,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char * p;
-    FILE * na_config = NULL;
+    char  *p;
+    FILE  *na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -474,7 +474,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int *               rpc_return;
+    int                *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -530,7 +530,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int *           rpc_return;
+    int            *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -558,7 +558,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int *              rpc_return;
+    int               *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -942,7 +942,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char *                         target_addr_string;
+    char                          *target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1217,14 +1217,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void *              buf = NULL;
-    void **             ids_buf;
+    void               *buf = NULL;
+    void              **ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t *          ids_buf_sizes;
+    uint64_t           *ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t *    meta_ptr;
-    uint64_t *          u64_arr_ptr;
+    pdc_metadata_t     *meta_ptr;
+    uint64_t           *u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1326,7 +1326,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char *      ret_value = NULL;
+    char       *ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1353,10 +1353,11 @@ drc_strerror(int errnum)
 perr_t
 PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int port)
 {
-    perr_t ret_value = SUCCEED;
-    char   na_info_string[NA_STRING_INFO_LEN];
-    char * hostname;
-    int    local_server_id;
+    perr_t  ret_value = SUCCEED;
+    char    na_info_string[NA_STRING_INFO_LEN];
+    char   *hostname;
+    pbool_t free_hostname = false;
+    int     local_server_id;
     /* Set the default mercury transport
      * but enable overriding that to any of:
      *   "ofi+gni"
@@ -1364,13 +1365,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char *              default_hg_transport = "ofi+tcp";
-    char *              hg_transport;
+    char               *default_hg_transport = "ofi+tcp";
+    char               *hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -1383,14 +1384,14 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
         hostname = PDC_malloc(HOSTNAME_LEN);
         memset(hostname, 0, HOSTNAME_LEN);
         gethostname(hostname, HOSTNAME_LEN - 1);
+        free_hostname = true;
     }
     sprintf(na_info_string, "%s://%s:%d", hg_transport, hostname, port);
-    if (pdc_client_mpi_rank_g == 0) {
-        LOG_INFO("==PDC_CLIENT: using %s\n", na_info_string);
-        fflush(stdout);
-    }
 
-    free(hostname);
+    if (pdc_client_mpi_rank_g == 0)
+        LOG_INFO("==PDC_CLIENT: using %s\n", na_info_string);
+    if (free_hostname)
+        hostname = (char *)PDC_free(hostname);
 
 // gni starts here
 #ifdef PDC_HAS_CRAY_DRC
@@ -1570,7 +1571,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char *   tmp_dir;
+    char    *tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1767,16 +1768,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
-    struct bulk_args_t *          bulk_args;
-    void *                        recv_meta;
+    const struct hg_info         *hg_info            = NULL;
+    struct bulk_args_t           *bulk_args;
+    void                         *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -2186,7 +2187,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2407,7 +2408,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop *         delete_prop;
+    struct _pdc_obj_prop          *delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2467,7 +2468,7 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t *                     metadata_query_handle;
+    hg_handle_t                      *metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
@@ -2774,7 +2775,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop *         create_prop = NULL;
+    struct _pdc_obj_prop          *create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2935,7 +2936,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
+    } // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2964,7 +2965,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    }     // End pdc_client_mpi_size_g < pdc_server_num_g
+    } // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3147,7 +3148,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t *                          hg_class;
+    hg_class_t                           *hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3273,7 +3274,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t *                                      hg_class;
+    hg_class_t                                       *hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3337,7 +3338,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t *                                     hg_class;
+    hg_class_t                                      *hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3402,7 +3403,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t *                               hg_class;
+    hg_class_t                                *hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3478,7 +3479,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t *                      hg_class;
+    hg_class_t                       *hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3714,12 +3715,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t * hg_class;
+    hg_class_t  *hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void **                  data_ptrs = NULL;
-    size_t *                 data_size = NULL;
+    void                   **data_ptrs = NULL;
+    size_t                  *data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -4103,11 +4104,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char *                  shm_base      = NULL; // base address, from mmap()
-    char *                  shm_addr      = NULL;
+    char                   *shm_base      = NULL; // base address, from mmap()
+    char                   *shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t *    read_info     = NULL;
-    struct pdc_request *    elt           = NULL;
+    client_read_info_t     *read_info     = NULL;
+    struct pdc_request     *elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4198,8 +4199,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char *                         shm_base; // base address, from mmap()
-    char *                         shm_addr;
+    char                          *shm_base; // base address, from mmap()
+    char                          *shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4334,8 +4335,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
 
     FUNC_ENTER(NULL);
 
@@ -4467,8 +4468,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -4569,9 +4570,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
-    void *                         buf;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
+    void                          *buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -4627,7 +4628,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-        // close and shm_unlink?
+    // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -4839,7 +4840,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t *      meta;
+    pdc_metadata_t       *meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5070,7 +5071,7 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5096,7 +5097,7 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5124,7 +5125,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info *  info;
+    struct _pdc_id_info   *info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5379,12 +5380,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes, total_size;
+    uint64_t                *buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request *                   request;
+    struct pdc_request                    *request;
 
     FUNC_ENTER(NULL);
 
@@ -5671,7 +5672,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            ret_value = NULL;
+    region_list_t             *ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5697,7 +5698,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            new_region;
+    region_list_t             *new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -5764,7 +5765,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                            HG_BULK_READ_ONLY, &bulk_handle);
+                               HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -5797,7 +5798,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void *                 buf = NULL;
+    void                  *buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -5909,8 +5910,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char *         fname, *prev_fname;
-    FILE *         fp_read = NULL;
+    char          *fname, *prev_fname;
+    FILE          *fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -6011,15 +6012,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes = NULL, total_size;
+    uint64_t                *buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char ***                 obj_names_by_server          = NULL;
-    char **                  obj_names_by_server_2d       = NULL;
+    char                  ***obj_names_by_server          = NULL;
+    char                   **obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request **                  requests, *request;
+    struct pdc_request                   **requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6242,12 +6243,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char **                 all_names = my_obj_names;
-    char *                  local_names_1d, *all_names_1d = NULL;
-    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char                  **all_names = my_obj_names;
+    char                   *local_names_1d, *all_names_1d = NULL;
+    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6538,7 +6539,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        }     // ndim=2
+        } // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -6609,8 +6610,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -6717,8 +6718,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info *     obj_prop;
-    struct _pdc_cont_info *    cont_prop;
+    struct _pdc_obj_info      *obj_prop;
+    struct _pdc_cont_info     *cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -6778,12 +6779,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void *              buf = NULL;
+    void               *buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t *          ids_buf_sizes;
-    void **             ids_buf;
-    uint64_t *          u64_arr_ptr;
+    uint64_t           *ids_buf_sizes;
+    void              **ids_buf;
+    uint64_t           *u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -6836,14 +6837,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          bulk_arg;
+    struct bulk_args_t           *bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
+    const struct hg_info         *hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7021,8 +7022,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7264,7 +7265,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info *  id_info = NULL;
+    struct _pdc_id_info   *id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7370,7 +7371,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info * obj_prop;
+    struct _pdc_obj_info  *obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -7503,7 +7504,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7531,10 +7532,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t *                     target_servers = NULL;
+    uint32_t                      *target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t *             query_xfer;
+    pdc_query_xfer_t              *query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -7622,12 +7623,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7708,7 +7709,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7780,11 +7781,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7856,9 +7857,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time = server_call_count_g[i] > 0
-                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                  : 0.0;
+        double avg_srv_time  = server_call_count_g[i] > 0
+                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                   : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -7998,7 +7999,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8007,8 +8008,8 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args;
-    void *                recv_meta;
+    struct bulk_args_t   *bulk_args;
+    void                 *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -8177,7 +8178,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
     struct bulk_args_t *lookup_args =
         (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t       ret_value            = 0;
-    hg_handle_t *  dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
     int            num_requests         = 0;
     uint32_t       total_n_meta         = 0;
     dart_op_type_t op_type              = dart_in->op_type;
@@ -8241,9 +8242,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char *         k_query = get_key(query_string, '=');
-    char *         v_query = get_value(query_string, '=');
-    char *         tok     = NULL;
+    char          *k_query = get_key(query_string, '=');
+    char          *v_query = get_value(query_string, '=');
+    char          *tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -95,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int              *debug_server_id_count = NULL;
+static int *             debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -111,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t   *send_class_g       = NULL;
+static hg_class_t *  send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -126,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART                  *dart_g;
+static DART *                 dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -390,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char  *p;
-    FILE  *na_config = NULL;
+    char * p;
+    FILE * na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -474,7 +474,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int                *rpc_return;
+    int *               rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -530,7 +530,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int            *rpc_return;
+    int *           rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -558,7 +558,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int               *rpc_return;
+    int *              rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -942,7 +942,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char                          *target_addr_string;
+    char *                         target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1217,14 +1217,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void               *buf = NULL;
-    void              **ids_buf;
+    void *              buf = NULL;
+    void **             ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t           *ids_buf_sizes;
+    uint64_t *          ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t     *meta_ptr;
-    uint64_t           *u64_arr_ptr;
+    pdc_metadata_t *    meta_ptr;
+    uint64_t *          u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1326,7 +1326,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char       *ret_value = NULL;
+    char *      ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1364,13 +1364,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char               *default_hg_transport = "ofi+tcp";
-    char               *hg_transport;
+    char *              default_hg_transport = "ofi+tcp";
+    char *              hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char             *auth_key;
+    char *            auth_key;
     int               rc;
 #endif
 
@@ -1566,7 +1566,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char    *tmp_dir;
+    char *   tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1763,16 +1763,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *client_lookup_args;
+    struct bulk_args_t *          client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info         *hg_info            = NULL;
-    struct bulk_args_t           *bulk_args;
-    void                         *recv_meta;
+    const struct hg_info *        hg_info            = NULL;
+    struct bulk_args_t *          bulk_args;
+    void *                        recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -2182,7 +2182,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_obj_info *         obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2403,7 +2403,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop          *delete_prop;
+    struct _pdc_obj_prop *         delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2463,7 +2463,7 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t                      *metadata_query_handle;
+    hg_handle_t *                     metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
@@ -2770,7 +2770,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop          *create_prop = NULL;
+    struct _pdc_obj_prop *         create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2931,7 +2931,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    } // End pdc_client_mpi_size_g >= pdc_server_num_g
+    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2960,7 +2960,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    } // End pdc_client_mpi_size_g < pdc_server_num_g
+    }     // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3143,7 +3143,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t                           *hg_class;
+    hg_class_t *                          hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3269,7 +3269,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t                                       *hg_class;
+    hg_class_t *                                      hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3333,7 +3333,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t                                      *hg_class;
+    hg_class_t *                                     hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3398,7 +3398,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t                                *hg_class;
+    hg_class_t *                               hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3474,7 +3474,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t                       *hg_class;
+    hg_class_t *                      hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3710,12 +3710,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t  *hg_class;
+    hg_class_t * hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void                   **data_ptrs = NULL;
-    size_t                  *data_size = NULL;
+    void **                  data_ptrs = NULL;
+    size_t *                 data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -4099,11 +4099,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char                   *shm_base      = NULL; // base address, from mmap()
-    char                   *shm_addr      = NULL;
+    char *                  shm_base      = NULL; // base address, from mmap()
+    char *                  shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t     *read_info     = NULL;
-    struct pdc_request     *elt           = NULL;
+    client_read_info_t *    read_info     = NULL;
+    struct pdc_request *    elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4194,8 +4194,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char                          *shm_base; // base address, from mmap()
-    char                          *shm_addr;
+    char *                         shm_base; // base address, from mmap()
+    char *                         shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4330,8 +4330,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
 
     FUNC_ENTER(NULL);
 
@@ -4463,8 +4463,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -4565,9 +4565,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
-    void                          *buf;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
+    void *                         buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -4623,7 +4623,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-    // close and shm_unlink?
+        // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -4835,7 +4835,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t       *meta;
+    pdc_metadata_t *      meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5066,7 +5066,7 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t            *obj_ids;
+    uint64_t *           obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5092,7 +5092,7 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t            *obj_ids;
+    uint64_t *           obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5120,7 +5120,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info   *info;
+    struct _pdc_id_info *  info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5375,12 +5375,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t                *buf_sizes, total_size;
+    uint64_t *               buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request                    *request;
+    struct pdc_request *                   request;
 
     FUNC_ENTER(NULL);
 
@@ -5667,7 +5667,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t             *ret_value = NULL;
+    region_list_t *            ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5693,7 +5693,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t             *new_region;
+    region_list_t *            new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -5760,7 +5760,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                               HG_BULK_READ_ONLY, &bulk_handle);
+                            HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -5793,7 +5793,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void                  *buf = NULL;
+    void *                 buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -5905,8 +5905,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char          *fname, *prev_fname;
-    FILE          *fp_read = NULL;
+    char *         fname, *prev_fname;
+    FILE *         fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -6007,15 +6007,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t                *buf_sizes = NULL, total_size;
+    uint64_t *               buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char                  ***obj_names_by_server          = NULL;
-    char                   **obj_names_by_server_2d       = NULL;
+    char ***                 obj_names_by_server          = NULL;
+    char **                  obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request                   **requests, *request;
+    struct pdc_request **                  requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6238,12 +6238,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char                  **all_names = my_obj_names;
-    char                   *local_names_1d, *all_names_1d = NULL;
-    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char **                 all_names = my_obj_names;
+    char *                  local_names_1d, *all_names_1d = NULL;
+    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6534,7 +6534,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        } // ndim=2
+        }     // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -6605,8 +6605,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info          *obj_prop;
-    struct _pdc_cont_info         *cont_prop;
+    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_cont_info *        cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -6713,8 +6713,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info      *obj_prop;
-    struct _pdc_cont_info     *cont_prop;
+    struct _pdc_obj_info *     obj_prop;
+    struct _pdc_cont_info *    cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -6774,12 +6774,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void               *buf = NULL;
+    void *              buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t           *ids_buf_sizes;
-    void              **ids_buf;
-    uint64_t           *u64_arr_ptr;
+    uint64_t *          ids_buf_sizes;
+    void **             ids_buf;
+    uint64_t *          u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -6832,14 +6832,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *bulk_arg;
+    struct bulk_args_t *          bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info         *hg_info            = NULL;
+    const struct hg_info *        hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7017,8 +7017,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info          *obj_prop;
-    struct _pdc_cont_info         *cont_prop;
+    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_cont_info *        cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7260,7 +7260,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info   *id_info = NULL;
+    struct _pdc_id_info *  id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7366,7 +7366,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info  *obj_prop;
+    struct _pdc_obj_info * obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -7499,7 +7499,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7527,10 +7527,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t                      *target_servers = NULL;
+    uint32_t *                     target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t              *query_xfer;
+    pdc_query_xfer_t *             query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -7618,12 +7618,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void                          *buf;
+    void *                         buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7704,7 +7704,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_obj_info *         obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7777,11 +7777,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void                          *buf;
+    void *                         buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7853,9 +7853,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time  = server_call_count_g[i] > 0
-                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                   : 0.0;
+        double avg_srv_time = server_call_count_g[i] > 0
+                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                  : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -7995,7 +7995,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *client_lookup_args;
+    struct bulk_args_t *          client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8004,8 +8004,8 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t   *bulk_args;
-    void                 *recv_meta;
+    struct bulk_args_t *  bulk_args;
+    void *                recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -8174,7 +8174,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
     struct bulk_args_t *lookup_args =
         (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t       ret_value            = 0;
-    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t *  dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
     int            num_requests         = 0;
     uint32_t       total_n_meta         = 0;
     dart_op_type_t op_type              = dart_in->op_type;
@@ -8238,9 +8238,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char          *k_query = get_key(query_string, '=');
-    char          *v_query = get_value(query_string, '=');
-    char          *tok     = NULL;
+    char *         k_query = get_key(query_string, '=');
+    char *         v_query = get_value(query_string, '=');
+    char *         tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -95,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int *             debug_server_id_count = NULL;
+static int              *debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -111,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t *  send_class_g       = NULL;
+static hg_class_t   *send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -126,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART *                 dart_g;
+static DART                  *dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -390,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char * p;
-    FILE * na_config = NULL;
+    char  *p;
+    FILE  *na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -474,7 +474,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int *               rpc_return;
+    int                *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -530,7 +530,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int *           rpc_return;
+    int            *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -558,7 +558,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int *              rpc_return;
+    int               *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -942,7 +942,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char *                         target_addr_string;
+    char                          *target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1217,14 +1217,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void *              buf = NULL;
-    void **             ids_buf;
+    void               *buf = NULL;
+    void              **ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t *          ids_buf_sizes;
+    uint64_t           *ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t *    meta_ptr;
-    uint64_t *          u64_arr_ptr;
+    pdc_metadata_t     *meta_ptr;
+    uint64_t           *u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1326,7 +1326,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char *      ret_value = NULL;
+    char       *ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1364,13 +1364,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char *              default_hg_transport = "ofi+tcp";
-    char *              hg_transport;
+    char               *default_hg_transport = "ofi+tcp";
+    char               *hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -1566,7 +1566,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char *   tmp_dir;
+    char    *tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1763,16 +1763,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
-    struct bulk_args_t *          bulk_args;
-    void *                        recv_meta;
+    const struct hg_info         *hg_info            = NULL;
+    struct bulk_args_t           *bulk_args;
+    void                         *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -2182,7 +2182,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2403,7 +2403,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop *         delete_prop;
+    struct _pdc_obj_prop          *delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2463,7 +2463,7 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t *                     metadata_query_handle;
+    hg_handle_t                      *metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
@@ -2770,7 +2770,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop *         create_prop = NULL;
+    struct _pdc_obj_prop          *create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2931,7 +2931,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
+    } // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2960,7 +2960,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    }     // End pdc_client_mpi_size_g < pdc_server_num_g
+    } // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3143,7 +3143,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t *                          hg_class;
+    hg_class_t                           *hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3269,7 +3269,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t *                                      hg_class;
+    hg_class_t                                       *hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3333,7 +3333,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t *                                     hg_class;
+    hg_class_t                                      *hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3398,7 +3398,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t *                               hg_class;
+    hg_class_t                                *hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3474,7 +3474,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t *                      hg_class;
+    hg_class_t                       *hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3710,12 +3710,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t * hg_class;
+    hg_class_t  *hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void **                  data_ptrs = NULL;
-    size_t *                 data_size = NULL;
+    void                   **data_ptrs = NULL;
+    size_t                  *data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -4099,11 +4099,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char *                  shm_base      = NULL; // base address, from mmap()
-    char *                  shm_addr      = NULL;
+    char                   *shm_base      = NULL; // base address, from mmap()
+    char                   *shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t *    read_info     = NULL;
-    struct pdc_request *    elt           = NULL;
+    client_read_info_t     *read_info     = NULL;
+    struct pdc_request     *elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4194,8 +4194,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char *                         shm_base; // base address, from mmap()
-    char *                         shm_addr;
+    char                          *shm_base; // base address, from mmap()
+    char                          *shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4330,8 +4330,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
 
     FUNC_ENTER(NULL);
 
@@ -4463,8 +4463,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -4565,9 +4565,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
-    void *                         buf;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
+    void                          *buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -4623,7 +4623,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-        // close and shm_unlink?
+    // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -4835,7 +4835,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t *      meta;
+    pdc_metadata_t       *meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5066,7 +5066,7 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5092,7 +5092,7 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5120,7 +5120,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info *  info;
+    struct _pdc_id_info   *info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5375,12 +5375,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes, total_size;
+    uint64_t                *buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request *                   request;
+    struct pdc_request                    *request;
 
     FUNC_ENTER(NULL);
 
@@ -5667,7 +5667,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            ret_value = NULL;
+    region_list_t             *ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5693,7 +5693,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            new_region;
+    region_list_t             *new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -5760,7 +5760,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                            HG_BULK_READ_ONLY, &bulk_handle);
+                               HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -5793,7 +5793,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void *                 buf = NULL;
+    void                  *buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -5905,8 +5905,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char *         fname, *prev_fname;
-    FILE *         fp_read = NULL;
+    char          *fname, *prev_fname;
+    FILE          *fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -5939,7 +5939,7 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
             cache_region = PDC_get_storage_meta_from_io_list(&client_cache_list_head_g, all_storage_meta[i]);
             if (cache_region != NULL) {
                 buf_size      = all_storage_meta[i]->size;
-                (*buf_arr)[i] = malloc(buf_size);
+                (*buf_arr)[i] = PDC_malloc(buf_size);
                 memcpy((*buf_arr)[i], cache_region->buf, buf_size);
                 cache_count_g++;
                 continue;
@@ -5973,7 +5973,7 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
         buf_size      = all_storage_meta[i]->size;
 
         // malloc the buf array, this array should be freed by user afterwards.
-        (*buf_arr)[i] = malloc(buf_size);
+        (*buf_arr)[i] = PDC_malloc(buf_size);
         PDC_Client_read_overlap_regions(ndim, &req_start, &req_count, &storage_start, &storage_count, fp_read,
                                         file_offset, (*buf_arr)[i], &read_bytes);
         size_arr[i] = read_bytes;
@@ -6007,15 +6007,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes = NULL, total_size;
+    uint64_t                *buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char ***                 obj_names_by_server          = NULL;
-    char **                  obj_names_by_server_2d       = NULL;
+    char                  ***obj_names_by_server          = NULL;
+    char                   **obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request **                  requests, *request;
+    struct pdc_request                   **requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6238,12 +6238,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char **                 all_names = my_obj_names;
-    char *                  local_names_1d, *all_names_1d = NULL;
-    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char                  **all_names = my_obj_names;
+    char                   *local_names_1d, *all_names_1d = NULL;
+    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6534,7 +6534,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        }     // ndim=2
+        } // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -6605,8 +6605,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -6689,7 +6689,7 @@ metadata_get_kvtag_rpc_cb(const struct hg_cb_info *callback_info)
     client_lookup_args->kvtag->size = output.kvtag.size;
     client_lookup_args->kvtag->type = output.kvtag.type;
     if (output.kvtag.size > 0) {
-        client_lookup_args->kvtag->value = malloc(output.kvtag.size);
+        client_lookup_args->kvtag->value = PDC_malloc(output.kvtag.size);
         memcpy(client_lookup_args->kvtag->value, output.kvtag.value, output.kvtag.size);
     }
     else
@@ -6713,8 +6713,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info *     obj_prop;
-    struct _pdc_cont_info *    cont_prop;
+    struct _pdc_obj_info      *obj_prop;
+    struct _pdc_cont_info     *cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -6774,12 +6774,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void *              buf = NULL;
+    void               *buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t *          ids_buf_sizes;
-    void **             ids_buf;
-    uint64_t *          u64_arr_ptr;
+    uint64_t           *ids_buf_sizes;
+    void              **ids_buf;
+    uint64_t           *u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -6832,14 +6832,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          bulk_arg;
+    struct bulk_args_t           *bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
+    const struct hg_info         *hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7017,8 +7017,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7260,7 +7260,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info *  id_info = NULL;
+    struct _pdc_id_info   *id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7366,7 +7366,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info * obj_prop;
+    struct _pdc_obj_info  *obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -7499,7 +7499,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7527,10 +7527,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t *                     target_servers = NULL;
+    uint32_t                      *target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t *             query_xfer;
+    pdc_query_xfer_t              *query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -7618,12 +7618,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7704,7 +7704,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7777,11 +7777,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7810,7 +7810,7 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
                     result_elt->data_arr_size = PDC_calloc(sizeof(uint64_t *), pdc_server_num_g);
                 }
 
-                result_elt->data_arr[seq_id] = malloc(bulk_args->nbytes);
+                result_elt->data_arr[seq_id] = PDC_malloc(bulk_args->nbytes);
                 memcpy(result_elt->data_arr[seq_id], buf, bulk_args->nbytes);
                 result_elt->data_arr_size[seq_id] = bulk_args->nbytes;
                 result_elt->recv_data_nhits += nhits;
@@ -7853,9 +7853,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time = server_call_count_g[i] > 0
-                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                  : 0.0;
+        double avg_srv_time  = server_call_count_g[i] > 0
+                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                   : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -7995,7 +7995,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8004,8 +8004,8 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args;
-    void *                recv_meta;
+    struct bulk_args_t   *bulk_args;
+    void                 *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -8174,7 +8174,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
     struct bulk_args_t *lookup_args =
         (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t       ret_value            = 0;
-    hg_handle_t *  dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
     int            num_requests         = 0;
     uint32_t       total_n_meta         = 0;
     dart_op_type_t op_type              = dart_in->op_type;
@@ -8238,9 +8238,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char *         k_query = get_key(query_string, '=');
-    char *         v_query = get_value(query_string, '=');
-    char *         tok     = NULL;
+    char          *k_query = get_key(query_string, '=');
+    char          *v_query = get_value(query_string, '=');
+    char          *tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -95,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int              *debug_server_id_count = NULL;
+static int *             debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -111,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t   *send_class_g       = NULL;
+static hg_class_t *  send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -126,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART                  *dart_g;
+static DART *                 dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -390,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char  *p;
-    FILE  *na_config = NULL;
+    char * p;
+    FILE * na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -474,7 +474,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int                *rpc_return;
+    int *               rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -530,7 +530,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int            *rpc_return;
+    int *           rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -558,7 +558,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int               *rpc_return;
+    int *              rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -942,7 +942,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char                          *target_addr_string;
+    char *                         target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1217,14 +1217,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void               *buf = NULL;
-    void              **ids_buf;
+    void *              buf = NULL;
+    void **             ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t           *ids_buf_sizes;
+    uint64_t *          ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t     *meta_ptr;
-    uint64_t           *u64_arr_ptr;
+    pdc_metadata_t *    meta_ptr;
+    uint64_t *          u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1326,7 +1326,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char       *ret_value = NULL;
+    char *      ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1364,13 +1364,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char               *default_hg_transport = "ofi+tcp";
-    char               *hg_transport;
+    char *              default_hg_transport = "ofi+tcp";
+    char *              hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char             *auth_key;
+    char *            auth_key;
     int               rc;
 #endif
 
@@ -1565,7 +1565,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char    *tmp_dir;
+    char *   tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1762,16 +1762,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *client_lookup_args;
+    struct bulk_args_t *          client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info         *hg_info            = NULL;
-    struct bulk_args_t           *bulk_args;
-    void                         *recv_meta;
+    const struct hg_info *        hg_info            = NULL;
+    struct bulk_args_t *          bulk_args;
+    void *                        recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -2181,7 +2181,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_obj_info *         obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2402,7 +2402,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop          *delete_prop;
+    struct _pdc_obj_prop *         delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2462,7 +2462,7 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t                      *metadata_query_handle;
+    hg_handle_t *                     metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
@@ -2769,7 +2769,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop          *create_prop = NULL;
+    struct _pdc_obj_prop *         create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2930,7 +2930,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    } // End pdc_client_mpi_size_g >= pdc_server_num_g
+    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2959,7 +2959,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    } // End pdc_client_mpi_size_g < pdc_server_num_g
+    }     // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3142,7 +3142,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t                           *hg_class;
+    hg_class_t *                          hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3268,7 +3268,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t                                       *hg_class;
+    hg_class_t *                                      hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3332,7 +3332,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t                                      *hg_class;
+    hg_class_t *                                     hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3397,7 +3397,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t                                *hg_class;
+    hg_class_t *                               hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3473,7 +3473,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t                       *hg_class;
+    hg_class_t *                      hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3709,12 +3709,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t  *hg_class;
+    hg_class_t * hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void                   **data_ptrs = NULL;
-    size_t                  *data_size = NULL;
+    void **                  data_ptrs = NULL;
+    size_t *                 data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -4098,11 +4098,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char                   *shm_base      = NULL; // base address, from mmap()
-    char                   *shm_addr      = NULL;
+    char *                  shm_base      = NULL; // base address, from mmap()
+    char *                  shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t     *read_info     = NULL;
-    struct pdc_request     *elt           = NULL;
+    client_read_info_t *    read_info     = NULL;
+    struct pdc_request *    elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4193,8 +4193,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char                          *shm_base; // base address, from mmap()
-    char                          *shm_addr;
+    char *                         shm_base; // base address, from mmap()
+    char *                         shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4329,8 +4329,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
 
     FUNC_ENTER(NULL);
 
@@ -4462,8 +4462,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -4564,9 +4564,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t                *meta;
-    struct pdc_region_info        *region;
-    void                          *buf;
+    pdc_metadata_t *               meta;
+    struct pdc_region_info *       region;
+    void *                         buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -4622,7 +4622,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-    // close and shm_unlink?
+        // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -4834,7 +4834,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t       *meta;
+    pdc_metadata_t *      meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5065,7 +5065,7 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t            *obj_ids;
+    uint64_t *           obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5091,7 +5091,7 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t            *obj_ids;
+    uint64_t *           obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
@@ -5119,7 +5119,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info   *info;
+    struct _pdc_id_info *  info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5374,12 +5374,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t                *buf_sizes, total_size;
+    uint64_t *               buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request                    *request;
+    struct pdc_request *                   request;
 
     FUNC_ENTER(NULL);
 
@@ -5666,7 +5666,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t             *ret_value = NULL;
+    region_list_t *            ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5692,7 +5692,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t             *new_region;
+    region_list_t *            new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -5759,7 +5759,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                               HG_BULK_READ_ONLY, &bulk_handle);
+                            HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -5792,7 +5792,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void                  *buf = NULL;
+    void *                 buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -5904,8 +5904,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char          *fname, *prev_fname;
-    FILE          *fp_read = NULL;
+    char *         fname, *prev_fname;
+    FILE *         fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -6006,15 +6006,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t                *buf_sizes = NULL, total_size;
+    uint64_t *               buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char                  ***obj_names_by_server          = NULL;
-    char                   **obj_names_by_server_2d       = NULL;
+    char ***                 obj_names_by_server          = NULL;
+    char **                  obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request                   **requests, *request;
+    struct pdc_request **                  requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6237,12 +6237,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char                  **all_names = my_obj_names;
-    char                   *local_names_1d, *all_names_1d = NULL;
-    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char **                 all_names = my_obj_names;
+    char *                  local_names_1d, *all_names_1d = NULL;
+    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6533,7 +6533,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        } // ndim=2
+        }     // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -6604,8 +6604,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info          *obj_prop;
-    struct _pdc_cont_info         *cont_prop;
+    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_cont_info *        cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -6712,8 +6712,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info      *obj_prop;
-    struct _pdc_cont_info     *cont_prop;
+    struct _pdc_obj_info *     obj_prop;
+    struct _pdc_cont_info *    cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -6773,12 +6773,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void               *buf = NULL;
+    void *              buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t           *ids_buf_sizes;
-    void              **ids_buf;
-    uint64_t           *u64_arr_ptr;
+    uint64_t *          ids_buf_sizes;
+    void **             ids_buf;
+    uint64_t *          u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -6831,14 +6831,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *bulk_arg;
+    struct bulk_args_t *          bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info         *hg_info            = NULL;
+    const struct hg_info *        hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7016,8 +7016,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info          *obj_prop;
-    struct _pdc_cont_info         *cont_prop;
+    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_cont_info *        cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7259,7 +7259,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info   *id_info = NULL;
+    struct _pdc_id_info *  id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7365,7 +7365,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info  *obj_prop;
+    struct _pdc_obj_info * obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -7498,7 +7498,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7526,10 +7526,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t                      *target_servers = NULL;
+    uint32_t *                     target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t              *query_xfer;
+    pdc_query_xfer_t *             query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -7617,12 +7617,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void                          *buf;
+    void *                         buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7703,7 +7703,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_obj_info *         obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -7775,11 +7775,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void                          *buf;
+    void *                         buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -7851,9 +7851,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time  = server_call_count_g[i] > 0
-                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                   : 0.0;
+        double avg_srv_time = server_call_count_g[i] > 0
+                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                  : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -7993,7 +7993,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t           *client_lookup_args;
+    struct bulk_args_t *          client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8002,8 +8002,8 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t   *bulk_args;
-    void                 *recv_meta;
+    struct bulk_args_t *  bulk_args;
+    void *                recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -8172,7 +8172,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
     struct bulk_args_t *lookup_args =
         (struct bulk_args_t *)PDC_calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t       ret_value            = 0;
-    hg_handle_t   *dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t *  dart_request_handles = (hg_handle_t *)PDC_calloc(num_servers, sizeof(hg_handle_t));
     int            num_requests         = 0;
     uint32_t       total_n_meta         = 0;
     dart_op_type_t op_type              = dart_in->op_type;
@@ -8236,9 +8236,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char          *k_query = get_key(query_string, '=');
-    char          *v_query = get_value(query_string, '=');
-    char          *tok     = NULL;
+    char *         k_query = get_key(query_string, '=');
+    char *         v_query = get_value(query_string, '=');
+    char *         tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -43,6 +43,7 @@
 #include "pdc_transforms_common.h"
 #include "pdc_client_connect.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 #include "mercury.h"
 #include "mercury_macros.h"
@@ -94,7 +95,7 @@ int pdc_nclient_per_server_g = 0;
 
 char                     pdc_client_tmp_dir_g[ADDR_MAX];
 struct _pdc_server_info *pdc_server_info_g     = NULL;
-static int *             debug_server_id_count = NULL;
+static int              *debug_server_id_count = NULL;
 
 int                 pdc_io_request_seq_id = PDC_SEQ_ID_INIT_VALUE;
 struct pdc_request *pdc_io_request_list_g = NULL;
@@ -110,7 +111,7 @@ int    nread_bb_g     = 0;
 double read_bb_size_g = 0.0;
 
 static int           mercury_has_init_g = 0;
-static hg_class_t *  send_class_g       = NULL;
+static hg_class_t   *send_class_g       = NULL;
 static hg_context_t *send_context_g     = NULL;
 int                  query_id_g         = 0;
 
@@ -125,7 +126,7 @@ static hg_atomic_int32_t response_done_g;
 hg_atomic_int32_t        bulk_transfer_done_g;
 
 // global variables for DART
-static DART *                 dart_g;
+static DART                  *dart_g;
 static dart_hash_algo_t       dart_hash_algo_g    = DART_HASH;
 static dart_object_ref_type_t dart_obj_ref_type_g = REF_PRIMARY_ID;
 
@@ -389,8 +390,8 @@ PDC_Client_read_server_addr_from_file()
     perr_t ret_value = SUCCEED;
     int    max_tries = 9, sleeptime = 1;
     int    i = 0, is_server_ready = 0;
-    char * p;
-    FILE * na_config = NULL;
+    char  *p;
+    FILE  *na_config = NULL;
     char   config_fname[PATH_MAX];
     char   n_server_string[PATH_MAX];
 
@@ -472,7 +473,7 @@ client_send_flush_obj_all_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t         ret_value = HG_SUCCESS;
     hg_handle_t         handle;
     flush_obj_all_out_t output;
-    int *               rpc_return;
+    int                *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -528,7 +529,7 @@ client_send_flush_obj_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t     ret_value = HG_SUCCESS;
     hg_handle_t     handle;
     flush_obj_out_t output;
-    int *           rpc_return;
+    int            *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -556,7 +557,7 @@ client_send_close_all_server_rpc_cb(const struct hg_cb_info *callback_info)
     hg_return_t        ret_value = HG_SUCCESS;
     hg_handle_t        handle;
     close_server_out_t output;
-    int *              rpc_return;
+    int               *rpc_return;
 
     FUNC_ENTER(NULL);
 
@@ -940,7 +941,7 @@ PDC_Client_lookup_server(int server_id, int is_init)
     hg_return_t                    hg_ret;
     struct _pdc_client_lookup_args lookup_args;
     char                           self_addr[ADDR_MAX];
-    char *                         target_addr_string;
+    char                          *target_addr_string;
 
     FUNC_ENTER(NULL);
 
@@ -1215,14 +1216,14 @@ hg_test_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args;
     hg_bulk_t           local_bulk_handle;
     uint32_t            i;
-    void *              buf = NULL;
-    void **             ids_buf;
+    void               *buf = NULL;
+    void              **ids_buf;
     uint32_t            n_meta;
     uint64_t            buf_sizes[2] = {0, 0};
-    uint64_t *          ids_buf_sizes;
+    uint64_t           *ids_buf_sizes;
     uint32_t            actual_cnt;
-    pdc_metadata_t *    meta_ptr;
-    uint64_t *          u64_arr_ptr;
+    pdc_metadata_t     *meta_ptr;
+    uint64_t           *u64_arr_ptr;
     uint32_t            bulk_sgnum;
 
     FUNC_ENTER(NULL);
@@ -1277,7 +1278,6 @@ done:
     hg_atomic_cas32(&(bulk_args->bulk_done_flag), 0, 1);
 
     fflush(stdout);
-    // free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -1325,7 +1325,7 @@ PDC_Client_check_bulk(hg_context_t *hg_context)
 static const char *
 drc_strerror(int errnum)
 {
-    char *      ret_value = NULL;
+    char       *ret_value = NULL;
     const char *errstring = "UNDEFINED";
 
     FUNC_ENTER(NULL);
@@ -1363,13 +1363,13 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
      *   "cci+tcp"
      */
     struct hg_init_info init_info            = {0};
-    char *              default_hg_transport = "ofi+tcp";
-    char *              hg_transport;
+    char               *default_hg_transport = "ofi+tcp";
+    char               *hg_transport;
 #ifdef PDC_HAS_CRAY_DRC
     uint32_t          credential, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -1380,6 +1380,7 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
     }
     memset(hostname, 0, sizeof(hostname));
     gethostname(hostname, sizeof(hostname));
+    strcpy(hostname, "eno1");
     sprintf(na_info_string, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_client_mpi_rank_g == 0) {
         LOG_INFO("==PDC_CLIENT: using %.7s\n", na_info_string);
@@ -1564,7 +1565,7 @@ PDC_Client_init()
 {
     perr_t ret_value  = SUCCEED;
     pdc_server_info_g = NULL;
-    char *   tmp_dir;
+    char    *tmp_dir;
     uint32_t port;
     int      is_mpi_init = 0;
 
@@ -1637,7 +1638,7 @@ PDC_Client_init()
 
     // Init debug info
     if (pdc_server_num_g > 0) {
-        debug_server_id_count = (int *)malloc(sizeof(int) * pdc_server_num_g);
+        debug_server_id_count = (int *)PDC_malloc(sizeof(int) * pdc_server_num_g);
         memset(debug_server_id_count, 0, sizeof(int) * pdc_server_num_g);
     }
     else
@@ -1725,7 +1726,7 @@ PDC_Client_finalize()
     }
 
     if (pdc_server_info_g != NULL)
-        free(pdc_server_info_g);
+        pdc_server_info_g = (struct _pdc_server_info *)PDC_free(pdc_server_info_g);
 
     // Terminate thread
     if (hg_progress_flag_g == 0) {
@@ -1741,7 +1742,7 @@ PDC_Client_finalize()
 #endif
     // free debug info
     if (debug_server_id_count != NULL)
-        free(debug_server_id_count);
+        debug_server_id_count = (int *)PDC_free(debug_server_id_count);
 
 #ifdef ENABLE_TIMING
     if (pdc_client_mpi_rank_g == 0)
@@ -1766,16 +1767,16 @@ static hg_return_t
 metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
-    struct bulk_args_t *          bulk_args;
-    void *                        recv_meta;
+    const struct hg_info         *hg_info            = NULL;
+    struct bulk_args_t           *bulk_args;
+    void                         *recv_meta;
 
     FUNC_ENTER(NULL);
 
@@ -1801,7 +1802,7 @@ metadata_query_bulk_cb(const struct hg_cb_info *callback_info)
     origin_bulk_handle = output.bulk_handle;
     hg_info            = HG_Get_info(handle);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     bulk_args->handle = handle;
     bulk_args->nbytes = HG_Bulk_get_size(origin_bulk_handle);
@@ -1936,7 +1937,7 @@ PDC_partial_query(int is_list_all, int user_id, const char *app_name, const char
 
         if (*out == NULL) {
             out_size = sizeof(pdc_metadata_t *) * (lookup_args.n_meta);
-            *out     = (pdc_metadata_t **)malloc(out_size);
+            *out     = (pdc_metadata_t **)PDC_malloc(out_size);
         }
         else {
             out_size += sizeof(pdc_metadata_t *) * (lookup_args.n_meta);
@@ -2020,7 +2021,7 @@ PDC_Client_query_tag(const char *tags, int *n_res, pdc_metadata_t ***out)
 
         if (*out == NULL) {
             out_size = sizeof(pdc_metadata_t *) * ((lookup_args.n_meta));
-            *out     = (pdc_metadata_t **)malloc(out_size);
+            *out     = (pdc_metadata_t **)PDC_malloc(out_size);
         }
         else {
             out_size += sizeof(pdc_metadata_t *) * ((lookup_args.n_meta));
@@ -2066,7 +2067,7 @@ metadata_query_rpc_cb(const struct hg_cb_info *callback_info)
         client_lookup_args->data = NULL;
     }
     else {
-        client_lookup_args->data = (pdc_metadata_t *)malloc(sizeof(pdc_metadata_t));
+        client_lookup_args->data = (pdc_metadata_t *)PDC_malloc(sizeof(pdc_metadata_t));
         if (client_lookup_args->data == NULL)
             PGOTO_ERROR(HG_OTHER_ERROR,
                         "==PDC_CLIENT[%d]: - cannnot allocate space for client_lookup_args->data",
@@ -2185,7 +2186,7 @@ PDC_Client_add_tag(pdcid_t obj_id, const char *tag)
     hg_handle_t                    metadata_add_tag_handle;
     uint64_t                       meta_id;
     uint32_t                       server_id;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_client_lookup_args lookup_args;
     metadata_add_tag_in_t          in;
 
@@ -2406,7 +2407,7 @@ PDC_Client_delete_metadata(char *delete_name, pdcid_t obj_delete_prop)
 {
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret    = 0;
-    struct _pdc_obj_prop *         delete_prop;
+    struct _pdc_obj_prop          *delete_prop;
     metadata_delete_in_t           in;
     int                            hash_name_value;
     uint32_t                       server_id;
@@ -2466,23 +2467,23 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
     struct _pdc_metadata_query_args **lookup_args;
     uint32_t                          server_id;
     uint32_t                          i, count = 0;
-    hg_handle_t *                     metadata_query_handle;
+    hg_handle_t                      *metadata_query_handle;
 
     FUNC_ENTER(NULL);
 
-    metadata_query_handle = (hg_handle_t *)malloc(sizeof(hg_handle_t) * pdc_server_num_g);
+    metadata_query_handle = (hg_handle_t *)PDC_malloc(sizeof(hg_handle_t) * pdc_server_num_g);
 
     // Fill input structure
     in.obj_name   = obj_name;
     in.time_step  = 0;
     in.hash_value = PDC_get_hash_by_name(obj_name);
 
-    lookup_args = (struct _pdc_metadata_query_args **)malloc(sizeof(struct _pdc_metadata_query_args *) *
-                                                             pdc_server_num_g);
+    lookup_args = (struct _pdc_metadata_query_args **)PDC_malloc(sizeof(struct _pdc_metadata_query_args *) *
+                                                                 pdc_server_num_g);
 
     for (server_id = 0; server_id < (uint32_t)pdc_server_num_g; server_id++) {
         lookup_args[server_id] =
-            (struct _pdc_metadata_query_args *)malloc(sizeof(struct _pdc_metadata_query_args));
+            (struct _pdc_metadata_query_args *)PDC_malloc(sizeof(struct _pdc_metadata_query_args));
 
         // Debug statistics for counting number of messages sent to each server.
         debug_server_id_count[server_id]++;
@@ -2508,14 +2509,13 @@ PDC_Client_query_metadata_name_only(const char *obj_name, pdc_metadata_t **out)
             *out = lookup_args[i]->data;
             count++;
         }
-
         // TODO lookup_args[i] are not freed
         HG_Destroy(metadata_query_handle[i]);
     }
 
 done:
     fflush(stdout);
-    free(metadata_query_handle);
+    metadata_query_handle = (hg_handle_t *)PDC_free(metadata_query_handle);
 
     FUNC_LEAVE(ret_value);
 }
@@ -2555,7 +2555,7 @@ PDC_Client_query_metadata_name_timestep(const char *obj_name, int time_step, pdc
     in.hash_value = PDC_get_hash_by_name(obj_name);
     in.time_step  = time_step;
 
-    lookup_args.data = (pdc_metadata_t *)malloc(sizeof(pdc_metadata_t));
+    lookup_args.data = (pdc_metadata_t *)PDC_malloc(sizeof(pdc_metadata_t));
     if (lookup_args.data == NULL)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: ERROR - PDC_Client_query_metadata_with_name() "
                           "cannnot allocate space for client_lookup_args->data");
@@ -2774,7 +2774,7 @@ PDC_Client_send_name_recv_id(const char *obj_name, uint64_t cont_id, pdcid_t obj
     perr_t                         ret_value = SUCCEED;
     hg_return_t                    hg_ret;
     uint32_t                       server_id   = 0;
-    struct _pdc_obj_prop *         create_prop = NULL;
+    struct _pdc_obj_prop          *create_prop = NULL;
     gen_obj_id_in_t                in;
     uint32_t                       hash_name_value;
     struct _pdc_client_lookup_args lookup_args;
@@ -2935,7 +2935,7 @@ PDC_Client_close_all_server()
             if (hg_ret != HG_SUCCESS)
                 PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
         } // End pdc_client_mpi_rank_g < pdc_server_num_g
-    }     // End pdc_client_mpi_size_g >= pdc_server_num_g
+    } // End pdc_client_mpi_size_g >= pdc_server_num_g
     else {
         if (pdc_client_mpi_rank_g == 0) {
             for (i = 0; i < (uint32_t)pdc_server_num_g; i++) {
@@ -2964,7 +2964,7 @@ PDC_Client_close_all_server()
                     PGOTO_ERROR(FAIL, "PDC_Client_close_all_server(): Could not destroy handle");
             }
         } // End of mpi_rank == 0
-    }     // End pdc_client_mpi_size_g < pdc_server_num_g
+    } // End pdc_client_mpi_size_g < pdc_server_num_g
 
 #ifdef ENABLE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -3147,7 +3147,7 @@ PDC_Client_transfer_request_all(int n_objs, pdc_access_t access_type, uint32_t d
     perr_t                                ret_value = SUCCEED;
     hg_return_t                           hg_ret    = HG_SUCCESS;
     transfer_request_all_in_t             in;
-    hg_class_t *                          hg_class;
+    hg_class_t                           *hg_class;
     int                                   i;
     hg_handle_t                           client_send_transfer_request_all_handle;
     struct _pdc_transfer_request_all_args transfer_args;
@@ -3273,7 +3273,7 @@ PDC_Client_transfer_request_metadata_query2(char *buf, uint64_t total_buf_size, 
     perr_t                                            ret_value = SUCCEED;
     hg_return_t                                       hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query2_in_t             in;
-    hg_class_t *                                      hg_class;
+    hg_class_t                                       *hg_class;
     hg_handle_t                                       client_send_transfer_request_metadata_query2_handle;
     struct _pdc_transfer_request_metadata_query2_args transfer_args;
 
@@ -3337,7 +3337,7 @@ PDC_Client_transfer_request_metadata_query(char *buf, uint64_t total_buf_size, i
     perr_t                                           ret_value = SUCCEED;
     hg_return_t                                      hg_ret    = HG_SUCCESS;
     transfer_request_metadata_query_in_t             in;
-    hg_class_t *                                     hg_class;
+    hg_class_t                                      *hg_class;
     hg_handle_t                                      client_send_transfer_request_metadata_query_handle;
     struct _pdc_transfer_request_metadata_query_args transfer_args;
 
@@ -3402,7 +3402,7 @@ PDC_Client_transfer_request_wait_all(int n_objs, pdcid_t *transfer_request_id, u
     perr_t                                     ret_value = SUCCEED;
     hg_return_t                                hg_ret    = HG_SUCCESS;
     transfer_request_wait_all_in_t             in;
-    hg_class_t *                               hg_class;
+    hg_class_t                                *hg_class;
     hg_handle_t                                client_send_transfer_request_wait_all_handle;
     struct _pdc_transfer_request_wait_all_args transfer_args;
     char                                       cur_time[64];
@@ -3478,7 +3478,7 @@ PDC_Client_transfer_request(void *buf, pdcid_t obj_id, uint32_t data_server_id, 
     perr_t                            ret_value = SUCCEED;
     hg_return_t                       hg_ret    = HG_SUCCESS;
     transfer_request_in_t             in;
-    hg_class_t *                      hg_class;
+    hg_class_t                       *hg_class;
     uint32_t                          meta_server_id;
     hg_size_t                         total_data_size;
     int                               i;
@@ -3714,12 +3714,12 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     hg_return_t  hg_ret    = HG_SUCCESS;
     buf_map_in_t in;
     uint32_t     data_server_id, meta_server_id;
-    hg_class_t * hg_class;
+    hg_class_t  *hg_class;
 
     hg_uint32_t              i, j;
     hg_uint32_t              local_count;
-    void **                  data_ptrs = NULL;
-    size_t *                 data_size = NULL;
+    void                   **data_ptrs = NULL;
+    size_t                  *data_size = NULL;
     size_t                   unit, unit_to;
     struct _pdc_buf_map_args map_args;
     hg_handle_t              client_send_buf_map_handle;
@@ -3757,15 +3757,15 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
 
     if (ndim == 1 && local_offset[0] == 0) {
         local_count = 1;
-        data_ptrs   = (void **)malloc(sizeof(void *));
-        data_size   = (size_t *)malloc(sizeof(size_t));
+        data_ptrs   = (void **)PDC_malloc(sizeof(void *));
+        data_size   = (size_t *)PDC_malloc(sizeof(size_t));
         *data_ptrs  = local_data;
         *data_size  = unit * local_dims[0];
     }
     else if (ndim == 1) {
         local_count = 1;
-        data_ptrs   = (void **)malloc(sizeof(void *));
-        data_size   = (size_t *)malloc(sizeof(size_t));
+        data_ptrs   = (void **)PDC_malloc(sizeof(void *));
+        data_size   = (size_t *)PDC_malloc(sizeof(size_t));
         *data_ptrs  = local_data + unit * local_offset[0];
         *data_size  = unit * local_dims[0];
         LOG_DEBUG("offset size = %d, local dim = %d, unit = %d, data_ptrs[0] = %d, data_ptrs[1] = %d\n",
@@ -3774,15 +3774,15 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     }
     else if (ndim == 2 && local_offset[1] == 0) {
         local_count = 1;
-        data_ptrs   = (void **)malloc(sizeof(void *));
-        data_size   = (size_t *)malloc(sizeof(size_t));
+        data_ptrs   = (void **)PDC_malloc(sizeof(void *));
+        data_size   = (size_t *)PDC_malloc(sizeof(size_t));
         *data_ptrs  = local_data;
         *data_size  = unit * local_dims[0] * local_dims[1];
     }
     else if (ndim == 2) {
         local_count  = local_dims[0];
-        data_ptrs    = (void **)malloc(local_count * sizeof(void *));
-        data_size    = (size_t *)malloc(local_count * sizeof(size_t));
+        data_ptrs    = (void **)PDC_malloc(local_count * sizeof(void *));
+        data_size    = (size_t *)PDC_malloc(local_count * sizeof(size_t));
         data_ptrs[0] = local_data + unit * (local_dims[1] * local_offset[0] + local_offset[1]);
         data_size[0] = local_dims[1];
         data_size[0] = unit * local_dims[1];
@@ -3793,15 +3793,15 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
     }
     else if (ndim == 3 && local_offset[2] == 0) {
         local_count = 1;
-        data_ptrs   = (void **)malloc(sizeof(void *));
-        data_size   = (size_t *)malloc(sizeof(size_t));
+        data_ptrs   = (void **)PDC_malloc(sizeof(void *));
+        data_size   = (size_t *)PDC_malloc(sizeof(size_t));
         *data_ptrs  = local_data;
         *data_size  = unit * local_dims[0] * local_dims[1] * local_dims[2];
     }
     else if (ndim == 3) {
         local_count  = local_dims[0] * local_dims[1];
-        data_ptrs    = (void **)malloc(local_count * sizeof(void *));
-        data_size    = (size_t *)malloc(local_count * sizeof(size_t));
+        data_ptrs    = (void **)PDC_malloc(local_count * sizeof(void *));
+        data_size    = (size_t *)PDC_malloc(local_count * sizeof(size_t));
         data_ptrs[0] = local_data + unit * (local_dims[2] * local_dims[1] * local_offset[0] +
                                             local_dims[2] * local_offset[1] + local_offset[2]);
         data_size[0] = local_dims[2];
@@ -3860,8 +3860,8 @@ PDC_Client_buf_map(pdcid_t local_region_id, pdcid_t remote_obj_id, size_t ndim, 
 
 done:
     fflush(stdout);
-    free(data_ptrs);
-    free(data_size);
+    data_ptrs = (void **)PDC_free(data_ptrs);
+    data_size = (size_t *)PDC_free(data_size);
     HG_Destroy(client_send_buf_map_handle);
 
     FUNC_LEAVE(ret_value);
@@ -3960,531 +3960,6 @@ done:
 
     FUNC_LEAVE(ret_value);
 }
-/*
-static perr_t
-pdc_region_release_with_server_transform(struct _pdc_obj_info *  object_info,
-                                         struct pdc_region_info *region_info, pdc_access_t access_type,
-                                         pdc_var_type_t data_type, size_t type_extent, int transform_state,
-                                         struct _pdc_region_transform_ftn_info *this_transform,
-                                         size_t client_transform_size, void *client_transform_result,
-                                         pbool_t *status)
-{
-    perr_t                         ret_value = SUCCEED;
-    void **                        data_ptrs = NULL;
-    size_t                         unit = 1, *data_size = NULL;
-    hg_class_t *                   hg_class = NULL;
-    hg_return_t                    hg_ret;
-    uint32_t                       server_id, meta_server_id;
-    region_transform_and_lock_in_t in;
-    struct _pdc_client_lookup_args lookup_args;
-    hg_handle_t                    region_release_handle = HG_HANDLE_NULL;
-
-    FUNC_ENTER(NULL);
-
-    // Compute local data server id
-    if (pdc_server_selection_g != PDC_SERVER_DEFAULT) {
-        server_id      = object_info->obj_info_pub->server_id;
-        meta_server_id = server_id;
-    }
-    else {
-        // Compute metadata server id
-        meta_server_id = PDC_get_server_by_obj_id(object_info->obj_info_pub->meta_id, pdc_server_num_g);
-        // Compute local data server id
-        server_id = PDC_CLIENT_DATA_SERVER();
-    }
-    if (this_transform == NULL)
-        in.transform_id = -1;
-    else {
-        in.transform_id = this_transform->meta_index;
-        in.data_type    = this_transform->type;
-    }
-    in.dest_type           = data_type;
-    in.meta_server_id      = meta_server_id;
-    in.obj_id              = object_info->obj_info_pub->meta_id;
-    in.access_type         = access_type;
-    in.mapping             = region_info->mapping;
-    in.local_reg_id        = region_info->local_id;
-    in.transform_state     = transform_state;
-    in.transform_data_size = client_transform_size;
-    in.client_data_ptr     = (uint64_t)client_transform_result;
-
-
-    data_ptrs  = (void **)malloc(sizeof(void *));
-    data_size  = (size_t *)malloc(sizeof(size_t));
-    *data_ptrs = client_transform_result;
-    *data_size = client_transform_size;
-
-    hg_class = HG_Context_get_class(send_context_g);
-
-    unit = type_extent;
-    PDC_region_info_t_to_transfer_unit(region_info, &(in.region), unit);
-
-    if (PDC_Client_try_lookup_server(server_id, 0) != SUCCEED)
-        PGOTO_ERROR(FAIL, "==CLIENT[%d]: ERROR with PDC_Client_try_lookup_server", pdc_client_mpi_rank_g);
-
-    // Create a bulk handle for the temp buffer used by the transform
-    hg_ret = HG_Bulk_create(hg_class, 1, (void **)data_ptrs, (hg_size_t *)data_size, HG_BULK_READWRITE,
-                            &(in.local_bulk_handle));
-    if (hg_ret != HG_SUCCESS)
-        PGOTO_ERROR(FAIL, "HG_Bulk_create() failed");
-
-    HG_Create(send_context_g, pdc_server_info_g[server_id].addr, transform_region_release_register_id_g,
-              &region_release_handle);
-
-    hg_ret = HG_Forward(region_release_handle, client_region_release_rpc_cb, &lookup_args, &in);
-    if (hg_ret != HG_SUCCESS)
-        PGOTO_ERROR(FAIL, "PDC_Client_send_name_to_server(): Could not start HG_Forward()");
-
-    // Wait for response from server
-    hg_atomic_set32(&atomic_work_todo_g, 1) ;
-    PDC_Client_check_response(&send_context_g);
-
-    // RPC is complete
-    // We can free up the bulk handle
-    // We can also free the local transform result...
-    HG_Bulk_free(in.local_bulk_handle);
-    if (transform_state && client_transform_result)
-        free(client_transform_result);
-
-    // Now the return value is stored in lookup_args.ret
-    if (lookup_args.ret == 1) {
-        *status   = TRUE;
-        ret_value = SUCCEED;
-    }
-    else {
-        *status   = FALSE;
-        ret_value = FAIL;
-    }
-
-done:
-    if (data_ptrs)
-        free(data_ptrs);
-    if (data_size)
-        free(data_size);
-
-    if (region_release_handle != HG_HANDLE_NULL)
-        HG_Destroy(region_release_handle);
-
-    fflush(stdout);
-    FUNC_LEAVE(ret_value);
-}
-
-static perr_t
-pdc_region_release_with_server_analysis(struct _pdc_obj_info *  object_info,
-                                        struct pdc_region_info *region_info, pdc_access_t access_type,
-                                        pdc_var_type_t data_type, size_t type_extent,
-                                        struct _pdc_region_analysis_ftn_info *registry, pbool_t *status)
-{
-    perr_t                         ret_value = SUCCEED;
-    size_t                         unit;
-    size_t                         output_extent;
-    pdc_var_type_t                 output_datatype;
-    hg_return_t                    hg_ret;
-    uint32_t                       server_id, meta_server_id;
-    region_analysis_and_lock_in_t  in;
-    struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_iterator_info *    inputIter, *outputIter;
-    hg_handle_t                    region_release_handle = HG_HANDLE_NULL;
-    pdcid_t                        result_obj            = 0;
-    struct _pdc_id_info *          obj_info;
-    struct _pdc_obj_prop *         obj_prop;
-
-    FUNC_ENTER(NULL);
-
-    if (pdc_server_selection_g != PDC_SERVER_DEFAULT) {
-
-        server_id      = object_info->obj_info_pub->server_id;
-        meta_server_id = server_id;
-    }
-    else {
-        // Compute metadata server id
-        meta_server_id = PDC_get_server_by_obj_id(object_info->obj_info_pub->meta_id, pdc_server_num_g);
-        // Compute local data server id
-        server_id = PDC_CLIENT_DATA_SERVER();
-    }
-    in.meta_server_id = meta_server_id;
-    in.obj_id         = object_info->obj_info_pub->meta_id;
-    in.access_type    = access_type;
-    in.local_reg_id   = region_info->local_id;
-    in.mapping        = region_info->mapping;
-    in.data_type      = data_type;
-    in.lock_mode      = 0;
-    unit              = type_extent;
-
-    PDC_region_info_t_to_transfer_unit(region_info, &(in.region), unit);
-    in.type_extent         = unit;
-    in.analysis_meta_index = registry->meta_index;
-    inputIter              = &PDC_Block_iterator_cache[registry->object_id[0]];
-    in.input_iter          = inputIter->meta_id;
-    in.n_args              = registry->n_args;
-    outputIter             = &PDC_Block_iterator_cache[registry->object_id[registry->n_args - 1]];
-    output_datatype        = PDC_Block_iterator_cache[registry->object_id[registry->n_args - 1]].pdc_datatype;
-    output_extent          = PDC_get_var_type_size(output_datatype);
-    in.output_type_extent  = output_extent;
-
-    result_obj       = outputIter->objectId;
-    obj_info         = PDC_find_id(result_obj);
-    obj_prop         = (struct _pdc_obj_prop *)(obj_info->obj_ptr);
-    in.output_obj_id = obj_prop->obj_prop_pub->obj_prop_id;
-    in.output_iter   = outputIter->meta_id;
-
-    if (PDC_Client_try_lookup_server(server_id, 0) != SUCCEED)
-        PGOTO_ERROR(FAIL, "==CLIENT[%d]: ERROR with PDC_Client_try_lookup_server", pdc_client_mpi_rank_g);
-
-    HG_Create(send_context_g, pdc_server_info_g[server_id].addr, region_analysis_release_register_id_g,
-              &region_release_handle);
-
-    hg_ret = HG_Forward(region_release_handle, client_region_release_rpc_cb, &lookup_args, &in);
-    if (hg_ret != HG_SUCCESS)
-        PGOTO_ERROR(FAIL, "PDC_Client_send_name_to_server(): Could not start HG_Forward()");
-
-    // Wait for response from server
-    hg_atomic_set32(&atomic_work_todo_g, 1) ;
-    PDC_Client_check_response(&send_context_g);
-
-    // Now the return value is stored in lookup_args.ret
-    if (lookup_args.ret == 1) {
-
-        *status   = TRUE;
-        ret_value = SUCCEED;
-    }
-    else {
-        *status   = FALSE;
-        ret_value = FAIL;
-    }
-
-done:
-    fflush(stdout);
-    if (region_release_handle != HG_HANDLE_NULL)
-        HG_Destroy(region_release_handle);
-
-    FUNC_LEAVE(ret_value);
-}
-*/
-
-/*
-// This function supports transforms which are to occur
-// post-READ (mapping operations) on the client.
-static perr_t
-pdc_region_release_with_client_transform(struct _pdc_obj_info *  object_info,
-                                         struct pdc_region_info *region_info, pdc_access_t access_type,
-                                         pdc_var_type_t data_type, int type_extent, int transform_state,
-                                         struct _pdc_region_transform_ftn_info *this_transform,
-                                         size_t *client_transform_size, void *client_transform_result,
-                                         pbool_t *status)
-{
-    perr_t                            ret_value = SUCCEED;
-    void **                           data_ptrs = NULL;
-    size_t                            unit = 1, *data_size = NULL;
-    hg_class_t *                      hg_class = NULL;
-    hg_return_t                       hg_ret;
-    uint32_t                          server_id, meta_server_id;
-    region_transform_and_lock_in_t    in;
-    struct _pdc_client_transform_args transform_args;
-    hg_handle_t                       region_release_handle = HG_HANDLE_NULL;
-
-    FUNC_ENTER(NULL);
-
-    // Compute local data server id
-    if (pdc_server_selection_g != PDC_SERVER_DEFAULT) {
-        server_id      = object_info->obj_info_pub->server_id;
-        meta_server_id = server_id;
-    }
-    else {
-        // Compute metadata server id
-        meta_server_id = PDC_get_server_by_obj_id(object_info->obj_info_pub->meta_id, pdc_server_num_g);
-        // Compute local data server id
-        server_id = PDC_CLIENT_DATA_SERVER();
-    }
-    if (this_transform == NULL)
-        in.transform_id = -1;
-    else {
-        in.transform_id = this_transform->meta_index;
-        in.data_type    = this_transform->type;
-    }
-    if (object_info->obj_pt->data_state == 0)
-        in.dest_type = data_type;
-    else
-        in.dest_type = object_info->obj_pt->transform_prop.dtype;
-
-    in.meta_server_id      = meta_server_id;
-    in.obj_id              = object_info->obj_info_pub->meta_id;
-    in.access_type         = access_type;
-    in.mapping             = region_info->mapping;
-    in.local_reg_id        = region_info->local_id;
-    in.transform_state     = transform_state;
-    in.transform_data_size = *client_transform_size;
-
-    data_ptrs    = (void **)malloc(sizeof(void *));
-    data_size    = (size_t *)malloc(sizeof(size_t));
-    data_ptrs[0] = malloc(*client_transform_size);
-    data_size[0] = *client_transform_size;
-
-    hg_class = HG_Context_get_class(send_context_g);
-
-    // The following values need to specify the actual region info
-    // since the server uses that to locate the matching server info
-    // which includes the relevant file pointer, etc...
-    unit = type_extent;
-    PDC_region_info_t_to_transfer_unit(region_info, &(in.region), unit);
-
-    if (PDC_Client_try_lookup_server(server_id, 0) != SUCCEED)
-        PGOTO_ERROR(FAIL, "==CLIENT[%d]: ERROR with PDC_Client_try_lookup_server", pdc_client_mpi_rank_g);
-
-    transform_args.data             = data_ptrs[0];
-    transform_args.transform_result = client_transform_result;
-    transform_args.size             = *client_transform_size;
-    transform_args.this_transform   = this_transform;
-    transform_args.transform_state  = transform_state;
-    transform_args.type_extent      = type_extent;
-    transform_args.region_info      = region_info;
-
-    // Create a bulk handle for the temp buffer used by the transform
-    hg_ret = HG_Bulk_create(hg_class, 1, (void **)data_ptrs, (hg_size_t *)data_size, HG_BULK_READWRITE,
-                            &(in.local_bulk_handle));
-
-    transform_args.local_bulk_handle = in.local_bulk_handle;
-
-    HG_Create(send_context_g, pdc_server_info_g[server_id].addr, transform_region_release_register_id_g,
-              &region_release_handle);
-
-    hg_ret = HG_Forward(region_release_handle, client_region_release_with_transform_cb, &transform_args, &in);
-    if (hg_ret != HG_SUCCESS)
-        PGOTO_ERROR(FAIL, "PDC_Client_send_name_to_server(): Could not start HG_Forward()");
-
-    // Wait for response from server
-    hg_atomic_set32(&atomic_work_todo_g, 1) ;
-    PDC_Client_check_response(&send_context_g);
-
-    ret_value = HG_Bulk_free(in.local_bulk_handle);
-
-    // Now the return value is stored in lookup_args.ret
-    if (transform_args.ret == 1) {
-        // Update size with what the transform produced...
-        *client_transform_size = transform_args.size;
-        *status                = TRUE;
-        ret_value              = SUCCEED;
-    }
-    else {
-        *status   = FALSE;
-        ret_value = FAIL;
-    }
-
-done:
-    if (data_ptrs) {
-        free(data_ptrs[0]);
-        free(data_ptrs);
-    }
-    if (data_size)
-        free(data_size);
-
-    if (region_release_handle != HG_HANDLE_NULL)
-        HG_Destroy(region_release_handle);
-
-    fflush(stdout);
-    FUNC_LEAVE(ret_value);
-}
-
-static void
-update_metadata(struct _pdc_obj_info *object_info, pdc_var_type_t data_type, size_t type_extent,
-                int transform_state, size_t transform_size, struct _pdc_region_transform_ftn_info *transform)
-{
-    pdc_metadata_t meta;
-    size_t         expected_size;
-
-    FUNC_ENTER(NULL);
-
-#ifdef ENABLE_MPI
-    // This is symetric with how the query_metadata works, i.e.
-    // MPI rank 0 does some work and broadcasts the results.  In
-    // this example, we don't need to broadcast anything, but only
-    // a single rank should update the metadata.
-    //
-    // FIXME:  The above may or may not be correct, e.g. when
-    // using PDCobj_create_mpi, each MPI rank does the same work,
-    // but the total object extent is the sum of all rank instances.
-    // Does the metadata reflect this correctly?
-
-    if (pdc_client_mpi_rank_g == 0) {
-        PDC_metadata_init(&meta);
-        strcpy(meta.obj_name, object_info->obj_info_pub->name);
-        meta.time_step = object_info->obj_pt->time_step;
-        meta.obj_id    = object_info->obj_info_pub->meta_id;
-        meta.cont_id   = object_info->cont->cont_info_pub->meta_id;
-        meta.data_type = data_type;
-        meta.ndim      = object_info->obj_pt->obj_prop_pub->ndim;
-
-        meta.dims[0]  = object_info->obj_pt->obj_prop_pub->dims[0];
-        expected_size = (size_t)meta.dims[0] * type_extent;
-        if (meta.ndim > 1) {
-            meta.dims[1] = object_info->obj_pt->obj_prop_pub->dims[1];
-            expected_size *= (size_t)meta.dims[1];
-        }
-        if (meta.ndim > 2) {
-            meta.dims[2] = object_info->obj_pt->obj_prop_pub->dims[2];
-            expected_size *= (size_t)meta.dims[2];
-        }
-        if (meta.ndim > 3) {
-            meta.dims[3] = object_info->obj_pt->obj_prop_pub->dims[3];
-            expected_size *= (size_t)meta.dims[3];
-        }
-
-        meta.transform_state          = transform_state;
-        meta.current_state.meta_index = transform->meta_index;
-
-        if (transform_size != expected_size) {
-            meta.current_state.dtype   = PDC_INT8;
-            meta.current_state.ndim    = 1;
-            meta.current_state.dims[0] = transform_size;
-            meta.current_state.dims[1] = 0;
-            meta.current_state.dims[2] = 0;
-            meta.current_state.dims[3] = 0;
-        }
-        else {
-            meta.current_state.dtype   = data_type;
-            meta.current_state.ndim    = meta.ndim;
-            meta.current_state.dims[0] = meta.dims[0];
-            meta.current_state.dims[1] = meta.dims[1];
-            meta.current_state.dims[2] = meta.dims[2];
-            meta.current_state.dims[3] = meta.dims[3];
-        }
-        PDC_Client_update_metadata(&meta, &meta);
-    }
-#endif
-
-    FUNC_LEAVE_VOID;
-}
-*/
-
-/*
-static size_t
-
-get_transform_size(struct _pdc_transform_state *transform_state)
-{
-    size_t ret_value = 0;
-    size_t i, transform_size;
-    int    type_size;
-
-    FUNC_ENTER(NULL);
-
-    type_size      = PDC_get_var_type_size(transform_state->dtype);
-    transform_size = transform_state->dims[0] * type_size;
-    for (i = 1; i < transform_state->ndim; i++)
-        transform_size *= transform_state->dims[i];
-
-    ret_value = transform_size;
-
-    FUNC_LEAVE(ret_value);
-}
-
-static hg_return_t
-maybe_run_transform(struct _pdc_obj_info *object_info, struct pdc_region_info *region_info,
-                    pdc_access_t access_type, pdc_var_type_t data_type, int *readyState, int *transform_index,
-                    void **transform_result, size_t *transform_size)
-{
-    pbool_t                                 status    = TRUE;
-    perr_t                                  ret_value = SUCCEED;
-    size_t                                  i, client_transform_size = 0, server_transform_size = 0;
-    pdc_var_type_t                          dest_type = PDC_UNKNOWN;
-    struct _pdc_region_transform_ftn_info **registry  = NULL;
-    int                                     k, type_size, registered_count = PDC_get_transforms(&registry);
-
-    // FIXME: In theory, the transforms will be enabled ONLY
-    // when the identified readyState value is reached.
-    // For now we are relying on the ordering in which
-    // functions are registered.  To fix this, after each
-    // transform, we should restart the scan loop to choose
-    // a "next" transform if there is one...
-
-    FUNC_ENTER(NULL);
-
-    if (access_type == PDC_WRITE) {
-        for (k = 0; k < registered_count; k++) {
-            if ((registry[k]->op_type == PDC_DATA_MAP) && (registry[k]->when == DATA_OUT) &&
-                (registry[k]->readyState == *readyState)) {
-                size_t (*this_transform)(void *, pdc_var_type_t, int, uint64_t *, void **, pdc_var_type_t) =
-                    registry[k]->ftnPtr;
-                dest_type         = registry[k]->dest_type;
-                *transform_result = registry[k]->result;
-                client_transform_size =
-                    this_transform(registry[k]->data, registry[k]->type, region_info->ndim, region_info->size,
-                                   transform_result, dest_type);
-                *readyState      = registry[k]->nextState;
-                *transform_index = k;
-            }
-
-        }
-        //Check next for SERVER (post-data-xfer) transforms
-        for (k = 0; k < registered_count; k++) {
-            if ((registry[k]->dest_region == region_info) && (registry[k]->op_type == PDC_DATA_MAP) &&
-                (registry[k]->when == DATA_IN) && (registry[k]->readyState == *readyState)) {
-                if (client_transform_size == 0) {
-                    // No previous transforms, so just use the current region data
-                    *transform_result     = registry[k]->data;
-                    server_transform_size = region_info->size[0];
-                    for (i = 1; i < region_info->ndim; i++)
-                        server_transform_size *= region_info->size[i];
-                }
-                else
-                    server_transform_size = region_info->size[0];
-                *transform_index = k;
-            }
-        }
-
-        type_size = PDC_get_var_type_size(registry[*transform_index]->type);
-
-        //Client side transform only
-        if ((client_transform_size > 0) && (server_transform_size == 0)) {
-            *transform_size = client_transform_size;
-            ret_value       = pdc_region_release_with_server_transform(
-                object_info, region_info, access_type, data_type, type_size, *readyState, NULL,
-                client_transform_size, *transform_result, &status);
-        }
-        //Client and Server side transforms
-        else if ((client_transform_size > 0) && (server_transform_size > 0)) {
-            *transform_size = server_transform_size;
-            ret_value       = pdc_region_release_with_server_transform(
-                object_info, region_info, access_type, data_type, type_size, *readyState,
-                registry[*transform_index], client_transform_size, *transform_result, &status);
-        }
-        //Server side transform only
-        else if (server_transform_size > 0) {
-            *transform_size = server_transform_size;
-            ret_value       = pdc_region_release_with_server_transform(
-                object_info, region_info, access_type, data_type, type_size, *readyState,
-                registry[*transform_index], server_transform_size, *transform_result, &status);
-        }
-    }
-    else if (access_type == PDC_READ) {
-        for (k = 0; k < registered_count; k++) {
-            // Check for SERVER (pre-data-xfer) transforms
-            if ((registry[k]->op_type == PDC_DATA_MAP) && (registry[k]->when == DATA_OUT) &&
-                (registry[k]->readyState == *readyState))
-                puts("Server READ transform identified");
-        }
-        for (k = 0; k < registered_count; k++) {
-            //Check for CLIENT (post-data-xfer) transforms
-            if ((registry[k]->dest_region == region_info) && (registry[k]->op_type == PDC_DATA_MAP) &&
-                (registry[k]->when == DATA_IN) && (registry[k]->readyState == *readyState)) {
-
-                type_size         = PDC_get_var_type_size(registry[k]->type);
-                *transform_result = registry[k]->data;
-                *transform_size   = get_transform_size(&object_info->obj_pt->transform_prop);
-                ret_value         = pdc_region_release_with_client_transform(
-                    object_info, region_info, access_type, data_type, type_size, *readyState, registry[k],
-                    transform_size, registry[k]->data, &status);
-                if (ret_value == SUCCEED) {
-                    *readyState      = registry[k]->nextState;
-                    *transform_index = k;
-                }
-            }
-        }
-    }
-
-    fflush(stdout);
-    FUNC_LEAVE(ret_value);
-}
-*/
 
 perr_t
 PDC_Client_region_release(pdcid_t remote_obj_id, struct _pdc_obj_info *object_info,
@@ -4499,46 +3974,12 @@ PDC_Client_region_release(pdcid_t remote_obj_id, struct _pdc_obj_info *object_in
     // size_t                         type_extent;
     struct _pdc_client_lookup_args lookup_args;
     hg_handle_t                    region_release_handle = HG_HANDLE_NULL;
-    // void *transform_result = NULL;
-    // size_t transform_size = 0;
-    // struct _pdc_region_transform_ftn_info **registry = NULL;
-    // int transform_index;
-    // int k, registered_count;
-    // struct _pdc_region_analysis_ftn_info **analysis_registry;
 
     FUNC_ENTER(NULL);
 #ifdef PDC_TIMING
     double start          = MPI_Wtime(), end;
     double function_start = start;
 #endif
-    // type_extent = object_info->obj_pt->type_extent;
-    /*
-        if (region_info->registered_op & PDC_TRANSFORM) {
-            transform_index = -1;
-            PDC_get_transforms(&registry);
-            // Get the current data_state of this object::
-            readyState = currentState = object_info->obj_pt->data_state;
-            ret_value = maybe_run_transform(object_info, region_info, access_type, data_type,
-                            &currentState, &transform_index, &transform_result, &transform_size);
-            if ((ret_value == SUCCEED) && (readyState != currentState)) {
-                update_metadata(object_info, data_type, type_extent, currentState,
-                                transform_size, registry[transform_index]);
-                PGOTO_DONE(ret_value);
-            }
-        }
-        // FIXME:  What if the user has coupled a transform with an analysis function?
-        // How do we provide the transformed data into the analysis?
-        if (region_info->registered_op & PDC_ANALYSIS) {
-            registered_count = PDC_get_analysis_registry(&analysis_registry);
-            for (k=0; k < registered_count; k++) {
-                if (analysis_registry[k]->region_id[0] == region_info->local_id) {
-                    ret_value = pdc_region_release_with_server_analysis(object_info, region_info,
-                        access_type, data_type, type_extent, analysis_registry[k], status);
-                    PGOTO_DONE(ret_value);
-                }
-            }
-        }
-    */
     // Compute data server and metadata server ids.
     server_id         = ((pdc_metadata_t *)object_info->metadata)->data_server_id;
     meta_server_id    = PDC_get_server_by_obj_id(remote_obj_id, pdc_server_num_g);
@@ -4639,7 +4080,7 @@ data_server_read_check_rpc_cb(const struct hg_cb_info *callback_info)
 
     client_lookup_args->ret = output.ret;
     if (output.shm_addr != NULL) {
-        client_lookup_args->ret_string = (char *)malloc(strlen(output.shm_addr) + 1);
+        client_lookup_args->ret_string = (char *)PDC_malloc(strlen(output.shm_addr) + 1);
         strcpy(client_lookup_args->ret_string, output.shm_addr);
     }
     else
@@ -4662,11 +4103,11 @@ PDC_Client_get_data_from_server_shm_cb(const struct hg_cb_info *callback_info)
 
     int                     shm_fd        = -1; // file descriptor, from shm_open()
     uint32_t                i             = 0;
-    char *                  shm_base      = NULL; // base address, from mmap()
-    char *                  shm_addr      = NULL;
+    char                   *shm_base      = NULL; // base address, from mmap()
+    char                   *shm_addr      = NULL;
     uint64_t                data_size     = 1;
-    client_read_info_t *    read_info     = NULL;
-    struct pdc_request *    elt           = NULL;
+    client_read_info_t     *read_info     = NULL;
+    struct pdc_request     *elt           = NULL;
     struct pdc_region_info *target_region = NULL;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
@@ -4757,8 +4198,8 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
     uint64_t                       read_size = 1;
     hg_handle_t                    data_server_read_check_handle;
     int                            shm_fd;   // file descriptor, from shm_open()
-    char *                         shm_base; // base address, from mmap()
-    char *                         shm_addr;
+    char                          *shm_base; // base address, from mmap()
+    char                          *shm_addr;
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -4848,7 +4289,7 @@ PDC_Client_data_server_read_check(int server_id, uint32_t client_id, pdc_metadat
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Close failed!");
 
     // TODO: need to make sure server has cached it to BB
-    free(lookup_args.ret_string);
+    lookup_args.ret_string = (char *)PDC_free(lookup_args.ret_string);
 
 done:
     fflush(stdout);
@@ -4893,8 +4334,8 @@ PDC_Client_data_server_read(struct pdc_request *request)
     data_server_read_in_t          in;
     hg_handle_t                    data_server_read_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
 
     FUNC_ENTER(NULL);
 
@@ -5026,8 +4467,8 @@ PDC_Client_data_server_write_check(struct pdc_request *request, int *status)
     data_server_write_check_in_t   in;
     hg_handle_t                    data_server_write_check_handle;
     int                            server_id;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
     uint64_t                       write_size = 1;
     uint32_t                       i;
 
@@ -5128,9 +4569,9 @@ PDC_Client_data_server_write(struct pdc_request *request)
     int                            server_ret;
     hg_handle_t                    data_server_write_handle;
     int                            server_id, n_client, n_update;
-    pdc_metadata_t *               meta;
-    struct pdc_region_info *       region;
-    void *                         buf;
+    pdc_metadata_t                *meta;
+    struct pdc_region_info        *region;
+    void                          *buf;
 
     int rnd;
 #ifdef ENABLE_TIMING
@@ -5186,7 +4627,7 @@ PDC_Client_data_server_write(struct pdc_request *request)
     request->shm_base = mmap(0, region_size, PROT_READ | PROT_WRITE, MAP_SHARED, request->shm_fd, 0);
     if (request->shm_base == MAP_FAILED)
         PGOTO_ERROR(FAIL, "==PDC_CLIENT: Shared memory mmap failed, region size = %" PRIu64 "", region_size);
-        // close and shm_unlink?
+    // close and shm_unlink?
 
 #ifdef ENABLE_TIMING
     gettimeofday(&pdc_timer_start, 0);
@@ -5398,7 +4839,7 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     struct _pdc_id_info *info;
 
     struct _pdc_obj_info *object;
-    pdc_metadata_t *      meta;
+    pdc_metadata_t       *meta;
     perr_t                ret_value = SUCCEED;
 
     FUNC_ENTER(NULL);
@@ -5483,7 +4924,7 @@ perr_t
 PDC_Client_write_wait_notify(pdc_metadata_t *meta, struct pdc_region_info *region, void *buf)
 {
     perr_t              ret_value = SUCCEED;
-    struct pdc_request *request   = (struct pdc_request *)malloc(sizeof(struct pdc_request));
+    struct pdc_request *request   = (struct pdc_request *)PDC_malloc(sizeof(struct pdc_request));
 
     FUNC_ENTER(NULL);
 
@@ -5511,7 +4952,7 @@ perr_t
 PDC_Client_read_wait_notify(pdc_metadata_t *meta, struct pdc_region_info *region, void *buf)
 {
     perr_t              ret_value = SUCCEED;
-    struct pdc_request *request   = (struct pdc_request *)malloc(sizeof(struct pdc_request));
+    struct pdc_request *request   = (struct pdc_request *)PDC_malloc(sizeof(struct pdc_request));
 
     FUNC_ENTER(NULL);
 
@@ -5629,13 +5070,13 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
     FUNC_ENTER(NULL);
 
-    obj_ids = (uint64_t *)malloc(sizeof(uint64_t) * nobj);
+    obj_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * nobj);
     for (i = 0; i < nobj; i++) {
         id_info    = PDC_find_id(local_obj_ids[i]);
         obj_ids[i] = ((struct _pdc_obj_info *)(id_info->obj_ptr))->obj_info_pub->meta_id;
@@ -5655,13 +5096,13 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 {
     perr_t               ret_value = SUCCEED;
     int                  i;
-    uint64_t *           obj_ids;
+    uint64_t            *obj_ids;
     uint64_t             cont_meta_id;
     struct _pdc_id_info *id_info = NULL;
 
     FUNC_ENTER(NULL);
 
-    obj_ids = (uint64_t *)malloc(sizeof(uint64_t) * nobj);
+    obj_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * nobj);
     for (i = 0; i < nobj; i++) {
         id_info    = PDC_find_id(local_obj_ids[i]);
         obj_ids[i] = ((struct _pdc_obj_info *)(id_info->obj_ptr))->obj_info_pub->meta_id;
@@ -5683,7 +5124,7 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     hg_return_t            hg_ret    = HG_SUCCESS;
     hg_handle_t            rpc_handle;
     uint32_t               server_id;
-    struct _pdc_id_info *  info;
+    struct _pdc_id_info   *info;
     struct _pdc_cont_info *object;
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
@@ -5938,12 +5379,12 @@ PDC_Client_query_name_read_entire_obj(int nobj, char **obj_names, void ***out_bu
     hg_handle_t              rpc_handle;
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes, total_size;
+    uint64_t                *buf_sizes, total_size;
     int                      i;
     query_read_obj_name_in_t bulk_rpc_in;
     // Reuse the existing args structure
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request *                   request;
+    struct pdc_request                    *request;
 
     FUNC_ENTER(NULL);
 
@@ -6053,7 +5494,7 @@ PDC_Client_complete_read_request(int nbuf, struct pdc_request *req)
 #endif
 
         // Copy data
-        (*req->buf_arr)[i] = (void *)malloc((req->shm_size_arr)[i]);
+        (*req->buf_arr)[i] = (void *)PDC_malloc((req->shm_size_arr)[i]);
         memcpy((*req->buf_arr)[i], req->shm_base_arr[i], (req->shm_size_arr)[i]);
 
 #ifdef ENABLE_TIMING
@@ -6261,7 +5702,7 @@ static region_list_t *
 PDC_get_storage_meta_from_io_list(pdc_data_server_io_list_t **list, region_storage_meta_t *storage_meta)
 {
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            ret_value = NULL;
+    region_list_t             *ret_value = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -6287,7 +5728,7 @@ PDC_add_storage_meta_to_io_list(pdc_data_server_io_list_t **list, region_storage
 {
 
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
-    region_list_t *            new_region;
+    region_list_t             *new_region;
     int                        j;
     perr_t                     ret_value = SUCCEED;
 
@@ -6354,7 +5795,7 @@ PDC_send_region_storage_meta_shm(uint32_t server_id, int n, region_storage_meta_
 
     buf_sizes = n * sizeof(region_storage_meta_t);
     hg_ret    = HG_Bulk_create(send_class_g, 1, (void **)&storage_meta, (const hg_size_t *)&buf_sizes,
-                            HG_BULK_READ_ONLY, &bulk_handle);
+                               HG_BULK_READ_ONLY, &bulk_handle);
     if (hg_ret != HG_SUCCESS)
         PGOTO_ERROR(FAIL, "Could not create bulk data handle");
 
@@ -6387,7 +5828,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     perr_t                 ret_value = SUCCEED;
     uint32_t               ndim, server_id;
     uint64_t               total_size = 0, cp_loc = 0;
-    void *                 buf = NULL;
+    void                  *buf = NULL;
     char                   shm_addr[ADDR_MAX];
     int                    i, *total_obj = NULL, ntotal_obj = nobj, *recvcounts = NULL, *displs = NULL;
     region_storage_meta_t *all_region_storage_meta_1d = NULL, *my_region_storage_meta_1d = NULL;
@@ -6431,9 +5872,9 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     }
 
 #ifdef ENABLE_MPI
-    displs     = (int *)malloc(sizeof(int) * pdc_client_same_node_size_g);
-    recvcounts = (int *)malloc(sizeof(int) * pdc_client_same_node_size_g);
-    total_obj  = (int *)malloc(sizeof(int) * pdc_client_same_node_size_g);
+    displs     = (int *)PDC_malloc(sizeof(int) * pdc_client_same_node_size_g);
+    recvcounts = (int *)PDC_malloc(sizeof(int) * pdc_client_same_node_size_g);
+    total_obj  = (int *)PDC_malloc(sizeof(int) * pdc_client_same_node_size_g);
 
     // Gather number of objects to each client
     MPI_Allgather(&nobj, 1, MPI_INT, total_obj, 1, MPI_INT, PDC_SAME_NODE_COMM_g);
@@ -6450,11 +5891,11 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
         }
 
         all_region_storage_meta_1d =
-            (region_storage_meta_t *)malloc(ntotal_obj * sizeof(region_storage_meta_t));
+            (region_storage_meta_t *)PDC_malloc(ntotal_obj * sizeof(region_storage_meta_t));
     }
 
     // Copy data to 1 buffer
-    my_region_storage_meta_1d = (region_storage_meta_t *)malloc(nobj * sizeof(region_storage_meta_t));
+    my_region_storage_meta_1d = (region_storage_meta_t *)PDC_malloc(nobj * sizeof(region_storage_meta_t));
     for (i = 0; i < nobj; i++)
         memcpy(&my_region_storage_meta_1d[i], all_storage_meta[i], sizeof(region_storage_meta_t));
 
@@ -6470,12 +5911,12 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
         ret_value = PDC_send_region_storage_meta_shm(server_id, ntotal_obj, all_region_storage_meta_1d);
     }
 
-    free(displs);
-    free(recvcounts);
-    free(total_obj);
-    free(my_region_storage_meta_1d);
+    displs                    = (int *)PDC_free(displs);
+    recvcounts                = (int *)PDC_free(recvcounts);
+    total_obj                 = (int *)PDC_free(total_obj);
+    my_region_storage_meta_1d = (region_storage_meta_t *)PDC_free(my_region_storage_meta_1d);
     if (pdc_client_same_node_rank_g == 0)
-        free(all_region_storage_meta_1d);
+        all_region_storage_meta_1d = (region_storage_meta_t *)PDC_free(all_region_storage_meta_1d);
 
 #else
     // send to node local server
@@ -6486,7 +5927,7 @@ PDC_Client_cp_data_to_local_server(int nobj, region_storage_meta_t **all_storage
     server_id = PDC_get_local_server_id(pdc_client_mpi_rank_g, pdc_nclient_per_server_g, pdc_server_num_g);
     ret_value = PDC_send_region_storage_meta_shm(server_id, nobj, all_region_storage_meta_1d);
 
-    free(all_region_storage_meta_1d);
+    all_region_storage_meta_1d = (region_storage_meta_t *)PDC_free(all_region_storage_meta_1d);
 #endif
 
     FUNC_LEAVE(ret_value);
@@ -6499,8 +5940,8 @@ PDC_Client_read_with_storage_meta(int nobj, region_storage_meta_t **all_storage_
 {
     perr_t         ret_value = SUCCEED;
     int            i;
-    char *         fname, *prev_fname;
-    FILE *         fp_read = NULL;
+    char          *fname, *prev_fname;
+    FILE          *fp_read = NULL;
     uint32_t       ndim;
     uint64_t       req_start, req_count, storage_start, storage_count, file_offset, buf_size;
     size_t         read_bytes;
@@ -6601,15 +6042,15 @@ PDC_Client_query_multi_storage_info(int nobj, char **obj_names, region_storage_m
 
     hg_bulk_t                bulk_handle;
     uint32_t                 server_id;
-    uint64_t *               buf_sizes = NULL, total_size;
+    uint64_t                *buf_sizes = NULL, total_size;
     int                      i, j, loc, iter, *n_obj_name_by_server = NULL;
-    int **                   obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
+    int                    **obj_names_server_seq_mapping = NULL, *obj_names_server_seq_mapping_1d;
     int                      send_n_request               = 0;
-    char ***                 obj_names_by_server          = NULL;
-    char **                  obj_names_by_server_2d       = NULL;
+    char                  ***obj_names_by_server          = NULL;
+    char                   **obj_names_by_server_2d       = NULL;
     query_read_obj_name_in_t bulk_rpc_in;
     update_region_storage_meta_bulk_args_t cb_args;
-    struct pdc_request **                  requests, *request;
+    struct pdc_request                   **requests, *request;
 
     FUNC_ENTER(NULL);
 
@@ -6725,11 +6166,11 @@ done:
     fflush(stdout);
 
     if (NULL != obj_names_by_server)
-        free(obj_names_by_server);
+        obj_names_by_server = (char ***)PDC_free(obj_names_by_server);
     if (NULL != n_obj_name_by_server)
-        free(n_obj_name_by_server);
+        n_obj_name_by_server = (int *)PDC_free(n_obj_name_by_server);
     if (NULL != obj_names_by_server_2d)
-        free(obj_names_by_server_2d);
+        obj_names_by_server_2d = (char **)PDC_free(obj_names_by_server_2d);
 
     FUNC_LEAVE(ret_value);
 }
@@ -6832,12 +6273,12 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
                                                  size_t *out_buf_sizes)
 {
     perr_t                  ret_value = SUCCEED;
-    char **                 all_names = my_obj_names;
-    char *                  local_names_1d, *all_names_1d = NULL;
-    int *                   total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
+    char                  **all_names = my_obj_names;
+    char                   *local_names_1d, *all_names_1d = NULL;
+    int                    *total_obj = NULL, i, ntotal_obj = my_nobj, *recvcounts = NULL, *displs = NULL;
     size_t                  max_name_len     = 64;
     region_storage_meta_t **all_storage_meta = NULL, **my_storage_meta = NULL;
-    region_storage_meta_t * my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
+    region_storage_meta_t  *my_storage_meta_1d = NULL, *res_storage_meta_1d = NULL;
 
 #ifdef ENABLE_TIMING
     struct timeval pdc_timer1;
@@ -6856,9 +6297,9 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
         strncpy(local_names_1d + i * max_name_len, my_obj_names[i], max_name_len - 1);
     }
 
-    displs     = (int *)malloc(sizeof(int) * pdc_client_same_node_size_g);
-    recvcounts = (int *)malloc(sizeof(int) * pdc_client_same_node_size_g);
-    total_obj  = (int *)malloc(sizeof(int) * pdc_client_same_node_size_g);
+    displs     = (int *)PDC_malloc(sizeof(int) * pdc_client_same_node_size_g);
+    recvcounts = (int *)PDC_malloc(sizeof(int) * pdc_client_same_node_size_g);
+    total_obj  = (int *)PDC_malloc(sizeof(int) * pdc_client_same_node_size_g);
     MPI_Allgather(&my_nobj, 1, MPI_INT, total_obj, 1, MPI_INT, PDC_SAME_NODE_COMM_g);
 
     ntotal_obj = 0;
@@ -6877,7 +6318,7 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
 
     if (pdc_client_same_node_rank_g == 0) {
         all_names    = (char **)calloc(sizeof(char *), ntotal_obj);
-        all_names_1d = (char *)malloc(ntotal_obj * max_name_len);
+        all_names_1d = (char *)PDC_malloc(ntotal_obj * max_name_len);
         for (i = 0; i < ntotal_obj; i++)
             all_names[i] = all_names_1d + i * max_name_len;
     }
@@ -6896,7 +6337,7 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
 
         // Copy the result to the result array for scatter
         // res_storage_meta_1d = (region_storage_meta_t *)calloc(sizeof(region_storage_meta_t), ntotal_obj);
-        res_storage_meta_1d = (region_storage_meta_t *)malloc(sizeof(region_storage_meta_t) * ntotal_obj);
+        res_storage_meta_1d = (region_storage_meta_t *)PDC_malloc(sizeof(region_storage_meta_t) * ntotal_obj);
         for (i = 0; i < ntotal_obj; i++)
             memcpy(&res_storage_meta_1d[i], all_storage_meta[i], sizeof(region_storage_meta_t));
     }
@@ -6952,16 +6393,16 @@ PDC_Client_query_name_read_entire_obj_client_agg(int my_nobj, char **my_obj_name
 
 #ifdef ENABLE_MPI
     if (pdc_client_same_node_rank_g == 0) {
-        free(all_names);
-        free(all_names_1d);
+        all_names    = (char **)PDC_free(all_names);
+        all_names_1d = (char *)PDC_free(all_names_1d);
     }
-    free(recvcounts);
-    free(displs);
-    free(total_obj);
+    recvcounts = (int *)PDC_free(recvcounts);
+    displs     = (int *)PDC_free(displs);
+    total_obj  = (int *)PDC_free(total_obj);
     if (NULL != my_storage_meta)
-        free(my_storage_meta);
+        my_storage_meta = (region_storage_meta_t **)PDC_free(my_storage_meta);
     if (NULL != my_storage_meta_1d)
-        free(my_storage_meta_1d);
+        my_storage_meta_1d = (region_storage_meta_t *)PDC_free(my_storage_meta_1d);
 #endif
 
     FUNC_LEAVE(ret_value);
@@ -7127,7 +6568,7 @@ PDC_Client_read_overlap_regions(uint32_t ndim, uint64_t *req_start, uint64_t *re
 
                 *total_read_bytes += read_bytes;
             } // for each row
-        }     // ndim=2
+        } // ndim=2
         else if (ndim == 3) {
 
             if (is_client_debug_g == 1) {
@@ -7198,8 +6639,8 @@ PDC_add_kvtag(pdcid_t obj_id, pdc_kvtag_t *kvtag, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_add_kvtag_handle;
     metadata_add_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7306,8 +6747,8 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     hg_handle_t                metadata_get_kvtag_handle;
     metadata_get_kvtag_in_t    in;
     struct _pdc_get_kvtag_args lookup_args;
-    struct _pdc_obj_info *     obj_prop;
-    struct _pdc_cont_info *    cont_prop;
+    struct _pdc_obj_info      *obj_prop;
+    struct _pdc_cont_info     *cont_prop;
 
     FUNC_ENTER(NULL);
 
@@ -7339,7 +6780,7 @@ PDC_get_kvtag(pdcid_t obj_id, char *tag_name, pdc_kvtag_t **kvtag, int is_cont)
     else
         PGOTO_ERROR(FAIL, "PDC_get_kvtag: invalid tag content!");
 
-    *kvtag            = (pdc_kvtag_t *)malloc(sizeof(pdc_kvtag_t));
+    *kvtag            = (pdc_kvtag_t *)PDC_malloc(sizeof(pdc_kvtag_t));
     lookup_args.kvtag = *kvtag;
     hg_ret            = HG_Forward(metadata_get_kvtag_handle, metadata_get_kvtag_rpc_cb, &lookup_args, &in);
     if (hg_ret != HG_SUCCESS)
@@ -7367,12 +6808,12 @@ kvtag_query_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_bulk_t           origin_bulk_handle = hg_cb_info->info.bulk.origin_handle;
     hg_bulk_t           local_bulk_handle  = hg_cb_info->info.bulk.local_handle;
     uint32_t            n_meta, actual_cnt;
-    void *              buf = NULL;
+    void               *buf = NULL;
     uint64_t            buf_sizes[1];
     uint32_t            bulk_sgnum;
-    uint64_t *          ids_buf_sizes;
-    void **             ids_buf;
-    uint64_t *          u64_arr_ptr;
+    uint64_t           *ids_buf_sizes;
+    void              **ids_buf;
+    uint64_t           *u64_arr_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -7425,14 +6866,14 @@ static hg_return_t
 kvtag_query_forward_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          bulk_arg;
+    struct bulk_args_t           *bulk_arg;
     hg_handle_t                   handle;
     metadata_query_transfer_out_t output;
     uint32_t                      n_meta;
     hg_op_id_t                    hg_bulk_op_id;
     hg_bulk_t                     local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t                     origin_bulk_handle = HG_BULK_NULL;
-    const struct hg_info *        hg_info            = NULL;
+    const struct hg_info         *hg_info            = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -7551,7 +6992,7 @@ PDC_Client_query_kvtag_server(uint32_t server_id, const pdc_kvtag_t *kvtag, int 
     *n_res = bulk_arg->n_meta;
     if (*n_res > 0)
         *out = bulk_arg->obj_ids;
-    free(bulk_arg);
+    bulk_arg = (struct bulk_args_t *)PDC_free(bulk_arg);
     // TODO: need to be careful when freeing the lookup_args, as it include the results returned to user
 
 done:
@@ -7590,7 +7031,7 @@ PDC_Client_query_kvtag(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_ids)
         else if (nmeta > 0) {
             *pdc_ids = (uint64_t *)realloc(*pdc_ids, sizeof(uint64_t) * (*n_res + nmeta));
             memcpy(*pdc_ids + (*n_res), temp_ids, nmeta * sizeof(uint64_t));
-            free(temp_ids);
+            temp_ids = (uint64_t *)PDC_free(temp_ids);
         }
         *n_res = *n_res + nmeta;
     }
@@ -7610,8 +7051,8 @@ PDCtag_delete(pdcid_t obj_id, char *tag_name, int is_cont)
     uint32_t                       server_id;
     hg_handle_t                    metadata_del_kvtag_handle;
     metadata_get_kvtag_in_t        in;
-    struct _pdc_obj_info *         obj_prop;
-    struct _pdc_cont_info *        cont_prop;
+    struct _pdc_obj_info          *obj_prop;
+    struct _pdc_cont_info         *cont_prop;
     struct _pdc_client_lookup_args lookup_args;
 
     FUNC_ENTER(NULL);
@@ -7853,7 +7294,7 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     perr_t  ret;
     // pdc_metadata_t *meta;
     struct _pdc_cont_info *info    = NULL;
-    struct _pdc_id_info *  id_info = NULL;
+    struct _pdc_id_info   *id_info = NULL;
     pdcid_t                transfer_request;
 
     FUNC_ENTER(NULL);
@@ -7959,7 +7400,7 @@ PDC_Client_del_metadata(pdcid_t obj_id, int is_cont)
 {
     perr_t                 ret_value = SUCCEED;
     uint64_t               meta_id;
-    struct _pdc_obj_info * obj_prop;
+    struct _pdc_obj_info  *obj_prop;
     struct _pdc_cont_info *cont_prop;
 
     FUNC_ENTER(NULL);
@@ -8092,7 +7533,7 @@ hg_return_t
 PDC_recv_nhits(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value = HG_SUCCESS;
-    send_nhits_t *                 in        = (send_nhits_t *)callback_info->arg;
+    send_nhits_t                  *in        = (send_nhits_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -8108,7 +7549,7 @@ PDC_recv_nhits(const struct hg_cb_info *callback_info)
     }
 
     hg_atomic_decr32(&atomic_work_todo_g);
-    free(in);
+    in = (send_nhits_t *)PDC_free(in);
 
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -8120,10 +7561,10 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 {
     perr_t                         ret_value      = SUCCEED;
     hg_return_t                    hg_ret         = 0;
-    uint32_t *                     target_servers = NULL;
+    uint32_t                      *target_servers = NULL;
     int                            i, server_id, next_server = 0, prev_server = 0, ntarget = 0;
     hg_handle_t                    handle;
-    pdc_query_xfer_t *             query_xfer;
+    pdc_query_xfer_t              *query_xfer;
     struct _pdc_client_lookup_args lookup_args;
     struct _pdc_query_result_list *result;
 
@@ -8201,7 +7642,7 @@ PDC_send_data_query(pdc_query_t *query, pdc_query_get_op_t get_op, uint64_t *nhi
 done:
     fflush(stdout);
     if (target_servers)
-        free(target_servers);
+        target_servers = (uint32_t *)PDC_free(target_servers);
 
     FUNC_LEAVE(ret_value);
 }
@@ -8211,12 +7652,12 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     uint32_t                       ndim;
     int                            query_id, origin;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -8246,7 +7687,7 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
             if (result_elt->query_id == query_id) {
                 result_elt->ndim   = ndim;
                 result_elt->nhits  = nhits;
-                result_elt->coords = (uint64_t *)malloc(nhits * ndim * sizeof(uint64_t));
+                result_elt->coords = (uint64_t *)PDC_malloc(nhits * ndim * sizeof(uint64_t));
                 memcpy(result_elt->coords, buf, nhits * ndim * sizeof(uint64_t));
                 break;
             }
@@ -8270,7 +7711,7 @@ done:
 
     fflush(stdout);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -8281,7 +7722,7 @@ PDCselection_free(pdc_selection_t *sel)
     FUNC_ENTER(NULL);
 
     if (sel->coords_alloc > 0 && sel->coords)
-        free(sel->coords);
+        sel->coords = (uint64_t *)PDC_free(sel->coords);
 
     FUNC_LEAVE_VOID;
 }
@@ -8297,7 +7738,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
     uint64_t                       meta_id, off;
     get_sel_data_rpc_in_t          in;
     struct _pdc_client_lookup_args lookup_args;
-    struct _pdc_obj_info *         obj_prop;
+    struct _pdc_obj_info          *obj_prop;
     struct _pdc_query_result_list *result_elt;
 
     FUNC_ENTER(NULL);
@@ -8349,7 +7790,7 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
                 if (result_elt->data_arr[i] != NULL) {
                     memcpy(data + off, result_elt->data_arr[i], result_elt->data_arr_size[i]);
                     off += result_elt->data_arr_size[i];
-                    free(result_elt->data_arr[i]);
+                    result_elt->data_arr[i] = (void **)PDC_free(result_elt->data_arr[i]);
                     result_elt->data_arr[i] = NULL;
                 }
             }
@@ -8370,11 +7811,11 @@ PDC_recv_read_coords_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t                    ret_value         = HG_SUCCESS;
     hg_bulk_t                      local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *           bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    struct bulk_args_t            *bulk_args         = (struct bulk_args_t *)callback_info->arg;
     struct _pdc_query_result_list *result_elt;
     uint64_t                       nhits = 0;
     int                            query_id, seq_id;
-    void *                         buf;
+    void                          *buf;
     pdc_int_ret_t                  out;
 
     FUNC_ENTER(NULL);
@@ -8436,7 +7877,7 @@ done:
 
     fflush(stdout);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -8446,9 +7887,9 @@ report_avg_server_profiling_rst()
 {
     for (int i = 0; i < pdc_server_num_g; i++) {
 
-        double avg_srv_time = server_call_count_g[i] > 0
-                                  ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
-                                  : 0.0;
+        double avg_srv_time  = server_call_count_g[i] > 0
+                                   ? (double)(server_time_total_g[i]) / (double)(server_call_count_g[i])
+                                   : 0.0;
         double srv_mem_usage = server_mem_usage_g[i] / 1024.0 / 1024.0;
         LOG_INFO("==PDC_CLIENT[%d]: server %d, avg profiling time: %.4f ms, memory usage: %.4f MB\n",
                  pdc_client_mpi_rank_g, i, avg_srv_time / 1000.0, srv_mem_usage);
@@ -8588,7 +8029,7 @@ static hg_return_t
 dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                   ret_value;
-    struct bulk_args_t *          client_lookup_args;
+    struct bulk_args_t           *client_lookup_args;
     hg_handle_t                   handle;
     dart_perform_one_server_out_t output;
     uint32_t                      n_meta;
@@ -8597,17 +8038,13 @@ dart_perform_one_server_on_receive_cb(const struct hg_cb_info *callback_info)
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args;
-    void *                recv_meta;
+    struct bulk_args_t   *bulk_args;
+    void                 *recv_meta;
 
     FUNC_ENTER(NULL);
 
-    // println("[Client_Side_Bulk]  Entering dart_perform_one_server_on_receive_cb. rank = %d",
-    // pdc_client_mpi_rank_g);
     client_lookup_args = (struct bulk_args_t *)callback_info->arg;
-    // (client_lookup_args->n_meta) = (uint32_t *)malloc(sizeof(uint32_t));
-    handle = callback_info->info.forward.handle;
-    // println("[Client_Side_Bulk]  before get output. rank = %d", pdc_client_mpi_rank_g);
+    handle             = callback_info->info.forward.handle;
     // Get output from server
     ret_value = HG_Get_output(handle, &output);
     if (ret_value != HG_SUCCESS) {
@@ -8748,7 +8185,7 @@ _aggregate_dart_results_from_all_servers(struct bulk_args_t *lookup_args, Set *o
         if (lookup_args[i].is_id == 1) {
             int n_meta = lookup_args[i].n_meta;
             for (int k = 0; k < n_meta; k++) {
-                uint64_t *id = (uint64_t *)malloc(sizeof(uint64_t));
+                uint64_t *id = (uint64_t *)PDC_malloc(sizeof(uint64_t));
                 *id          = lookup_args[i].obj_ids[k];
                 set_insert(output_set, id);
             }
@@ -8770,7 +8207,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
 {
     struct bulk_args_t *lookup_args = (struct bulk_args_t *)calloc(num_servers, sizeof(struct bulk_args_t));
     uint64_t            ret_value   = 0;
-    hg_handle_t *       dart_request_handles = (hg_handle_t *)calloc(num_servers, sizeof(hg_handle_t));
+    hg_handle_t        *dart_request_handles = (hg_handle_t *)calloc(num_servers, sizeof(hg_handle_t));
     int                 num_requests         = 0;
     uint32_t            total_n_meta         = 0;
     dart_op_type_t      op_type              = dart_in->op_type;
@@ -8816,23 +8253,7 @@ dart_perform_on_servers(index_hash_result_t **hash_result, int num_servers,
             server_call_count_g[srv_id] += 1;
             server_mem_usage_g[srv_id] = lookup_args[i].server_memory_consumption;
         }
-        // println("[CLIENT %d] (dart_perform_on_servers) %s on %d servers and get %d results, time : "
-        //         "%.4f ms. server_time_elapsed: %.4f ms",
-        //         pdc_client_mpi_rank_g, is_index_write_op(op_type) ? "write dart index" : "read dart index",
-        //         num_servers, total_n_meta, timer_delta_ms(&timer), total_server_elapsed / 1000.0);
-        // if (memory_debug_g == 0) {
-        //     for (int i = 0; i < num_servers; i++) {
-        //         println("[SERVER %d] memory_usage: %" PRId64 "", i,
-        //         lookup_args[i].server_memory_consumption);
-        //     }
-        // }
     }
-
-    // println("[CLIENT %d] (dart_perform_on_servers) %s on %d servers and get %d results, time : "
-    //         "%.4f ms. ",
-    //         pdc_client_mpi_rank_g, is_index_write_op(op_type) ? "write dart index" : "read dart index",
-    //         num_servers, total_n_meta, timer_delta_ms(&timer));
-    // free(dart_request_handles);
 done:
     FUNC_LEAVE(ret_value);
 }
@@ -8850,9 +8271,9 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
     stopwatch_t timer;
     timer_start(&timer);
 
-    char *         k_query = get_key(query_string, '=');
-    char *         v_query = get_value(query_string, '=');
-    char *         tok     = NULL;
+    char          *k_query = get_key(query_string, '=');
+    char          *v_query = get_value(query_string, '=');
+    char          *tok     = NULL;
     dart_op_type_t dart_op;
 
     dart_determine_query_token_by_key_query(k_query, &tok, &dart_op);
@@ -8910,23 +8331,18 @@ PDC_Client_search_obj_ref_through_dart(dart_hash_algo_t hash_algo, char *query_s
         for (i = 0; i < *n_res; i++) {
             (*out)[i] = set_arr[i][0];
         }
-        free(set_arr);
+        set_arr = (uint64_t **)PDC_free(set_arr);
     }
     set_free(result_set);
 
     // done:
-    free(k_query);
-    free(v_query);
+    k_query = (char *)PDC_free(k_query);
+    v_query = (char *)PDC_free(v_query);
 
     if (tok != NULL)
-        free(tok);
+        tok = (char *)PDC_free(tok);
 
     timer_pause(&timer);
-    // LOG_INFO("perform search [ %s ] on %d servers from rank %d, total_count %" PRIu64
-    //        ", n_res %d, duration: %.4f ms\n",
-    //        query_string, num_servers, pdc_client_mpi_rank_g, total_count, *n_res,
-    //        timer_delta_ms(&timer) / 1000.0);
-    // memory_debug_g = 1;
     return ret_value;
 }
 
@@ -9102,10 +8518,9 @@ PDC_Client_query_kvtag_col(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_
         else if (nmeta > 0) {
             *pdc_ids = (uint64_t *)realloc(*pdc_ids, sizeof(uint64_t) * (*n_res + nmeta));
             memcpy(*pdc_ids + (*n_res), temp_ids, nmeta * sizeof(uint64_t));
-            free(temp_ids);
+            temp_ids = (uint64_t *)PDC_free(temp_ids);
         }
-        *n_res = *n_res + nmeta;
-        /* LOG_INFO("==PDC_CLIENT[%d]: server %u returned %d res \n", pdc_client_mpi_rank_g, i, *n_res); */
+        *n_res      = *n_res + nmeta;
         *query_sent = 1;
     }
 
@@ -9139,17 +8554,17 @@ _standard_all_gather_result(int query_sent, int *n_res, uint64_t **pdc_ids, MPI_
         ntotal += all_nmeta_array[i];
     }
 
-    uint64_t *all_ids = (uint64_t *)malloc(ntotal * sizeof(uint64_t));
+    uint64_t *all_ids = (uint64_t *)PDC_malloc(ntotal * sizeof(uint64_t));
     MPI_Allgatherv(*pdc_ids, *n_res, MPI_UINT64_T, all_ids, all_nmeta_array, disp, MPI_UINT64_T, world_comm);
 
     if (*pdc_ids)
-        free(*pdc_ids);
+        *pdc_ids = (uint64_t *)PDC_free(*pdc_ids);
 
     *n_res   = ntotal;
     *pdc_ids = all_ids;
 
-    free(all_nmeta_array);
-    free(disp);
+    all_nmeta_array = (int *)PDC_free(all_nmeta_array);
+    disp            = (int *)PDC_free(disp);
 
     return;
 }
@@ -9219,7 +8634,7 @@ _customized_all_gather_result(int query_sent, int *n_res, uint64_t **pdc_ids, MP
     // Finally, let's gather all the results. Since each client is getting a partial result which can be of
     // different size, we need to use MPI_Allgatherv for gathering variable-size arrays from different
     // clients.
-    uint64_t *all_ids = (uint64_t *)malloc(ntotal * sizeof(uint64_t));
+    uint64_t *all_ids = (uint64_t *)PDC_malloc(ntotal * sizeof(uint64_t));
 
     MPI_Allgatherv(*pdc_ids, *n_res, MPI_UINT64_T, all_ids, all_nmeta, disp, MPI_UINT64_T, world_comm);
 
@@ -9259,13 +8674,6 @@ PDC_Client_query_kvtag_mpi(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_
         *n_res   = 0;
         *pdc_ids = NULL;
     }
-    else {
-        // print the pdc ids returned by this client, along with the client id
-        // LOG_INFO("==PDC_CLIENT == COLLECTIVE [%d]: ", pdc_client_mpi_rank_g);
-        // for (i = 0; i < *n_res; i++)
-        //     LOG_INFO("%llu ", (*pdc_ids)[i]);
-        // LOG_INFO("\n");
-    }
 
     if (pdc_client_mpi_size_g == 1) {
         goto done;
@@ -9286,11 +8694,11 @@ PDC_Client_query_kvtag_mpi(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_
     Set *result_set = set_new(ui64_hash, ui64_equal);
     set_register_free_function(result_set, free);
     for (i = 0; i < *n_res; i++) {
-        uint64_t *id = (uint64_t *)malloc(sizeof(uint64_t));
+        uint64_t *id = (uint64_t *)PDC_malloc(sizeof(uint64_t));
         *id          = (*pdc_ids)[i];
         set_insert(result_set, id);
     }
-    free(*pdc_ids);
+    *pdc_ids = (uint64_t *)PDC_free(*pdc_ids);
     // Pick deduplicated result.
     *n_res = set_num_entries(result_set);
     // println("num_ids = %d", num_ids);
@@ -9300,17 +8708,9 @@ PDC_Client_query_kvtag_mpi(const pdc_kvtag_t *kvtag, int *n_res, uint64_t **pdc_
         for (i = 0; i < *n_res; i++) {
             (*pdc_ids)[i] = set_arr[i][0];
         }
-        free(set_arr);
+        set_arr = (uint64_t **)PDC_free(set_arr);
     }
     set_free(result_set);
-
-    // print the pdc ids returned after gathering all the results
-    if (pdc_client_mpi_rank_g == 0) {
-        // LOG_INFO("==PDC_CLIENT == GATHERED [%d]: ", pdc_client_mpi_rank_g);
-        // for (i = 0; i < *n_res; i++)
-        //     LOG_INFO("%llu ", (*pdc_ids)[i]);
-        // LOG_INFO("\n");
-    }
 
 done:
     fflush(stdout);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -1381,7 +1381,6 @@ PDC_Client_mercury_init(hg_class_t **hg_class, hg_context_t **hg_context, int po
     }
     memset(hostname, 0, sizeof(hostname));
     gethostname(hostname, sizeof(hostname));
-    strcpy(hostname, "eno1");
     sprintf(na_info_string, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_client_mpi_rank_g == 0) {
         LOG_INFO("==PDC_CLIENT: using %.7s\n", na_info_string);
@@ -7757,7 +7756,6 @@ PDC_Client_get_sel_data(pdcid_t obj_id, pdc_selection_t *sel, void *data)
                     memcpy(data + off, result_elt->data_arr[i], result_elt->data_arr_size[i]);
                     off += result_elt->data_arr_size[i];
                     result_elt->data_arr[i] = (void **)PDC_free(result_elt->data_arr[i]);
-                    result_elt->data_arr[i] = NULL;
                 }
             }
             result_elt->recv_data_nhits = 0;

--- a/src/api/pdc_meta/pdc_metadata_client.c
+++ b/src/api/pdc_meta/pdc_metadata_client.c
@@ -38,7 +38,7 @@ void
 splitExpression(const char *expression, char conditions[][CONDITION_LENGTH], int *count)
 {
     char       tempExpr[1024];
-    char      *token;
+    char *     token;
     const char delimiters[] = "AND OR";
     int        index        = 0;
 

--- a/src/api/pdc_meta/pdc_metadata_client.c
+++ b/src/api/pdc_meta/pdc_metadata_client.c
@@ -38,7 +38,7 @@ void
 splitExpression(const char *expression, char conditions[][CONDITION_LENGTH], int *count)
 {
     char       tempExpr[1024];
-    char *     token;
+    char      *token;
     const char delimiters[] = "AND OR";
     int        index        = 0;
 
@@ -74,7 +74,7 @@ send_query_condition_get_separate_result(char conditions[][CONDITION_LENGTH], in
         LOG_INFO("No conditions to send\n");
         return;
     }
-    *result = (separate_query_result_t *)malloc(conditionCount * sizeof(separate_query_result_t));
+    *result = (separate_query_result_t *)PDC_malloc(conditionCount * sizeof(separate_query_result_t));
     for (int i = 0; i < conditionCount; i++) {
         // Send each condition to a separate server for execution
         // The server will execute the condition and return the result to the client
@@ -110,7 +110,7 @@ query_execution_and_local_merge(char conditions[][CONDITION_LENGTH], int conditi
     // step 2: merge the results from all servers
     for (int i = 0; i < conditionCount; i++) {
         if (separate_result[i].n_res > 0) {
-            *object_id_list = (uint64_t *)malloc(separate_result[i].n_res * sizeof(uint64_t));
+            *object_id_list = (uint64_t *)PDC_malloc(separate_result[i].n_res * sizeof(uint64_t));
             memcpy(*object_id_list, separate_result[i].out, separate_result[i].n_res * sizeof(uint64_t));
             *count = separate_result[i].n_res;
             break;
@@ -137,7 +137,7 @@ PDC_metadata_multi_condition_query(char *queryString, int isCollective, uint64_t
     // TODO: implement the above strategy
 
     // For now, we just return a dummy object ID list
-    *object_id_list = (uint64_t *)malloc(10 * sizeof(uint64_t));
+    *object_id_list = (uint64_t *)PDC_malloc(10 * sizeof(uint64_t));
     for (int i = 0; i < 10; i++) {
         (*object_id_list)[i] = i;
     }

--- a/src/api/pdc_obj/include/pdc_obj.h
+++ b/src/api/pdc_obj/include/pdc_obj.h
@@ -227,7 +227,7 @@ perr_t PDCprop_set_obj_tags(pdcid_t obj_prop, char *tags);
  * Set object dimension
  *
  * \param obj_prop [IN]         ID of object property, returned by PDCprop_create(PDC_OBJ_CREATE)
- * \param ndim [IN]             Number of dimensions
+ * \param ndim [IN]             Number of dimensions, must be greater than 0
  * \param dims [IN]             Size of each dimension, positive value, can be PDC_SIZE_UNLIMITED
  *
  * \return Non-negative on success/Negative on failure

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -57,7 +57,7 @@ PDCcont_create(const char *cont_name, pdcid_t cont_prop_id)
     perr_t                 ret       = SUCCEED;
     struct _pdc_cont_info *p         = NULL;
     struct _pdc_cont_prop *cont_prop = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -106,7 +106,7 @@ PDCcont_create_col(const char *cont_name, pdcid_t cont_prop_id)
     perr_t                 ret       = SUCCEED;
     struct _pdc_cont_info *p         = NULL;
     struct _pdc_cont_prop *cont_prop = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -152,7 +152,7 @@ PDC_cont_create_local(pdcid_t pdc, const char *cont_name, uint64_t cont_meta_id)
     pdcid_t                ret_value = 0;
     struct _pdc_cont_info *p         = NULL;
     struct _pdc_cont_prop *cont_prop = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
     pdcid_t                cont_prop_id;
 
     FUNC_ENTER(NULL);
@@ -312,7 +312,7 @@ PDC_cont_get_info(pdcid_t cont_id)
 {
     struct _pdc_cont_info *ret_value = NULL;
     struct _pdc_cont_info *info      = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -356,7 +356,7 @@ done:
 struct pdc_cont_info *
 PDCcont_get_info(const char *cont_name)
 {
-    struct pdc_cont_info  *ret_value = NULL;
+    struct pdc_cont_info * ret_value = NULL;
     struct _pdc_cont_info *tmp       = NULL;
     pdcid_t                cont_id;
 
@@ -380,8 +380,8 @@ done:
 cont_handle *
 PDCcont_iter_start()
 {
-    cont_handle        *ret_value = NULL;
-    cont_handle        *conthl    = NULL;
+    cont_handle *       ret_value = NULL;
+    cont_handle *       conthl    = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -431,7 +431,7 @@ done:
 struct pdc_cont_info *
 PDCcont_iter_get_info(cont_handle *chandle)
 {
-    struct pdc_cont_info  *ret_value = NULL;
+    struct pdc_cont_info * ret_value = NULL;
     struct _pdc_cont_info *info      = NULL;
 
     FUNC_ENTER(NULL);

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -57,7 +57,7 @@ PDCcont_create(const char *cont_name, pdcid_t cont_prop_id)
     perr_t                 ret       = SUCCEED;
     struct _pdc_cont_info *p         = NULL;
     struct _pdc_cont_prop *cont_prop = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -106,7 +106,7 @@ PDCcont_create_col(const char *cont_name, pdcid_t cont_prop_id)
     perr_t                 ret       = SUCCEED;
     struct _pdc_cont_info *p         = NULL;
     struct _pdc_cont_prop *cont_prop = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -152,7 +152,7 @@ PDC_cont_create_local(pdcid_t pdc, const char *cont_name, uint64_t cont_meta_id)
     pdcid_t                ret_value = 0;
     struct _pdc_cont_info *p         = NULL;
     struct _pdc_cont_prop *cont_prop = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
     pdcid_t                cont_prop_id;
 
     FUNC_ENTER(NULL);
@@ -221,12 +221,12 @@ PDC_cont_close(struct _pdc_cont_info *cp)
 
     FUNC_ENTER(NULL);
 
-    free((void *)(cp->cont_info_pub->name));
-    cp->cont_info_pub = (struct pdc_cont_info *)(intptr_t)PDC_free(cp->cont_info_pub);
-    free(cp->cont_pt->pdc->name);
-    cp->cont_pt->pdc = (struct _pdc_class *)(intptr_t)PDC_free(cp->cont_pt->pdc);
-    cp->cont_pt      = (struct _pdc_cont_prop *)(intptr_t)PDC_free(cp->cont_pt);
-    cp               = (struct _pdc_cont_info *)(intptr_t)PDC_free(cp);
+    cp->cont_info_pub->name = (char *)PDC_free((void *)(cp->cont_info_pub->name));
+    cp->cont_info_pub       = (struct pdc_cont_info *)(intptr_t)PDC_free(cp->cont_info_pub);
+    cp->cont_pt->pdc->name  = (char *)PDC_free(cp->cont_pt->pdc->name);
+    cp->cont_pt->pdc        = (struct _pdc_class *)(intptr_t)PDC_free(cp->cont_pt->pdc);
+    cp->cont_pt             = (struct _pdc_cont_prop *)(intptr_t)PDC_free(cp->cont_pt);
+    cp                      = (struct _pdc_cont_info *)(intptr_t)PDC_free(cp);
 
     FUNC_LEAVE(ret_value);
 }
@@ -312,7 +312,7 @@ PDC_cont_get_info(pdcid_t cont_id)
 {
     struct _pdc_cont_info *ret_value = NULL;
     struct _pdc_cont_info *info      = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -356,7 +356,7 @@ done:
 struct pdc_cont_info *
 PDCcont_get_info(const char *cont_name)
 {
-    struct pdc_cont_info * ret_value = NULL;
+    struct pdc_cont_info  *ret_value = NULL;
     struct _pdc_cont_info *tmp       = NULL;
     pdcid_t                cont_id;
 
@@ -380,8 +380,8 @@ done:
 cont_handle *
 PDCcont_iter_start()
 {
-    cont_handle *       ret_value = NULL;
-    cont_handle *       conthl    = NULL;
+    cont_handle        *ret_value = NULL;
+    cont_handle        *conthl    = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -431,7 +431,7 @@ done:
 struct pdc_cont_info *
 PDCcont_iter_get_info(cont_handle *chandle)
 {
-    struct pdc_cont_info * ret_value = NULL;
+    struct pdc_cont_info  *ret_value = NULL;
     struct _pdc_cont_info *info      = NULL;
 
     FUNC_ENTER(NULL);

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -119,10 +119,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info  *p         = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_obj_info * p         = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop  *obj_prop;
+    struct _pdc_obj_prop * obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -283,7 +283,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t                    *transfer_request_id;
+    pdcid_t *                   transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -419,12 +419,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t       *out       = NULL;
+    pdc_metadata_t *      out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle           *oh;
-    struct pdc_obj_info  *info;
+    obj_handle *          oh;
+    struct pdc_obj_info * info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -568,8 +568,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle         *ret_value = NULL;
-    obj_handle         *objhl     = NULL;
+    obj_handle *        ret_value = NULL;
+    obj_handle *        objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -631,7 +631,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -767,7 +767,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -796,7 +796,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -816,7 +816,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -836,7 +836,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -856,7 +856,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -876,7 +876,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -914,7 +914,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -933,10 +933,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void                **ret_value = NULL;
-    struct _pdc_id_info  *info;
+    void **               ret_value = NULL;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
-    void                **buffer;
+    void **               buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -956,7 +956,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info  *obj;
+    struct _pdc_id_info * obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1138,7 +1138,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -119,10 +119,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info * p         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_obj_info  *p         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop * obj_prop;
+    struct _pdc_obj_prop  *obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -204,7 +204,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
     p->obj_pt->obj_prop_pub->ndim = obj_prop->obj_prop_pub->ndim;
     LOG_INFO("ATTEMPTING TO ALLOCATE NDIM: %d\n", obj_prop->obj_prop_pub->ndim);
     p->obj_pt->obj_prop_pub->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (obj_prop->obj_prop_pub->ndim != 0 && !p->obj_pt->obj_prop_pub->dims)
+    if (!p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->dims");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
         p->obj_pt->obj_prop_pub->dims[i] = obj_prop->obj_prop_pub->dims[i];
@@ -247,7 +247,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     p->obj_info_pub->obj_pt->ndim = obj_prop->obj_prop_pub->ndim;
     p->obj_info_pub->obj_pt->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (obj_prop->obj_prop_pub->ndim != 0 && !p->obj_info_pub->obj_pt->dims)
+    if (!p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
         p->obj_info_pub->obj_pt->dims[i] = obj_prop->obj_prop_pub->dims[i];
@@ -283,7 +283,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t *                   transfer_request_id;
+    pdcid_t                    *transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -419,12 +419,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t *      out       = NULL;
+    pdc_metadata_t       *out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle *          oh;
-    struct pdc_obj_info * info;
+    obj_handle           *oh;
+    struct pdc_obj_info  *info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -493,7 +493,7 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     p->cont->cont_info_pub->meta_id = out->cont_id;
     p->obj_pt->obj_prop_pub->ndim   = out->ndim;
     p->obj_pt->obj_prop_pub->dims   = PDC_malloc(out->ndim * sizeof(uint64_t));
-    if (p->obj_pt->obj_prop_pub->ndim != 0 && !p->obj_pt->obj_prop_pub->dims)
+    if (!p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_prop_pub->dims");
 
     for (i = 0; i < out->ndim; i++)
@@ -531,7 +531,7 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
 
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     p->obj_info_pub->obj_pt->dims = PDC_malloc(p->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (p->obj_pt->obj_prop_pub->ndim != 0 && !p->obj_info_pub->obj_pt->dims)
+    if (!p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < p->obj_pt->obj_prop_pub->ndim; i++)
         p->obj_info_pub->obj_pt->dims[i] = p->obj_pt->obj_prop_pub->dims[i];
@@ -568,8 +568,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle *        ret_value = NULL;
-    obj_handle *        objhl     = NULL;
+    obj_handle         *ret_value = NULL;
+    obj_handle         *objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -631,7 +631,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -651,7 +651,7 @@ PDCobj_iter_get_info(obj_handle *ohandle)
         PGOTO_ERROR(NULL, "failed to allocate memory");
     memcpy(ret_value->obj_pt, info->obj_info_pub->obj_pt, sizeof(struct pdc_obj_prop));
     ret_value->obj_pt->dims = PDC_malloc(ret_value->obj_pt->ndim * sizeof(uint64_t));
-    if (ret_value->obj_pt->ndim != 0 && !ret_value->obj_pt->dims)
+    if (!ret_value->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < ret_value->obj_pt->ndim; i++)
         ret_value->obj_pt->dims[i] = info->obj_info_pub->obj_pt->dims[i];
@@ -767,14 +767,17 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
 
+    if (ndim <= 0)
+        PGOTO_ERROR(FAIL, "Invalid ndim size: %d", ndim);
+
     info = PDC_find_id(obj_prop);
     if (info == NULL)
-        PGOTO_ERROR(FAIL, "cannot locate object property ID");
+        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
     prop = (struct _pdc_obj_prop *)(info->obj_ptr);
     if (ndim > (PDC_int_t)prop->obj_prop_pub->ndim) {
         if (prop->obj_prop_pub->ndim > 0)
@@ -793,7 +796,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -813,7 +816,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -833,7 +836,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -853,7 +856,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -873,7 +876,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -911,7 +914,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -930,10 +933,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void **               ret_value = NULL;
-    struct _pdc_id_info * info;
+    void                **ret_value = NULL;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
-    void **               buffer;
+    void                **buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -953,7 +956,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info * obj;
+    struct _pdc_id_info  *obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -986,7 +989,7 @@ PDC_obj_get_info(pdcid_t obj_id)
     memcpy(ret_value->obj_info_pub->obj_pt, info->obj_info_pub->obj_pt, sizeof(struct pdc_obj_prop));
     ret_value->obj_info_pub->obj_pt->dims =
         PDC_malloc(ret_value->obj_info_pub->obj_pt->ndim * sizeof(uint64_t));
-    if (ret_value->obj_info_pub->obj_pt->ndim != 0 && !ret_value->obj_info_pub->obj_pt->dims)
+    if (!ret_value->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < ret_value->obj_info_pub->obj_pt->ndim; i++)
         ret_value->obj_info_pub->obj_pt->dims[i] = info->obj_info_pub->obj_pt->dims[i];
@@ -1135,7 +1138,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -202,7 +202,6 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
     if (!p->obj_pt->obj_prop_pub)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_pt->obj_prop_pub");
     p->obj_pt->obj_prop_pub->ndim = obj_prop->obj_prop_pub->ndim;
-    LOG_INFO("ATTEMPTING TO ALLOCATE NDIM: %d\n", obj_prop->obj_prop_pub->ndim);
     p->obj_pt->obj_prop_pub->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
     if (!p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->dims");

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -229,10 +229,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info  *p         = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_obj_info * p         = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop  *obj_prop;
+    struct _pdc_obj_prop * obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -392,7 +392,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t                    *transfer_request_id;
+    pdcid_t *                   transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -528,12 +528,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t       *out       = NULL;
+    pdc_metadata_t *      out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle           *oh;
-    struct pdc_obj_info  *info;
+    obj_handle *          oh;
+    struct pdc_obj_info * info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -680,8 +680,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle         *ret_value = NULL;
-    obj_handle         *objhl     = NULL;
+    obj_handle *        ret_value = NULL;
+    obj_handle *        objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -743,7 +743,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -879,7 +879,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -905,7 +905,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -925,7 +925,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -945,7 +945,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -965,7 +965,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -985,7 +985,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -1023,7 +1023,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -1042,10 +1042,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void                **ret_value = NULL;
-    struct _pdc_id_info  *info;
+    void **               ret_value = NULL;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
-    void                **buffer;
+    void **               buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -1065,7 +1065,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info  *obj;
+    struct _pdc_id_info * obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1244,7 +1244,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -229,10 +229,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info * p         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_obj_info  *p         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop * obj_prop;
+    struct _pdc_obj_prop  *obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -392,54 +392,51 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t *                   transfer_request_id;
+    pdcid_t                    *transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
     FUNC_ENTER(NULL);
 
     if (op->local_transfer_request_size) {
-        transfer_request_id = (pdcid_t *)malloc(sizeof(pdcid_t) * op->local_transfer_request_size);
+        transfer_request_id = (pdcid_t *)PDC_malloc(sizeof(pdcid_t) * op->local_transfer_request_size);
         temp                = op->local_transfer_request_head;
         n                   = 0;
         while (temp != NULL) {
             transfer_request_id[n] = temp->local_id;
             previous               = temp;
             temp                   = temp->next;
-            free(previous);
+            previous               = (pdc_local_transfer_request *)PDC_free(previous);
             ++n;
         }
         PDCregion_transfer_wait_all(transfer_request_id, n);
         for (i = 0; i < n; ++i) {
             PDCregion_transfer_close(transfer_request_id[i]);
         }
-        free(transfer_request_id);
+        transfer_request_id = (pdcid_t *)PDC_free(transfer_request_id);
     }
 
-    free((void *)(op->obj_info_pub->name));
-    free(op->cont->cont_info_pub->name);
-    op->cont->cont_info_pub = (struct pdc_cont_info *)(intptr_t)PDC_free(op->cont->cont_info_pub);
-    free(op->cont->cont_pt->pdc->name);
-    op->cont->cont_pt->pdc = (struct _pdc_class *)(intptr_t)PDC_free(op->cont->cont_pt->pdc);
-    op->cont->cont_pt      = (struct _pdc_cont_prop *)(intptr_t)PDC_free(op->cont->cont_pt);
-    op->cont               = (struct _pdc_cont_info *)(intptr_t)PDC_free(op->cont);
-
-    free(op->obj_pt->pdc->name);
-    op->obj_pt->pdc = (struct _pdc_class *)(intptr_t)PDC_free(op->obj_pt->pdc);
-    free(op->obj_pt->obj_prop_pub->dims);
-    op->obj_pt->obj_prop_pub = (struct pdc_obj_prop *)(intptr_t)PDC_free(op->obj_pt->obj_prop_pub);
-    free(op->obj_pt->app_name);
-    free(op->obj_pt->data_loc);
-    free(op->obj_pt->tags);
-    op->obj_pt = (struct _pdc_obj_prop *)(intptr_t)PDC_free(op->obj_pt);
+    op->obj_info_pub->name         = (char *)PDC_free((void *)(op->obj_info_pub->name));
+    op->cont->cont_info_pub->name  = (char *)PDC_free(op->cont->cont_info_pub->name);
+    op->cont->cont_info_pub        = (struct pdc_cont_info *)(intptr_t)PDC_free(op->cont->cont_info_pub);
+    op->cont->cont_pt->pdc->name   = (char *)PDC_free(op->cont->cont_pt->pdc->name);
+    op->cont->cont_pt->pdc         = (struct _pdc_class *)(intptr_t)PDC_free(op->cont->cont_pt->pdc);
+    op->cont->cont_pt              = (struct _pdc_cont_prop *)(intptr_t)PDC_free(op->cont->cont_pt);
+    op->cont                       = (struct _pdc_cont_info *)(intptr_t)PDC_free(op->cont);
+    op->obj_pt->pdc->name          = (char *)PDC_free(op->obj_pt->pdc->name);
+    op->obj_pt->pdc                = (struct _pdc_class *)(intptr_t)PDC_free(op->obj_pt->pdc);
+    op->obj_pt->obj_prop_pub->dims = (uint64_t *)PDC_free(op->obj_pt->obj_prop_pub->dims);
+    op->obj_pt->obj_prop_pub       = (struct pdc_obj_prop *)(intptr_t)PDC_free(op->obj_pt->obj_prop_pub);
+    op->obj_pt->app_name           = (char *)PDC_free(op->obj_pt->app_name);
+    op->obj_pt->data_loc           = (char *)PDC_free(op->obj_pt->data_loc);
+    op->obj_pt->tags               = (char *)PDC_free(op->obj_pt->tags);
+    op->obj_pt                     = (struct _pdc_obj_prop *)(intptr_t)PDC_free(op->obj_pt);
     if (op->metadata != NULL)
-        free(op->metadata);
-
-    free(op->obj_info_pub->obj_pt->dims);
-    op->obj_info_pub->obj_pt = (struct pdc_obj_prop *)(intptr_t)PDC_free(op->obj_info_pub->obj_pt);
-    op->obj_info_pub         = (struct pdc_obj_info *)(intptr_t)PDC_free(op->obj_info_pub);
-
-    op = (struct _pdc_obj_info *)(intptr_t)PDC_free(op);
+        op->metadata = (void *)PDC_free(op->metadata);
+    op->obj_info_pub->obj_pt->dims = (uint64_t *)PDC_free(op->obj_info_pub->obj_pt->dims);
+    op->obj_info_pub->obj_pt       = (struct pdc_obj_prop *)(intptr_t)PDC_free(op->obj_info_pub->obj_pt);
+    op->obj_info_pub               = (struct pdc_obj_info *)(intptr_t)PDC_free(op->obj_info_pub);
+    op                             = (struct _pdc_obj_info *)(intptr_t)PDC_free(op);
 
     FUNC_LEAVE(ret_value);
 }
@@ -531,12 +528,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t *      out       = NULL;
+    pdc_metadata_t       *out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle *          oh;
-    struct pdc_obj_info * info;
+    obj_handle           *oh;
+    struct pdc_obj_info  *info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -683,8 +680,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle *        ret_value = NULL;
-    obj_handle *        objhl     = NULL;
+    obj_handle         *ret_value = NULL;
+    obj_handle         *objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -746,7 +743,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -806,7 +803,8 @@ PDCprop_set_obj_app_name(pdcid_t obj_prop, char *app_name)
     if (info == NULL)
         PGOTO_ERROR(FAIL, "cannot locate object property ID");
     if (((struct _pdc_obj_prop *)(info->obj_ptr))->app_name != NULL) {
-        free(((struct _pdc_obj_prop *)(info->obj_ptr))->app_name);
+        ((struct _pdc_obj_prop *)(info->obj_ptr))->app_name =
+            (char *)PDC_free(((struct _pdc_obj_prop *)(info->obj_ptr))->app_name);
     }
     ((struct _pdc_obj_prop *)(info->obj_ptr))->app_name = strdup(app_name);
 
@@ -845,7 +843,8 @@ PDCprop_set_obj_data_loc(pdcid_t obj_prop, char *loc)
     if (info == NULL)
         PGOTO_ERROR(FAIL, "cannot locate object property ID");
     if (((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc != NULL) {
-        free(((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc);
+        ((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc =
+            (char *)PDC_free(((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc);
     }
     ((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc = strdup(loc);
 
@@ -866,7 +865,8 @@ PDCprop_set_obj_tags(pdcid_t obj_prop, char *tags)
     if (info == NULL)
         PGOTO_ERROR(FAIL, "cannot locate object property ID");
     if (((struct _pdc_obj_prop *)(info->obj_ptr))->tags != NULL) {
-        free(((struct _pdc_obj_prop *)(info->obj_ptr))->tags);
+        ((struct _pdc_obj_prop *)(info->obj_ptr))->tags =
+            (char *)PDC_free(((struct _pdc_obj_prop *)(info->obj_ptr))->tags);
     }
     ((struct _pdc_obj_prop *)(info->obj_ptr))->tags = strdup(tags);
 
@@ -879,7 +879,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -889,10 +889,9 @@ PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
         PGOTO_ERROR(FAIL, "cannot locate object property ID");
     prop = (struct _pdc_obj_prop *)(info->obj_ptr);
     if (ndim > (PDC_int_t)prop->obj_prop_pub->ndim) {
-        if (prop->obj_prop_pub->ndim > 0) {
-            free(prop->obj_prop_pub->dims);
-        }
-        prop->obj_prop_pub->dims = (uint64_t *)malloc(ndim * sizeof(uint64_t));
+        if (prop->obj_prop_pub->ndim > 0)
+            prop->obj_prop_pub->dims = (uint64_t *)PDC_free(prop->obj_prop_pub->dims);
+        prop->obj_prop_pub->dims = (uint64_t *)PDC_malloc(ndim * sizeof(uint64_t));
         prop->obj_prop_pub->ndim = ndim;
     }
     memcpy(prop->obj_prop_pub->dims, dims, ndim * sizeof(uint64_t));
@@ -906,7 +905,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -926,7 +925,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -946,7 +945,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -966,7 +965,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -986,7 +985,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -1024,7 +1023,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -1034,7 +1033,7 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
     }
     object = (struct _pdc_obj_info *)(info->obj_ptr);
     *ndim  = object->obj_pt->obj_prop_pub->ndim;
-    *dims  = (uint64_t *)malloc(sizeof(uint64_t) * ndim[0]);
+    *dims  = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim[0]);
     memcpy(*dims, object->obj_pt->obj_prop_pub->dims, sizeof(uint64_t) * ndim[0]);
 
     FUNC_LEAVE(ret_value);
@@ -1043,10 +1042,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void **               ret_value = NULL;
-    struct _pdc_id_info * info;
+    void                **ret_value = NULL;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
-    void **               buffer;
+    void                **buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -1066,7 +1065,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info * obj;
+    struct _pdc_id_info  *obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1199,18 +1198,18 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
     assert(obj);
 
     if (obj->obj_info_pub->name != NULL)
-        free(obj->obj_info_pub->name);
+        obj->obj_info_pub->name = (char *)PDC_free(obj->obj_info_pub->name);
     obj->obj_info_pub = (struct pdc_obj_info *)(intptr_t)PDC_free(obj->obj_info_pub);
 
     if (obj->metadata != NULL)
-        free(obj->metadata);
+        obj->metadata = (void *)PDC_free(obj->metadata);
 
     if (obj->cont != NULL) {
         if (obj->cont->cont_info_pub->name != NULL)
-            free(obj->cont->cont_info_pub->name);
+            obj->cont->cont_info_pub->name = (char *)PDC_free(obj->cont->cont_info_pub->name);
         obj->cont->cont_info_pub = (struct pdc_cont_info *)(intptr_t)PDC_free(obj->cont->cont_info_pub);
         if (obj->cont->cont_pt->pdc->name != NULL)
-            free(obj->cont->cont_pt->pdc->name);
+            obj->cont->cont_pt->pdc->name = (char *)PDC_free(obj->cont->cont_pt->pdc->name);
         obj->cont->cont_pt->pdc = (struct _pdc_class *)(intptr_t)PDC_free(obj->cont->cont_pt->pdc);
         obj->cont->cont_pt      = (struct _pdc_cont_prop *)(intptr_t)PDC_free(obj->cont->cont_pt);
         obj->cont               = (struct _pdc_cont_info *)(intptr_t)PDC_free(obj->cont);
@@ -1219,23 +1218,23 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
     if (obj->obj_pt != NULL) {
         if (obj->obj_pt->pdc != NULL) {
             if (obj->obj_pt->pdc->name != NULL)
-                free(obj->obj_pt->pdc->name);
+                obj->obj_pt->pdc->name = (char *)PDC_free(obj->obj_pt->pdc->name);
             obj->obj_pt->pdc = (struct _pdc_class *)(intptr_t)PDC_free(obj->obj_pt->pdc);
         }
         if (obj->obj_pt->obj_prop_pub->dims != NULL)
-            free(obj->obj_pt->obj_prop_pub->dims);
+            obj->obj_pt->obj_prop_pub->dims = (uint64_t *)PDC_free(obj->obj_pt->obj_prop_pub->dims);
         obj->obj_pt->obj_prop_pub = (struct pdc_obj_prop *)(intptr_t)PDC_free(obj->obj_pt->obj_prop_pub);
         if (obj->obj_pt->app_name != NULL)
-            free(obj->obj_pt->app_name);
+            obj->obj_pt->app_name = (char *)PDC_free(obj->obj_pt->app_name);
         if (obj->obj_pt->data_loc != NULL)
-            free(obj->obj_pt->data_loc);
+            obj->obj_pt->data_loc = (char *)PDC_free(obj->obj_pt->data_loc);
         if (obj->obj_pt->tags != NULL)
-            free(obj->obj_pt->tags);
+            obj->obj_pt->tags = (char *)PDC_free(obj->obj_pt->tags);
         obj->obj_pt = (struct _pdc_obj_prop *)(intptr_t)PDC_free(obj->obj_pt);
     }
 
     if (obj->region_list_head != NULL)
-        free(obj->region_list_head);
+        obj->region_list_head = (struct region_map_list *)PDC_free(obj->region_list_head);
 
     obj = (struct _pdc_obj_info *)(intptr_t)PDC_free(obj);
 
@@ -1245,7 +1244,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -200,7 +200,7 @@ PDC_Client_attach_metadata_to_local_obj(const char *obj_name, uint64_t obj_id, u
 
     FUNC_ENTER(NULL);
 
-    obj_info->metadata                              = (pdc_metadata_t *)calloc(1, sizeof(pdc_metadata_t));
+    obj_info->metadata                              = (pdc_metadata_t *)PDC_calloc(1, sizeof(pdc_metadata_t));
     ((pdc_metadata_t *)obj_info->metadata)->user_id = obj_info->obj_pt->user_id;
     if (NULL != obj_info->obj_pt->app_name)
         strcpy(((pdc_metadata_t *)obj_info->metadata)->app_name, obj_info->obj_pt->app_name);

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -61,119 +61,9 @@ done:
 pdcid_t
 PDCobj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id)
 {
-#if 0
-    uint64_t               meta_id;
-    struct _pdc_cont_info *cont_info;
-    struct _pdc_obj_prop * obj_prop;
-    struct _pdc_obj_info * p       = NULL;
-    struct _pdc_id_info *  id_info = NULL;
-    perr_t                 ret;
-    size_t                 i;
-#endif
     pdcid_t ret_value = 0;
     FUNC_ENTER(NULL);
-#if 0
-    p = (struct _pdc_obj_info *)PDC_malloc(sizeof(struct _pdc_obj_info));
-    if (!p)
-        PGOTO_ERROR(0, "PDC object memory allocation failed");
-    p->metadata         = NULL;
-    p->region_list_head = NULL;
-
-    if (cont_id == 0) {
-        meta_id = 0;
-    }
-    else {
-        id_info   = PDC_find_id(cont_id);
-        cont_info = (struct _pdc_cont_info *)(id_info->obj_ptr);
-
-        /* struct _pdc_cont_info field */
-        p->cont = (struct _pdc_cont_info *)PDC_calloc(1, sizeof(struct _pdc_cont_info));
-        if (!p->cont)
-            PGOTO_ERROR(0, "PDC object container memory allocation failed");
-        memcpy(p->cont, cont_info, sizeof(struct _pdc_cont_info));
-
-        p->cont->cont_info_pub = (struct pdc_cont_info *)PDC_calloc(1, sizeof(struct pdc_cont_info));
-        if (!p->cont->cont_info_pub)
-            PGOTO_ERROR(0, "PDC object pub container memory allocation failed");
-        memcpy(p->cont->cont_info_pub, cont_info->cont_info_pub, sizeof(struct pdc_cont_info));
-        if (cont_info->cont_info_pub->name)
-            p->cont->cont_info_pub->name = strdup(cont_info->cont_info_pub->name);
-
-        p->cont->cont_pt = (struct _pdc_cont_prop *)PDC_calloc(1, sizeof(struct _pdc_cont_prop));
-        if (!p->cont->cont_pt)
-            PGOTO_ERROR(0, "PDC object container property memory allocation failed");
-        memcpy(p->cont->cont_pt, cont_info->cont_pt, sizeof(struct _pdc_cont_prop));
-
-        p->cont->cont_pt->pdc = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
-        if (!p->cont->cont_pt->pdc)
-            PGOTO_ERROR(0, "PDC object container property pdc memory allocation failed");
-        p->cont->cont_pt->pdc->name     = strdup(cont_info->cont_pt->pdc->name);
-        p->cont->cont_pt->pdc->local_id = cont_info->cont_pt->pdc->local_id;
-        meta_id                         = p->cont->cont_info_pub->meta_id;
-    }
-
-    id_info  = PDC_find_id(obj_prop_id);
-    obj_prop = (struct _pdc_obj_prop *)(id_info->obj_ptr);
-
-    /* struct _pdc_obj_prop field */
-    p->obj_pt = (struct _pdc_obj_prop *)PDC_calloc(1, sizeof(struct _pdc_obj_prop));
-    if (!p->obj_pt)
-        PGOTO_ERROR(0, "PDC object property memory allocation failed");
-    memcpy(p->obj_pt, obj_prop, sizeof(struct _pdc_obj_prop));
-    if (obj_prop->app_name)
-        p->obj_pt->app_name = strdup(obj_prop->app_name);
-    p->obj_pt->pdc = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
-    if (!p->obj_pt->pdc)
-        PGOTO_ERROR(0, "cannot allocate ret_value->pdc");
-    p->obj_pt->pdc->name     = strdup(obj_prop->pdc->name);
-    p->obj_pt->pdc->local_id = obj_prop->pdc->local_id;
-
-    /* struct pdc_obj_prop field */
-    p->obj_pt->obj_prop_pub = (struct pdc_obj_prop *)PDC_calloc(1, sizeof(struct pdc_obj_prop));
-    if (!p->obj_pt->obj_prop_pub)
-        PGOTO_ERROR(0, "cannot allocate ret_value->obj_pt->obj_prop_pub");
-    p->obj_pt->obj_prop_pub->ndim = obj_prop->obj_prop_pub->ndim;
-    p->obj_pt->obj_prop_pub->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (!p->obj_pt->obj_prop_pub->dims)
-        PGOTO_ERROR(0, "cannot allocate ret_value->dims");
-    for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
-        p->obj_pt->obj_prop_pub->dims[i] = obj_prop->obj_prop_pub->dims[i];
-
-    p->obj_pt->obj_prop_pub->type = obj_prop->obj_prop_pub->type;
-    if (obj_prop->app_name)
-        p->obj_pt->app_name = strdup(obj_prop->app_name);
-    if (obj_prop->data_loc)
-        p->obj_pt->data_loc = strdup(obj_prop->data_loc);
-    if (obj_prop->tags)
-        p->obj_pt->tags = strdup(obj_prop->tags);
-
-    p->obj_info_pub = (struct pdc_obj_info *)PDC_malloc(sizeof(struct pdc_obj_info));
-    if (!p->obj_info_pub)
-        PGOTO_ERROR(0, "PDC pub object memory allocation failed");
-    p->obj_info_pub->name      = strdup(obj_name);
-    p->obj_info_pub->server_id = 0;
-    p->obj_info_pub->local_id  = PDC_id_register(PDC_OBJ, p);
-    ret = PDC_Client_send_name_recv_id(obj_name, meta_id, obj_prop_id, &(p->obj_info_pub->meta_id));
-    if (ret == FAIL)
-        PGOTO_ERROR(0, "Unable to create object on server!");
-
-    p->obj_info_pub->obj_pt = (struct pdc_obj_prop *)PDC_calloc(1, sizeof(struct pdc_obj_prop));
-    if (!p->obj_info_pub->obj_pt)
-        PGOTO_ERROR(0, "PDC object prop memory allocation failed");
-    memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
-    p->obj_info_pub->obj_pt->ndim = obj_prop->obj_prop_pub->ndim;
-    p->obj_info_pub->obj_pt->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (!p->obj_info_pub->obj_pt->dims)
-        PGOTO_ERROR(0, "failed to allocate obj pub property memory");
-    for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
-        p->obj_info_pub->obj_pt->dims[i] = obj_prop->obj_prop_pub->dims[i];
-
-    // PDC_Client_attach_metadata_to_local_obj((char *)obj_name, p->meta_id, p->cont->meta_id, p);
-
-    ret_value = p->obj_info_pub->local_id;
-#endif
     ret_value = PDC_obj_create(cont_id, obj_name, obj_prop_id, PDC_OBJ_GLOBAL);
-    // done:
     fflush(stdout);
     FUNC_LEAVE(ret_value);
 }
@@ -229,10 +119,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info * p         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_obj_info  *p         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop * obj_prop;
+    struct _pdc_obj_prop  *obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -312,8 +202,9 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
     if (!p->obj_pt->obj_prop_pub)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_pt->obj_prop_pub");
     p->obj_pt->obj_prop_pub->ndim = obj_prop->obj_prop_pub->ndim;
+    LOG_INFO("ATTEMPTING TO ALLOCATE NDIM: %d\n", obj_prop->obj_prop_pub->ndim);
     p->obj_pt->obj_prop_pub->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (!p->obj_pt->obj_prop_pub->dims)
+    if (obj_prop->obj_prop_pub->ndim != 0 && !p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->dims");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
         p->obj_pt->obj_prop_pub->dims[i] = obj_prop->obj_prop_pub->dims[i];
@@ -356,7 +247,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     p->obj_info_pub->obj_pt->ndim = obj_prop->obj_prop_pub->ndim;
     p->obj_info_pub->obj_pt->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (!p->obj_info_pub->obj_pt->dims)
+    if (obj_prop->obj_prop_pub->ndim != 0 && !p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
         p->obj_info_pub->obj_pt->dims[i] = obj_prop->obj_prop_pub->dims[i];
@@ -392,7 +283,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t *                   transfer_request_id;
+    pdcid_t                    *transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -528,12 +419,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t *      out       = NULL;
+    pdc_metadata_t       *out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle *          oh;
-    struct pdc_obj_info * info;
+    obj_handle           *oh;
+    struct pdc_obj_info  *info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -602,14 +493,11 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     p->cont->cont_info_pub->meta_id = out->cont_id;
     p->obj_pt->obj_prop_pub->ndim   = out->ndim;
     p->obj_pt->obj_prop_pub->dims   = PDC_malloc(out->ndim * sizeof(uint64_t));
-    if (!p->obj_pt->obj_prop_pub->dims)
+    if (p->obj_pt->obj_prop_pub->ndim != 0 && !p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_prop_pub->dims");
 
     for (i = 0; i < out->ndim; i++)
         p->obj_pt->obj_prop_pub->dims[i] = out->dims[i];
-    /*
-        memcpy(p->obj_pt->obj_prop_pub->dims, out->dims, sizeof(uint64_t) * out->ndim);
-    */
     /* 'app_name' is a char array */
     if (strlen(out->app_name) > 0)
         p->obj_pt->app_name = strdup(out->app_name);
@@ -643,7 +531,7 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
 
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     p->obj_info_pub->obj_pt->dims = PDC_malloc(p->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (!p->obj_info_pub->obj_pt->dims)
+    if (p->obj_pt->obj_prop_pub->ndim != 0 && !p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < p->obj_pt->obj_prop_pub->ndim; i++)
         p->obj_info_pub->obj_pt->dims[i] = p->obj_pt->obj_prop_pub->dims[i];
@@ -680,8 +568,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle *        ret_value = NULL;
-    obj_handle *        objhl     = NULL;
+    obj_handle         *ret_value = NULL;
+    obj_handle         *objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -743,7 +631,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -763,7 +651,7 @@ PDCobj_iter_get_info(obj_handle *ohandle)
         PGOTO_ERROR(NULL, "failed to allocate memory");
     memcpy(ret_value->obj_pt, info->obj_info_pub->obj_pt, sizeof(struct pdc_obj_prop));
     ret_value->obj_pt->dims = PDC_malloc(ret_value->obj_pt->ndim * sizeof(uint64_t));
-    if (!ret_value->obj_pt->dims)
+    if (ret_value->obj_pt->ndim != 0 && !ret_value->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < ret_value->obj_pt->ndim; i++)
         ret_value->obj_pt->dims[i] = info->obj_info_pub->obj_pt->dims[i];
@@ -879,7 +767,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -905,7 +793,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -925,7 +813,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -945,7 +833,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -965,7 +853,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -985,7 +873,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -1023,7 +911,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -1042,10 +930,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void **               ret_value = NULL;
-    struct _pdc_id_info * info;
+    void                **ret_value = NULL;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
-    void **               buffer;
+    void                **buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -1065,7 +953,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info * obj;
+    struct _pdc_id_info  *obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1098,7 +986,7 @@ PDC_obj_get_info(pdcid_t obj_id)
     memcpy(ret_value->obj_info_pub->obj_pt, info->obj_info_pub->obj_pt, sizeof(struct pdc_obj_prop));
     ret_value->obj_info_pub->obj_pt->dims =
         PDC_malloc(ret_value->obj_info_pub->obj_pt->ndim * sizeof(uint64_t));
-    if (!ret_value->obj_info_pub->obj_pt->dims)
+    if (ret_value->obj_info_pub->obj_pt->ndim != 0 && !ret_value->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < ret_value->obj_info_pub->obj_pt->ndim; i++)
         ret_value->obj_info_pub->obj_pt->dims[i] = info->obj_info_pub->obj_pt->dims[i];
@@ -1163,7 +1051,8 @@ PDC_obj_get_info(pdcid_t obj_id)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->obj_pt");
     ret_value->obj_pt->obj_prop_pub->dims =
         PDC_malloc(ret_value->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (ret_value->obj_pt->obj_prop_pub->dims) {
+    LOG_INFO("ndim is %d\n", ret_value->obj_pt->obj_prop_pub->ndim);
+    if (ret_value->obj_pt->obj_prop_pub->ndim == 0 || ret_value->obj_pt->obj_prop_pub->dims) {
         for (i = 0; i < ret_value->obj_pt->obj_prop_pub->ndim; i++) {
             ret_value->obj_pt->obj_prop_pub->dims[i] = info->obj_pt->obj_prop_pub->dims[i];
         }
@@ -1246,7 +1135,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -133,7 +133,7 @@ PDCobj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id)
     if (!p->obj_pt->obj_prop_pub)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_pt->obj_prop_pub");
     p->obj_pt->obj_prop_pub->ndim = obj_prop->obj_prop_pub->ndim;
-    p->obj_pt->obj_prop_pub->dims = malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
+    p->obj_pt->obj_prop_pub->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
     if (!p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->dims");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
@@ -162,7 +162,7 @@ PDCobj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id)
         PGOTO_ERROR(0, "PDC object prop memory allocation failed");
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     p->obj_info_pub->obj_pt->ndim = obj_prop->obj_prop_pub->ndim;
-    p->obj_info_pub->obj_pt->dims = malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
+    p->obj_info_pub->obj_pt->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
     if (!p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
@@ -229,10 +229,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info * p         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_obj_info  *p         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop * obj_prop;
+    struct _pdc_obj_prop  *obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -312,7 +312,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
     if (!p->obj_pt->obj_prop_pub)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_pt->obj_prop_pub");
     p->obj_pt->obj_prop_pub->ndim = obj_prop->obj_prop_pub->ndim;
-    p->obj_pt->obj_prop_pub->dims = malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
+    p->obj_pt->obj_prop_pub->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
     if (!p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->dims");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
@@ -355,7 +355,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
         PGOTO_ERROR(0, "PDC object prop memory allocation failed");
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     p->obj_info_pub->obj_pt->ndim = obj_prop->obj_prop_pub->ndim;
-    p->obj_info_pub->obj_pt->dims = malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
+    p->obj_info_pub->obj_pt->dims = PDC_malloc(obj_prop->obj_prop_pub->ndim * sizeof(uint64_t));
     if (!p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < obj_prop->obj_prop_pub->ndim; i++)
@@ -392,7 +392,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t *                   transfer_request_id;
+    pdcid_t                    *transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -528,12 +528,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t *      out       = NULL;
+    pdc_metadata_t       *out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle *          oh;
-    struct pdc_obj_info * info;
+    obj_handle           *oh;
+    struct pdc_obj_info  *info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -601,7 +601,7 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
 
     p->cont->cont_info_pub->meta_id = out->cont_id;
     p->obj_pt->obj_prop_pub->ndim   = out->ndim;
-    p->obj_pt->obj_prop_pub->dims   = malloc(out->ndim * sizeof(uint64_t));
+    p->obj_pt->obj_prop_pub->dims   = PDC_malloc(out->ndim * sizeof(uint64_t));
     if (!p->obj_pt->obj_prop_pub->dims)
         PGOTO_ERROR(0, "cannot allocate ret_value->obj_prop_pub->dims");
 
@@ -642,7 +642,7 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     p->obj_info_pub->metadata_server_id = metadata_server_id;
 
     memcpy(p->obj_info_pub->obj_pt, p->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
-    p->obj_info_pub->obj_pt->dims = malloc(p->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
+    p->obj_info_pub->obj_pt->dims = PDC_malloc(p->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
     if (!p->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < p->obj_pt->obj_prop_pub->ndim; i++)
@@ -680,8 +680,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle *        ret_value = NULL;
-    obj_handle *        objhl     = NULL;
+    obj_handle         *ret_value = NULL;
+    obj_handle         *objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -743,7 +743,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -762,7 +762,7 @@ PDCobj_iter_get_info(obj_handle *ohandle)
     if (!ret_value->obj_pt)
         PGOTO_ERROR(NULL, "failed to allocate memory");
     memcpy(ret_value->obj_pt, info->obj_info_pub->obj_pt, sizeof(struct pdc_obj_prop));
-    ret_value->obj_pt->dims = malloc(ret_value->obj_pt->ndim * sizeof(uint64_t));
+    ret_value->obj_pt->dims = PDC_malloc(ret_value->obj_pt->ndim * sizeof(uint64_t));
     if (!ret_value->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < ret_value->obj_pt->ndim; i++)
@@ -879,7 +879,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -905,7 +905,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -925,7 +925,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -945,7 +945,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -965,7 +965,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -985,7 +985,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -1023,7 +1023,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * info;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -1042,10 +1042,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void **               ret_value = NULL;
-    struct _pdc_id_info * info;
+    void                **ret_value = NULL;
+    struct _pdc_id_info  *info;
     struct _pdc_obj_info *object;
-    void **               buffer;
+    void                **buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -1065,7 +1065,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info * obj;
+    struct _pdc_id_info  *obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1096,7 +1096,8 @@ PDC_obj_get_info(pdcid_t obj_id)
     if (!ret_value->obj_info_pub->obj_pt)
         PGOTO_ERROR(NULL, "failed to allocate memory");
     memcpy(ret_value->obj_info_pub->obj_pt, info->obj_info_pub->obj_pt, sizeof(struct pdc_obj_prop));
-    ret_value->obj_info_pub->obj_pt->dims = malloc(ret_value->obj_info_pub->obj_pt->ndim * sizeof(uint64_t));
+    ret_value->obj_info_pub->obj_pt->dims =
+        PDC_malloc(ret_value->obj_info_pub->obj_pt->ndim * sizeof(uint64_t));
     if (!ret_value->obj_info_pub->obj_pt->dims)
         PGOTO_ERROR(0, "failed to allocate obj pub property memory");
     for (i = 0; i < ret_value->obj_info_pub->obj_pt->ndim; i++)
@@ -1160,7 +1161,8 @@ PDC_obj_get_info(pdcid_t obj_id)
         memcpy(ret_value->obj_pt->obj_prop_pub, info->obj_pt->obj_prop_pub, sizeof(struct pdc_obj_prop));
     else
         PGOTO_ERROR(NULL, "cannot allocate ret_value->obj_pt");
-    ret_value->obj_pt->obj_prop_pub->dims = malloc(ret_value->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
+    ret_value->obj_pt->obj_prop_pub->dims =
+        PDC_malloc(ret_value->obj_pt->obj_prop_pub->ndim * sizeof(uint64_t));
     if (ret_value->obj_pt->obj_prop_pub->dims) {
         for (i = 0; i < ret_value->obj_pt->obj_prop_pub->ndim; i++) {
             ret_value->obj_pt->obj_prop_pub->dims[i] = info->obj_pt->obj_prop_pub->dims[i];
@@ -1244,7 +1246,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info * ret_value = NULL;
+    struct pdc_obj_info  *ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -229,10 +229,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info  *p         = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_obj_info * p         = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop  *obj_prop;
+    struct _pdc_obj_prop * obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -392,7 +392,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t                    *transfer_request_id;
+    pdcid_t *                   transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -528,12 +528,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t       *out       = NULL;
+    pdc_metadata_t *      out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle           *oh;
-    struct pdc_obj_info  *info;
+    obj_handle *          oh;
+    struct pdc_obj_info * info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -680,8 +680,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle         *ret_value = NULL;
-    obj_handle         *objhl     = NULL;
+    obj_handle *        ret_value = NULL;
+    obj_handle *        objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -743,7 +743,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -879,7 +879,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -905,7 +905,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -925,7 +925,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -945,7 +945,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -965,7 +965,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -985,7 +985,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -1023,7 +1023,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -1042,10 +1042,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void                **ret_value = NULL;
-    struct _pdc_id_info  *info;
+    void **               ret_value = NULL;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
-    void                **buffer;
+    void **               buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -1065,7 +1065,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info  *obj;
+    struct _pdc_id_info * obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1246,7 +1246,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -119,10 +119,10 @@ pdcid_t
 PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_obj_location_t location)
 {
     pdcid_t                ret_value = 0;
-    struct _pdc_obj_info  *p         = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_obj_info * p         = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
     struct _pdc_cont_info *cont_info = NULL;
-    struct _pdc_obj_prop  *obj_prop;
+    struct _pdc_obj_prop * obj_prop;
     uint64_t               meta_id;
     uint32_t               data_server_id, metadata_server_id;
     size_t                 i;
@@ -283,7 +283,7 @@ perr_t
 PDC_obj_close(struct _pdc_obj_info *op)
 {
     perr_t                      ret_value = SUCCEED;
-    pdcid_t                    *transfer_request_id;
+    pdcid_t *                   transfer_request_id;
     pdc_local_transfer_request *temp, *previous;
     int                         i, n;
 
@@ -419,12 +419,12 @@ PDCobj_open_common(const char *obj_name, pdcid_t pdc, int is_col)
     pdcid_t               ret_value = 0;
     perr_t                ret       = SUCCEED;
     struct _pdc_obj_info *p         = NULL;
-    pdc_metadata_t       *out       = NULL;
+    pdc_metadata_t *      out       = NULL;
     pdcid_t               obj_prop;
     size_t                i;
     uint32_t              metadata_server_id;
-    obj_handle           *oh;
-    struct pdc_obj_info  *info;
+    obj_handle *          oh;
+    struct pdc_obj_info * info;
     int                   is_opened = 0;
 
     FUNC_ENTER(NULL);
@@ -568,8 +568,8 @@ PDCobj_open_col(const char *obj_name, pdcid_t pdc)
 obj_handle *
 PDCobj_iter_start(pdcid_t cont_id)
 {
-    obj_handle         *ret_value = NULL;
-    obj_handle         *objhl     = NULL;
+    obj_handle *        ret_value = NULL;
+    obj_handle *        objhl     = NULL;
     struct PDC_id_type *type_ptr;
 
     FUNC_ENTER(NULL);
@@ -631,7 +631,7 @@ done:
 struct pdc_obj_info *
 PDCobj_iter_get_info(obj_handle *ohandle)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
     unsigned              i;
 
@@ -767,7 +767,7 @@ perr_t
 PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -793,7 +793,7 @@ perr_t
 PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -813,7 +813,7 @@ perr_t
 PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t region_partition)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -833,7 +833,7 @@ perr_t
 PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consistency)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -853,7 +853,7 @@ perr_t
 PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
     FUNC_ENTER(NULL);
@@ -873,7 +873,7 @@ perr_t
 PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     int                   reset;
 
@@ -911,7 +911,7 @@ perr_t
 PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *info;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
     FUNC_ENTER(NULL);
 
@@ -930,10 +930,10 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
 void **
 PDCobj_buf_retrieve(pdcid_t obj_id)
 {
-    void                **ret_value = NULL;
-    struct _pdc_id_info  *info;
+    void **               ret_value = NULL;
+    struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
-    void                **buffer;
+    void **               buffer;
 
     FUNC_ENTER(NULL);
     info = PDC_find_id(obj_id);
@@ -953,7 +953,7 @@ PDC_obj_get_info(pdcid_t obj_id)
 {
     struct _pdc_obj_info *ret_value = NULL;
     struct _pdc_obj_info *info      = NULL;
-    struct _pdc_id_info  *obj;
+    struct _pdc_id_info * obj;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -1135,7 +1135,7 @@ PDC_free_obj_info(struct _pdc_obj_info *obj)
 struct pdc_obj_info *
 PDCobj_get_info(pdcid_t obj_id)
 {
-    struct pdc_obj_info  *ret_value = NULL;
+    struct pdc_obj_info * ret_value = NULL;
     struct _pdc_obj_info *tmp       = NULL;
     /* pdcid_t obj_id; */
 

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -58,9 +58,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
 {
     pdcid_t                ret_value = 0;
     struct _pdc_cont_prop *p         = NULL;
-    struct _pdc_obj_prop  *q         = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
-    struct _pdc_class     *pdc_class;
+    struct _pdc_obj_prop * q         = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_class *    pdc_class;
     pdcid_t                new_id_c;
     pdcid_t                new_id_o;
 
@@ -130,7 +130,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               ret_value = 0;
     struct _pdc_obj_prop *q         = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info  *prop      = NULL;
+    struct _pdc_id_info * prop      = NULL;
     pdcid_t               new_id;
     size_t                i;
 
@@ -294,7 +294,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
 {
     struct _pdc_cont_prop *ret_value = NULL;
     struct _pdc_cont_prop *info      = NULL;
-    struct _pdc_id_info   *prop;
+    struct _pdc_id_info *  prop;
 
     FUNC_ENTER(NULL);
 
@@ -324,9 +324,9 @@ done:
 struct pdc_obj_prop *
 PDCobj_prop_get_info(pdcid_t obj_prop)
 {
-    struct pdc_obj_prop  *ret_value = NULL;
+    struct pdc_obj_prop * ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info  *prop;
+    struct _pdc_id_info * prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -357,7 +357,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
 {
     struct _pdc_obj_prop *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info  *prop;
+    struct _pdc_id_info * prop;
     size_t                i;
 
     FUNC_ENTER(NULL);

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -58,9 +58,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
 {
     pdcid_t                ret_value = 0;
     struct _pdc_cont_prop *p         = NULL;
-    struct _pdc_obj_prop * q         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
-    struct _pdc_class *    pdc_class;
+    struct _pdc_obj_prop  *q         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_class     *pdc_class;
     pdcid_t                new_id_c;
     pdcid_t                new_id_o;
 
@@ -130,7 +130,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               ret_value = 0;
     struct _pdc_obj_prop *q         = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop      = NULL;
+    struct _pdc_id_info  *prop      = NULL;
     pdcid_t               new_id;
     size_t                i;
 
@@ -294,7 +294,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
 {
     struct _pdc_cont_prop *ret_value = NULL;
     struct _pdc_cont_prop *info      = NULL;
-    struct _pdc_id_info *  prop;
+    struct _pdc_id_info   *prop;
 
     FUNC_ENTER(NULL);
 
@@ -324,9 +324,9 @@ done:
 struct pdc_obj_prop *
 PDCobj_prop_get_info(pdcid_t obj_prop)
 {
-    struct pdc_obj_prop * ret_value = NULL;
+    struct pdc_obj_prop  *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -341,7 +341,7 @@ PDCobj_prop_get_info(pdcid_t obj_prop)
         PGOTO_ERROR(NULL, "PDC object property memory allocation failed");
     memcpy(ret_value, info->obj_prop_pub, sizeof(struct pdc_obj_prop));
 
-    ret_value->dims = malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
+    ret_value->dims = PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
     if (ret_value->dims == NULL)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->dims");
     for (i = 0; i < info->obj_prop_pub->ndim; i++)
@@ -357,7 +357,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
 {
     struct _pdc_obj_prop *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -393,7 +393,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
     if (ret_value->obj_prop_pub == NULL)
         PGOTO_ERROR(NULL, "PDC object pub property memory allocation failed");
     memcpy(ret_value->obj_prop_pub, info->obj_prop_pub, sizeof(struct pdc_obj_prop));
-    ret_value->obj_prop_pub->dims = malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
+    ret_value->obj_prop_pub->dims = PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
     if (ret_value->obj_prop_pub->dims == NULL)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->obj_prop_pub->dims");
     for (i = 0; i < info->obj_prop_pub->ndim; i++)

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -58,9 +58,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
 {
     pdcid_t                ret_value = 0;
     struct _pdc_cont_prop *p         = NULL;
-    struct _pdc_obj_prop * q         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
-    struct _pdc_class *    pdc_class;
+    struct _pdc_obj_prop  *q         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_class     *pdc_class;
     pdcid_t                new_id_c;
     pdcid_t                new_id_o;
 
@@ -130,7 +130,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               ret_value = 0;
     struct _pdc_obj_prop *q         = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop      = NULL;
+    struct _pdc_id_info  *prop      = NULL;
     pdcid_t               new_id;
     size_t                i;
 
@@ -159,7 +159,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     new_id                            = PDC_id_register(PDC_OBJ_PROP, q);
     q->obj_prop_pub->obj_prop_id      = new_id;
     q->obj_prop_pub->ndim             = info->obj_prop_pub->ndim;
-    q->obj_prop_pub->dims             = (uint64_t *)malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
+    q->obj_prop_pub->dims             = (uint64_t *)PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
     q->obj_prop_pub->type             = PDC_UNKNOWN;
     q->obj_prop_pub->region_partition = info->obj_prop_pub->region_partition;
     for (i = 0; i < info->obj_prop_pub->ndim; i++)
@@ -227,9 +227,9 @@ pdc_prop_cont_close(struct _pdc_cont_prop *cp)
 
     FUNC_ENTER(NULL);
 
-    free(cp->pdc->name);
-    cp->pdc = (struct _pdc_class *)(intptr_t)PDC_free(cp->pdc);
-    cp      = (struct _pdc_cont_prop *)(intptr_t)PDC_free(cp);
+    cp->pdc->name = (char *)PDC_free(cp->pdc->name);
+    cp->pdc       = (struct _pdc_class *)(intptr_t)PDC_free(cp->pdc);
+    cp            = (struct _pdc_cont_prop *)(intptr_t)PDC_free(cp);
 
     FUNC_LEAVE(ret_value);
 }
@@ -241,16 +241,16 @@ pdc_prop_obj_close(struct _pdc_obj_prop *cp)
 
     FUNC_ENTER(NULL);
 
-    free(cp->pdc->name);
-    cp->pdc = (struct _pdc_class *)(intptr_t)PDC_free(cp->pdc);
+    cp->pdc->name = (char *)PDC_free(cp->pdc->name);
+    cp->pdc       = (struct _pdc_class *)(intptr_t)PDC_free(cp->pdc);
     if (cp->obj_prop_pub->dims != NULL) {
-        free(cp->obj_prop_pub->dims);
+        cp->obj_prop_pub->dims = (uint64_t *)PDC_free(cp->obj_prop_pub->dims);
         cp->obj_prop_pub->dims = NULL;
     }
-    free(cp->app_name);
-    free(cp->tags);
-    free(cp->data_loc);
-    cp = (struct _pdc_obj_prop *)(intptr_t)PDC_free(cp);
+    cp->app_name = (char *)PDC_free(cp->app_name);
+    cp->tags     = (char *)PDC_free(cp->tags);
+    cp->data_loc = (char *)PDC_free(cp->data_loc);
+    cp           = (struct _pdc_obj_prop *)(intptr_t)PDC_free(cp);
 
     FUNC_LEAVE(ret_value);
 }
@@ -294,7 +294,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
 {
     struct _pdc_cont_prop *ret_value = NULL;
     struct _pdc_cont_prop *info      = NULL;
-    struct _pdc_id_info *  prop;
+    struct _pdc_id_info   *prop;
 
     FUNC_ENTER(NULL);
 
@@ -324,9 +324,9 @@ done:
 struct pdc_obj_prop *
 PDCobj_prop_get_info(pdcid_t obj_prop)
 {
-    struct pdc_obj_prop * ret_value = NULL;
+    struct pdc_obj_prop  *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -357,7 +357,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
 {
     struct _pdc_obj_prop *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -58,9 +58,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
 {
     pdcid_t                ret_value = 0;
     struct _pdc_cont_prop *p         = NULL;
-    struct _pdc_obj_prop * q         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
-    struct _pdc_class *    pdc_class;
+    struct _pdc_obj_prop  *q         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_class     *pdc_class;
     pdcid_t                new_id_c;
     pdcid_t                new_id_o;
 
@@ -91,7 +91,8 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
         q->obj_prop_pub = (struct pdc_obj_prop *)PDC_malloc(sizeof(struct pdc_obj_prop));
         if (!q->obj_prop_pub)
             PGOTO_ERROR(0, "PDC object pub property memory allocation failed");
-        q->obj_prop_pub->ndim             = 0;
+        // default ndim size to 1
+        q->obj_prop_pub->ndim             = 1;
         q->obj_prop_pub->dims             = NULL;
         q->obj_prop_pub->type             = PDC_UNKNOWN;
         q->obj_prop_pub->region_partition = PDC_REGION_STATIC;
@@ -130,7 +131,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               ret_value = 0;
     struct _pdc_obj_prop *q         = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop      = NULL;
+    struct _pdc_id_info  *prop      = NULL;
     pdcid_t               new_id;
     size_t                i;
 
@@ -294,7 +295,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
 {
     struct _pdc_cont_prop *ret_value = NULL;
     struct _pdc_cont_prop *info      = NULL;
-    struct _pdc_id_info *  prop;
+    struct _pdc_id_info   *prop;
 
     FUNC_ENTER(NULL);
 
@@ -324,9 +325,9 @@ done:
 struct pdc_obj_prop *
 PDCobj_prop_get_info(pdcid_t obj_prop)
 {
-    struct pdc_obj_prop * ret_value = NULL;
+    struct pdc_obj_prop  *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -342,7 +343,7 @@ PDCobj_prop_get_info(pdcid_t obj_prop)
     memcpy(ret_value, info->obj_prop_pub, sizeof(struct pdc_obj_prop));
 
     ret_value->dims = PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (info->obj_prop_pub->ndim != 0 && ret_value->dims == NULL)
+    if (ret_value->dims == NULL)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->dims");
     for (i = 0; i < info->obj_prop_pub->ndim; i++)
         ret_value->dims[i] = info->obj_prop_pub->dims[i];
@@ -357,7 +358,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
 {
     struct _pdc_obj_prop *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -394,7 +395,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
         PGOTO_ERROR(NULL, "PDC object pub property memory allocation failed");
     memcpy(ret_value->obj_prop_pub, info->obj_prop_pub, sizeof(struct pdc_obj_prop));
     ret_value->obj_prop_pub->dims = PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (info->obj_prop_pub->ndim != 0 && ret_value->obj_prop_pub->dims == NULL)
+    if (ret_value->obj_prop_pub->dims == NULL)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->obj_prop_pub->dims");
     for (i = 0; i < info->obj_prop_pub->ndim; i++)
         ret_value->obj_prop_pub->dims[i] = info->obj_prop_pub->dims[i];

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -58,9 +58,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
 {
     pdcid_t                ret_value = 0;
     struct _pdc_cont_prop *p         = NULL;
-    struct _pdc_obj_prop * q         = NULL;
-    struct _pdc_id_info *  id_info   = NULL;
-    struct _pdc_class *    pdc_class;
+    struct _pdc_obj_prop  *q         = NULL;
+    struct _pdc_id_info   *id_info   = NULL;
+    struct _pdc_class     *pdc_class;
     pdcid_t                new_id_c;
     pdcid_t                new_id_o;
 
@@ -130,7 +130,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               ret_value = 0;
     struct _pdc_obj_prop *q         = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop      = NULL;
+    struct _pdc_id_info  *prop      = NULL;
     pdcid_t               new_id;
     size_t                i;
 
@@ -294,7 +294,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
 {
     struct _pdc_cont_prop *ret_value = NULL;
     struct _pdc_cont_prop *info      = NULL;
-    struct _pdc_id_info *  prop;
+    struct _pdc_id_info   *prop;
 
     FUNC_ENTER(NULL);
 
@@ -324,9 +324,9 @@ done:
 struct pdc_obj_prop *
 PDCobj_prop_get_info(pdcid_t obj_prop)
 {
-    struct pdc_obj_prop * ret_value = NULL;
+    struct pdc_obj_prop  *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -342,7 +342,7 @@ PDCobj_prop_get_info(pdcid_t obj_prop)
     memcpy(ret_value, info->obj_prop_pub, sizeof(struct pdc_obj_prop));
 
     ret_value->dims = PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (ret_value->dims == NULL)
+    if (info->obj_prop_pub->ndim != 0 && ret_value->dims == NULL)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->dims");
     for (i = 0; i < info->obj_prop_pub->ndim; i++)
         ret_value->dims[i] = info->obj_prop_pub->dims[i];
@@ -357,7 +357,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
 {
     struct _pdc_obj_prop *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info * prop;
+    struct _pdc_id_info  *prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -394,7 +394,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
         PGOTO_ERROR(NULL, "PDC object pub property memory allocation failed");
     memcpy(ret_value->obj_prop_pub, info->obj_prop_pub, sizeof(struct pdc_obj_prop));
     ret_value->obj_prop_pub->dims = PDC_malloc(info->obj_prop_pub->ndim * sizeof(uint64_t));
-    if (ret_value->obj_prop_pub->dims == NULL)
+    if (info->obj_prop_pub->ndim != 0 && ret_value->obj_prop_pub->dims == NULL)
         PGOTO_ERROR(NULL, "cannot allocate ret_value->obj_prop_pub->dims");
     for (i = 0; i < info->obj_prop_pub->ndim; i++)
         ret_value->obj_prop_pub->dims[i] = info->obj_prop_pub->dims[i];

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -58,9 +58,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
 {
     pdcid_t                ret_value = 0;
     struct _pdc_cont_prop *p         = NULL;
-    struct _pdc_obj_prop  *q         = NULL;
-    struct _pdc_id_info   *id_info   = NULL;
-    struct _pdc_class     *pdc_class;
+    struct _pdc_obj_prop * q         = NULL;
+    struct _pdc_id_info *  id_info   = NULL;
+    struct _pdc_class *    pdc_class;
     pdcid_t                new_id_c;
     pdcid_t                new_id_o;
 
@@ -131,7 +131,7 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               ret_value = 0;
     struct _pdc_obj_prop *q         = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info  *prop      = NULL;
+    struct _pdc_id_info * prop      = NULL;
     pdcid_t               new_id;
     size_t                i;
 
@@ -295,7 +295,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
 {
     struct _pdc_cont_prop *ret_value = NULL;
     struct _pdc_cont_prop *info      = NULL;
-    struct _pdc_id_info   *prop;
+    struct _pdc_id_info *  prop;
 
     FUNC_ENTER(NULL);
 
@@ -325,9 +325,9 @@ done:
 struct pdc_obj_prop *
 PDCobj_prop_get_info(pdcid_t obj_prop)
 {
-    struct pdc_obj_prop  *ret_value = NULL;
+    struct pdc_obj_prop * ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info  *prop;
+    struct _pdc_id_info * prop;
     size_t                i;
 
     FUNC_ENTER(NULL);
@@ -358,7 +358,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
 {
     struct _pdc_obj_prop *ret_value = NULL;
     struct _pdc_obj_prop *info      = NULL;
-    struct _pdc_id_info  *prop;
+    struct _pdc_id_info * prop;
     size_t                i;
 
     FUNC_ENTER(NULL);

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -92,9 +92,9 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
         if (!q->obj_prop_pub)
             PGOTO_ERROR(0, "PDC object pub property memory allocation failed");
         // default ndim size to 1
-        q->obj_prop_pub->ndim             = 1;
-        q->obj_prop_pub->dims             = NULL;
-        q->obj_prop_pub->type             = PDC_UNKNOWN;
+        q->obj_prop_pub->ndim = 1;
+        q->obj_prop_pub->dims = (uint64_t *)PDC_calloc(1, q->obj_prop_pub->ndim * sizeof(uint64_t));
+        q->obj_prop_pub->type = PDC_UNKNOWN;
         q->obj_prop_pub->region_partition = PDC_REGION_STATIC;
         q->obj_prop_pub->consistency      = PDC_CONSISTENCY_EVENTUAL;
         q->data_loc                       = NULL;

--- a/src/api/pdc_query/pdc_query.c
+++ b/src/api/pdc_query/pdc_query.c
@@ -22,8 +22,8 @@
 pdc_query_t *
 PDCquery_create(pdcid_t obj_id, pdc_query_op_t op, pdc_var_type_t type, void *value)
 {
-    pdc_query_t          *ret_value = NULL;
-    pdc_query_t          *query;
+    pdc_query_t *         ret_value = NULL;
+    pdc_query_t *         query;
     int                   type_size;
     struct _pdc_obj_info *obj_prop;
     uint64_t              meta_id;

--- a/src/api/pdc_query/pdc_query.c
+++ b/src/api/pdc_query/pdc_query.c
@@ -22,8 +22,8 @@
 pdc_query_t *
 PDCquery_create(pdcid_t obj_id, pdc_query_op_t op, pdc_var_type_t type, void *value)
 {
-    pdc_query_t *         ret_value = NULL;
-    pdc_query_t *         query;
+    pdc_query_t          *ret_value = NULL;
+    pdc_query_t          *query;
     int                   type_size;
     struct _pdc_obj_info *obj_prop;
     uint64_t              meta_id;
@@ -210,8 +210,6 @@ PDCquery_and(pdc_query_t *q1, pdc_query_t *q2)
         query->constraint->value2   = q2->constraint->value;
         q1->constraint              = (pdc_query_constraint_t *)PDC_free(q1->constraint);
         q2->constraint              = (pdc_query_constraint_t *)PDC_free(q2->constraint);
-        q1->constraint              = NULL;
-        q2->constraint              = NULL;
     }
     else {
         query->left       = q1;

--- a/src/api/pdc_query/pdc_query.c
+++ b/src/api/pdc_query/pdc_query.c
@@ -22,8 +22,8 @@
 pdc_query_t *
 PDCquery_create(pdcid_t obj_id, pdc_query_op_t op, pdc_var_type_t type, void *value)
 {
-    pdc_query_t *         ret_value = NULL;
-    pdc_query_t *         query;
+    pdc_query_t          *ret_value = NULL;
+    pdc_query_t          *query;
     int                   type_size;
     struct _pdc_obj_info *obj_prop;
     uint64_t              meta_id;
@@ -208,10 +208,10 @@ PDCquery_and(pdc_query_t *q1, pdc_query_t *q2)
         query->constraint->is_range = 1;
         query->constraint->op2      = q2->constraint->op;
         query->constraint->value2   = q2->constraint->value;
-        free(q1->constraint);
-        free(q2->constraint);
-        q1->constraint = NULL;
-        q2->constraint = NULL;
+        q1->constraint              = (pdc_query_constraint_t *)PDC_free(q1->constraint);
+        q2->constraint              = (pdc_query_constraint_t *)PDC_free(q2->constraint);
+        q1->constraint              = NULL;
+        q2->constraint              = NULL;
     }
     else {
         query->left       = q1;

--- a/src/api/pdc_query/pdc_query.c
+++ b/src/api/pdc_query/pdc_query.c
@@ -40,8 +40,8 @@ PDCquery_create(pdcid_t obj_id, pdc_query_op_t op, pdc_var_type_t type, void *va
     else
         meta_id = obj_id;
 
-    query                     = (pdc_query_t *)calloc(1, sizeof(pdc_query_t));
-    query->constraint         = (pdc_query_constraint_t *)calloc(1, sizeof(pdc_query_constraint_t));
+    query                     = (pdc_query_t *)PDC_calloc(1, sizeof(pdc_query_t));
+    query->constraint         = (pdc_query_constraint_t *)PDC_calloc(1, sizeof(pdc_query_constraint_t));
     query->constraint->obj_id = meta_id; // Use global ID
     query->constraint->op     = op;
     query->constraint->type   = type;
@@ -199,11 +199,11 @@ PDCquery_and(pdc_query_t *q1, pdc_query_t *q2)
         }
     }
 
-    query         = (pdc_query_t *)calloc(1, sizeof(pdc_query_t));
+    query         = (pdc_query_t *)PDC_calloc(1, sizeof(pdc_query_t));
     query->region = q1->region != NULL ? q1->region : q2->region;
 
     if (can_combine == 1) {
-        query->constraint = (pdc_query_constraint_t *)calloc(1, sizeof(pdc_query_constraint_t));
+        query->constraint = (pdc_query_constraint_t *)PDC_calloc(1, sizeof(pdc_query_constraint_t));
         memcpy(query->constraint, q1->constraint, sizeof(pdc_query_constraint_t));
         query->constraint->is_range = 1;
         query->constraint->op2      = q2->constraint->op;
@@ -238,7 +238,7 @@ PDCquery_or(pdc_query_t *q1, pdc_query_t *q2)
     if (NULL == q1 || NULL == q2)
         PGOTO_DONE(NULL);
 
-    query             = (pdc_query_t *)calloc(1, sizeof(pdc_query_t));
+    query             = (pdc_query_t *)PDC_calloc(1, sizeof(pdc_query_t));
     query->left       = q1;
     query->right      = q2;
     query->constraint = NULL;

--- a/src/api/pdc_region/pdc_region.c
+++ b/src/api/pdc_region/pdc_region.c
@@ -212,12 +212,12 @@ PDCbuf_obj_map(void *buf, pdc_var_type_t local_type, pdcid_t local_reg, pdcid_t 
 {
     pdcid_t               ret_value = SUCCEED;
     size_t                i;
-    struct _pdc_id_info  *objinfo2;
+    struct _pdc_id_info * objinfo2;
     struct _pdc_obj_info *obj2;
     pdcid_t               remote_meta_id;
 
     pdc_var_type_t          remote_type;
-    struct _pdc_id_info    *reginfo1, *reginfo2;
+    struct _pdc_id_info *   reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
 
     FUNC_ENTER(NULL);
@@ -265,7 +265,7 @@ PDCregion_get_info(pdcid_t reg_id)
 {
     struct pdc_region_info *ret_value = NULL;
     struct pdc_region_info *info      = NULL;
-    struct _pdc_id_info    *region;
+    struct _pdc_id_info *   region;
 
     FUNC_ENTER(NULL);
 
@@ -285,8 +285,8 @@ perr_t
 PDCbuf_obj_unmap(pdcid_t remote_obj_id, pdcid_t remote_reg_id)
 {
     perr_t                  ret_value = SUCCEED;
-    struct _pdc_id_info    *info1;
-    struct _pdc_obj_info   *object1;
+    struct _pdc_id_info *   info1;
+    struct _pdc_obj_info *  object1;
     struct pdc_region_info *reginfo;
     pdc_var_type_t          data_type;
 
@@ -320,11 +320,11 @@ perr_t
 PDCreg_obtain_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type, pdc_lock_mode_t lock_mode)
 {
     perr_t                  ret_value = SUCCEED;
-    struct _pdc_obj_info   *object_info;
+    struct _pdc_obj_info *  object_info;
     struct pdc_region_info *region_info;
     pdc_var_type_t          data_type;
     pbool_t                 obtained;
-    struct _pdc_id_info    *info1;
+    struct _pdc_id_info *   info1;
 
     FUNC_ENTER(NULL);
 
@@ -336,7 +336,7 @@ PDCreg_obtain_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type, pdc
     data_type   = object_info->obj_pt->obj_prop_pub->type;
     region_info = PDCregion_get_info(reg_id);
     ret_value   = PDC_Client_region_lock(object_info->obj_info_pub->meta_id, object_info, region_info,
-                                         access_type, lock_mode, data_type, &obtained);
+                                       access_type, lock_mode, data_type, &obtained);
 
     // PDC_free_obj_info(object_info);
 done:
@@ -348,10 +348,10 @@ PDCreg_release_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type)
 {
     perr_t                  ret_value = SUCCEED;
     pbool_t                 released;
-    struct _pdc_obj_info   *object_info;
+    struct _pdc_obj_info *  object_info;
     struct pdc_region_info *region_info;
     pdc_var_type_t          data_type;
-    struct _pdc_id_info    *info1;
+    struct _pdc_id_info *   info1;
 
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_region/pdc_region.c
+++ b/src/api/pdc_region/pdc_region.c
@@ -103,8 +103,8 @@ pdc_region_close(struct pdc_region_info *op)
 
     FUNC_ENTER(NULL);
 
-    free(op->size);
-    free(op->offset);
+    op->size   = (uint64_t *)PDC_free(op->size);
+    op->offset = (uint64_t *)PDC_free(op->offset);
     if (op->obj != NULL)
         op->obj = (struct _pdc_obj_info *)(intptr_t)PDC_free(op->obj);
     op = (struct pdc_region_info *)(intptr_t)PDC_free(op);
@@ -189,8 +189,8 @@ PDCregion_create(psize_t ndims, uint64_t *offset, uint64_t *size)
         PGOTO_ERROR(ret_value, "PDC region memory allocation failed");
     p->ndim     = ndims;
     p->obj      = NULL;
-    p->offset   = (uint64_t *)malloc(ndims * sizeof(uint64_t));
-    p->size     = (uint64_t *)malloc(ndims * sizeof(uint64_t));
+    p->offset   = (uint64_t *)PDC_malloc(ndims * sizeof(uint64_t));
+    p->size     = (uint64_t *)PDC_malloc(ndims * sizeof(uint64_t));
     p->mapping  = 0;
     p->local_id = 0;
     for (i = 0; i < ndims; i++) {
@@ -212,12 +212,12 @@ PDCbuf_obj_map(void *buf, pdc_var_type_t local_type, pdcid_t local_reg, pdcid_t 
 {
     pdcid_t               ret_value = SUCCEED;
     size_t                i;
-    struct _pdc_id_info * objinfo2;
+    struct _pdc_id_info  *objinfo2;
     struct _pdc_obj_info *obj2;
     pdcid_t               remote_meta_id;
 
     pdc_var_type_t          remote_type;
-    struct _pdc_id_info *   reginfo1, *reginfo2;
+    struct _pdc_id_info    *reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
 
     FUNC_ENTER(NULL);
@@ -265,7 +265,7 @@ PDCregion_get_info(pdcid_t reg_id)
 {
     struct pdc_region_info *ret_value = NULL;
     struct pdc_region_info *info      = NULL;
-    struct _pdc_id_info *   region;
+    struct _pdc_id_info    *region;
 
     FUNC_ENTER(NULL);
 
@@ -285,8 +285,8 @@ perr_t
 PDCbuf_obj_unmap(pdcid_t remote_obj_id, pdcid_t remote_reg_id)
 {
     perr_t                  ret_value = SUCCEED;
-    struct _pdc_id_info *   info1;
-    struct _pdc_obj_info *  object1;
+    struct _pdc_id_info    *info1;
+    struct _pdc_obj_info   *object1;
     struct pdc_region_info *reginfo;
     pdc_var_type_t          data_type;
 
@@ -320,11 +320,11 @@ perr_t
 PDCreg_obtain_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type, pdc_lock_mode_t lock_mode)
 {
     perr_t                  ret_value = SUCCEED;
-    struct _pdc_obj_info *  object_info;
+    struct _pdc_obj_info   *object_info;
     struct pdc_region_info *region_info;
     pdc_var_type_t          data_type;
     pbool_t                 obtained;
-    struct _pdc_id_info *   info1;
+    struct _pdc_id_info    *info1;
 
     FUNC_ENTER(NULL);
 
@@ -336,7 +336,7 @@ PDCreg_obtain_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type, pdc
     data_type   = object_info->obj_pt->obj_prop_pub->type;
     region_info = PDCregion_get_info(reg_id);
     ret_value   = PDC_Client_region_lock(object_info->obj_info_pub->meta_id, object_info, region_info,
-                                       access_type, lock_mode, data_type, &obtained);
+                                         access_type, lock_mode, data_type, &obtained);
 
     // PDC_free_obj_info(object_info);
 done:
@@ -348,10 +348,10 @@ PDCreg_release_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type)
 {
     perr_t                  ret_value = SUCCEED;
     pbool_t                 released;
-    struct _pdc_obj_info *  object_info;
+    struct _pdc_obj_info   *object_info;
     struct pdc_region_info *region_info;
     pdc_var_type_t          data_type;
-    struct _pdc_id_info *   info1;
+    struct _pdc_id_info    *info1;
 
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -76,7 +76,7 @@ typedef struct pdc_transfer_request {
     // For each of the contig buffer sent to a server, we have a bulk buffer.
     char **bulk_buf;
     // Reference counter for bulk_buf, if 0, we free it.
-    int **                 bulk_buf_ref;
+    int                  **bulk_buf_ref;
     pdc_region_partition_t region_partition;
 
     // Consistency semantics required by user
@@ -128,7 +128,7 @@ typedef struct pdc_transfer_request_start_all_pkg {
     int index;
     // Data buffer. This data buffer is contiguous according to the remote region. We assume this is after
     // transformation of local regions
-    char *                                     buf;
+    char                                      *buf;
     struct pdc_transfer_request_start_all_pkg *next;
 } pdc_transfer_request_start_all_pkg;
 
@@ -142,7 +142,7 @@ typedef struct pdc_transfer_request_wait_all_pkg {
     // Record the index of the metadata_id in the current transfer_request
     int index;
     // Pointer to the transfer request
-    pdc_transfer_request *                    transfer_request;
+    pdc_transfer_request                     *transfer_request;
     struct pdc_transfer_request_wait_all_pkg *next;
 } pdc_transfer_request_wait_all_pkg;
 
@@ -196,12 +196,12 @@ PDCregion_transfer_create(void *buf, pdc_access_t access_type, pdcid_t obj_id, p
                           pdcid_t remote_reg)
 {
     pdcid_t                 ret_value = SUCCEED;
-    struct _pdc_id_info *   objinfo2;
-    struct _pdc_obj_info *  obj2;
-    pdc_transfer_request *  p;
-    struct _pdc_id_info *   reginfo1, *reginfo2;
+    struct _pdc_id_info    *objinfo2;
+    struct _pdc_obj_info   *obj2;
+    pdc_transfer_request   *p;
+    struct _pdc_id_info    *reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
-    uint64_t *              ptr;
+    uint64_t               *ptr;
     uint64_t                unit;
     int                     j;
 
@@ -287,7 +287,7 @@ done:
 perr_t
 PDCregion_transfer_close(pdcid_t transfer_request_id)
 {
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     perr_t                ret_value = SUCCEED;
     FUNC_ENTER(NULL);
@@ -525,7 +525,7 @@ pack_region_buffer(char *buf, uint64_t *obj_dims, size_t total_data_size, int lo
 {
     uint64_t i, j;
     perr_t   ret_value = SUCCEED;
-    char *   ptr;
+    char    *ptr;
 
     FUNC_ENTER(NULL);
 
@@ -592,7 +592,7 @@ pack_region_metadata_query(pdc_transfer_request_start_all_pkg **transfer_request
 {
     perr_t   ret_value = SUCCEED;
     int      i;
-    char *   ptr;
+    char    *ptr;
     uint64_t total_buf_size;
     uint8_t  region_partition;
 
@@ -640,13 +640,13 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
 {
     perr_t                              ret_value = SUCCEED;
     pdc_transfer_request_start_all_pkg *transfer_request_head, *transfer_request_end;
-    pdc_transfer_request *              local_request;
+    pdc_transfer_request               *local_request;
     int                                 size;
     int                                 i, j, index;
     int                                 counter;
-    char *                              ptr;
+    char                               *ptr;
     uint64_t                            region_size;
-    uint64_t *                          sub_offset;
+    uint64_t                           *sub_offset;
     FUNC_ENTER(NULL);
 
     local_request         = NULL;
@@ -740,10 +740,10 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
     perr_t                               ret_value = SUCCEED;
     int                                  i, j, index, size, output_size, remain_size, n_objs;
     pdc_transfer_request_start_all_pkg **transfer_requests;
-    pdc_transfer_request_start_all_pkg * transfer_request_head, *transfer_request_front_head,
+    pdc_transfer_request_start_all_pkg  *transfer_request_head, *transfer_request_front_head,
         *transfer_request_end, **transfer_request_output, *previous = NULL;
     uint64_t total_buf_size, output_buf_size, query_id;
-    char *   buf, *output_buf;
+    char    *buf, *output_buf;
 
     FUNC_ENTER(NULL);
     transfer_request_output     = NULL;
@@ -875,7 +875,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
         *read_request_pkgs, *write_request_pkgs_end, *read_request_pkgs_end, *request_pkgs,
         **transfer_request_output;
     int                   write_size, read_size, output_size;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     int                   set_output_buf = 0;
 
@@ -1077,7 +1077,7 @@ PDC_Client_pack_all_requests(int n_objs, pdc_transfer_request_start_all_pkg **tr
                              char **read_bulk_buf)
 {
     perr_t ret_value = SUCCEED;
-    char * bulk_buf, *ptr, *ptr2;
+    char  *bulk_buf, *ptr, *ptr2;
     size_t total_buf_size, obj_data_size, total_obj_data_size, unit, data_size, metadata_size;
     int    i, j;
 
@@ -1183,10 +1183,10 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
     int       index, i, j;
     int       n_objs;
     uint64_t *metadata_id;
-    char **   read_bulk_buf;
-    char *    bulk_buf;
+    char    **read_bulk_buf;
+    char     *bulk_buf;
     size_t    bulk_buf_size;
-    int *     bulk_buf_ref;
+    int      *bulk_buf_ref;
 
     FUNC_ENTER(NULL);
 
@@ -1269,10 +1269,10 @@ static perr_t
 merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merged_request_id,
                            int *merged_size)
 {
-    struct _pdc_id_info *  transferinfo;
+    struct _pdc_id_info   *transferinfo;
     pdcid_t                obj_id, new_local_reg, new_remote_reg;
     int                    flag = 0, i;
-    void *                 new_buf;
+    void                  *new_buf;
     pdc_access_t           access_type;
     pdc_transfer_request **all_transfer_request;
     uint64_t               new_buf_size = 0, copy_off = 0;
@@ -1376,7 +1376,7 @@ PDCregion_transfer_start_all_common(pdcid_t *transfer_request_id, int size, int 
     perr_t                               ret_value  = SUCCEED;
     int                                  write_size = 0, read_size = 0, posix_size = 0, merged_size = 0;
     pdc_transfer_request_start_all_pkg **write_transfer_requests = NULL, **read_transfer_requests = NULL;
-    pdcid_t *                            posix_transfer_request_id, *merged_request_id;
+    pdcid_t                             *posix_transfer_request_id, *merged_request_id;
 
     FUNC_ENTER(NULL);
 
@@ -1467,7 +1467,7 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
 #endif
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1607,7 +1607,7 @@ release_region_buffer(char *buf, uint64_t *obj_dims, int local_ndim, uint64_t *l
     int      k;
 
     perr_t ret_value = SUCCEED;
-    char * ptr;
+    char  *ptr;
     FUNC_ENTER(NULL);
     if (local_ndim == 2) {
         if (access_type == PDC_READ) {
@@ -1646,7 +1646,7 @@ perr_t
 PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *completed)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1737,13 +1737,13 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     int                                 index, i, j, merged_xfer = 0, ori_size = size, is_first = 1;
     size_t                              unit;
     int                                 total_requests, n_objs;
-    uint64_t *                          metadata_ids, merge_off = 0, cur_off = 0;
+    uint64_t                           *metadata_ids, merge_off = 0, cur_off = 0;
     pdc_transfer_request_wait_all_pkg **transfer_requests, *transfer_request_head, *transfer_request_end,
         *temp;
 
     struct _pdc_id_info **transferinfo;
     pdc_transfer_request *transfer_request, *merged_request;
-    pdcid_t *             my_transfer_request_id = transfer_request_id;
+    pdcid_t              *my_transfer_request_id = transfer_request_id;
 
     double t0, t1;
 
@@ -1957,7 +1957,6 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
             transfer_request->obj_servers = (uint32_t *)PDC_free(transfer_request->obj_servers);
         }
         transfer_request->metadata_id = (uint64_t *)PDC_free(transfer_request->metadata_id);
-        transfer_request->metadata_id = NULL;
         transfer_request->is_done     = 1;
         remove_local_transfer_request(transfer_request->obj_pointer, transfer_request_id[i]);
     }
@@ -1977,7 +1976,7 @@ perr_t
 PDCregion_transfer_wait(pdcid_t transfer_request_id)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -2048,7 +2047,6 @@ PDCregion_transfer_wait(pdcid_t transfer_request_id)
                 transfer_request->bulk_buf, transfer_request->bulk_buf_ref, transfer_request->read_bulk_buf);
         }
         transfer_request->metadata_id = (uint64_t *)PDC_free(transfer_request->metadata_id);
-        transfer_request->metadata_id = NULL;
         transfer_request->is_done     = 1;
         remove_local_transfer_request(transfer_request->obj_pointer, transfer_request_id);
     }

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -1853,9 +1853,14 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
                                 ->transfer_request->output_sizes[transfer_requests[j]->index]);
                     }
                     if (transfer_requests[j]->transfer_request->output_buf) {
-                        free(transfer_requests[j]->transfer_request->output_buf[transfer_requests[j]->index]);
+                        transfer_requests[j]->transfer_request->output_buf[transfer_requests[j]->index] =
+                            (char *)PDC_free(transfer_requests[j]
+                                                 ->transfer_request->output_buf[transfer_requests[j]->index]);
                     }
-                    free(transfer_requests[j]->transfer_request->output_offsets[transfer_requests[j]->index]);
+                    transfer_requests[j]->transfer_request->output_offsets[transfer_requests[j]->index] =
+                        (uint64_t *)PDC_free(
+                            transfer_requests[j]
+                                ->transfer_request->output_offsets[transfer_requests[j]->index]);
                 }
             }
             index = i;
@@ -1888,9 +1893,13 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
                         transfer_requests[j]->transfer_request->output_sizes[transfer_requests[j]->index]);
                 }
                 if (transfer_requests[j]->transfer_request->output_buf) {
-                    free(transfer_requests[j]->transfer_request->output_buf[transfer_requests[j]->index]);
+                    transfer_requests[j]->transfer_request->output_buf[transfer_requests[j]->index] =
+                        (char *)PDC_free(
+                            transfer_requests[j]->transfer_request->output_buf[transfer_requests[j]->index]);
                 }
-                free(transfer_requests[j]->transfer_request->output_offsets[transfer_requests[j]->index]);
+                transfer_requests[j]->transfer_request->output_offsets[transfer_requests[j]->index] =
+                    (uint64_t *)PDC_free(
+                        transfer_requests[j]->transfer_request->output_offsets[transfer_requests[j]->index]);
             }
         }
     }
@@ -2005,9 +2014,10 @@ PDCregion_transfer_wait(pdcid_t transfer_request_id)
                                      transfer_request->sub_offsets[i], transfer_request->output_sizes[i]);
                 }
                 if (transfer_request->output_buf) {
-                    free(transfer_request->output_buf[i]);
+                    transfer_request->output_buf[i] = (char *)PDC_free(transfer_request->output_buf[i]);
                 }
-                free(transfer_request->output_offsets[i]);
+                transfer_request->output_offsets[i] =
+                    (uint64_t *)PDC_free(transfer_request->output_offsets[i]);
             }
             // Copy read data from a contiguous buffer back to the user buffer using local data information.
             release_region_buffer(
@@ -2015,13 +2025,13 @@ PDCregion_transfer_wait(pdcid_t transfer_request_id)
                 transfer_request->local_region_offset, transfer_request->local_region_size, unit,
                 transfer_request->access_type, transfer_request->n_obj_servers, transfer_request->new_buf,
                 transfer_request->bulk_buf, transfer_request->bulk_buf_ref, transfer_request->read_bulk_buf);
-            free(transfer_request->output_offsets);
-            free(transfer_request->output_sizes);
-            free(transfer_request->sub_offsets);
+            transfer_request->output_offsets = (uint64_t **)PDC_free(transfer_request->output_offsets);
+            transfer_request->output_sizes   = (uint64_t **)PDC_free(transfer_request->output_sizes);
+            transfer_request->sub_offsets    = (uint64_t **)PDC_free(transfer_request->sub_offsets);
             if (transfer_request->output_buf) {
-                free(transfer_request->output_buf);
+                transfer_request->output_buf = (char **)PDC_free(transfer_request->output_buf);
             }
-            free(transfer_request->obj_servers);
+            transfer_request->obj_servers = (uint32_t *)PDC_free(transfer_request->obj_servers);
         }
         else if (transfer_request->region_partition == PDC_OBJ_STATIC) {
             ret_value = PDC_Client_transfer_request_wait(transfer_request->metadata_id[0],
@@ -2037,7 +2047,7 @@ PDCregion_transfer_wait(pdcid_t transfer_request_id)
                 transfer_request->access_type, transfer_request->n_obj_servers, transfer_request->new_buf,
                 transfer_request->bulk_buf, transfer_request->bulk_buf_ref, transfer_request->read_bulk_buf);
         }
-        free(transfer_request->metadata_id);
+        transfer_request->metadata_id = (uint64_t *)PDC_free(transfer_request->metadata_id);
         transfer_request->metadata_id = NULL;
         transfer_request->is_done     = 1;
         remove_local_transfer_request(transfer_request->obj_pointer, transfer_request_id);

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -76,7 +76,7 @@ typedef struct pdc_transfer_request {
     // For each of the contig buffer sent to a server, we have a bulk buffer.
     char **bulk_buf;
     // Reference counter for bulk_buf, if 0, we free it.
-    int **                 bulk_buf_ref;
+    int                  **bulk_buf_ref;
     pdc_region_partition_t region_partition;
 
     // Consistency semantics required by user
@@ -128,7 +128,7 @@ typedef struct pdc_transfer_request_start_all_pkg {
     int index;
     // Data buffer. This data buffer is contiguous according to the remote region. We assume this is after
     // transformation of local regions
-    char *                                     buf;
+    char                                      *buf;
     struct pdc_transfer_request_start_all_pkg *next;
 } pdc_transfer_request_start_all_pkg;
 
@@ -142,7 +142,7 @@ typedef struct pdc_transfer_request_wait_all_pkg {
     // Record the index of the metadata_id in the current transfer_request
     int index;
     // Pointer to the transfer request
-    pdc_transfer_request *                    transfer_request;
+    pdc_transfer_request                     *transfer_request;
     struct pdc_transfer_request_wait_all_pkg *next;
 } pdc_transfer_request_wait_all_pkg;
 
@@ -196,12 +196,12 @@ PDCregion_transfer_create(void *buf, pdc_access_t access_type, pdcid_t obj_id, p
                           pdcid_t remote_reg)
 {
     pdcid_t                 ret_value = SUCCEED;
-    struct _pdc_id_info *   objinfo2;
-    struct _pdc_obj_info *  obj2;
-    pdc_transfer_request *  p;
-    struct _pdc_id_info *   reginfo1, *reginfo2;
+    struct _pdc_id_info    *objinfo2;
+    struct _pdc_obj_info   *obj2;
+    pdc_transfer_request   *p;
+    struct _pdc_id_info    *reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
-    uint64_t *              ptr;
+    uint64_t               *ptr;
     uint64_t                unit;
     int                     j;
 
@@ -251,7 +251,7 @@ PDCregion_transfer_create(void *buf, pdc_access_t access_type, pdcid_t obj_id, p
     unit                  = p->unit;
 
     p->local_region_ndim   = reg1->ndim;
-    p->local_region_offset = (uint64_t *)malloc(
+    p->local_region_offset = (uint64_t *)PDC_malloc(
         sizeof(uint64_t) * (reg1->ndim * 2 + reg2->ndim * 2 + obj2->obj_pt->obj_prop_pub->ndim));
     ptr = p->local_region_offset;
     memcpy(p->local_region_offset, reg1->offset, sizeof(uint64_t) * reg1->ndim);
@@ -287,7 +287,7 @@ done:
 perr_t
 PDCregion_transfer_close(pdcid_t transfer_request_id)
 {
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     perr_t                ret_value = SUCCEED;
     FUNC_ENTER(NULL);
@@ -297,24 +297,12 @@ PDCregion_transfer_close(pdcid_t transfer_request_id)
         goto done;
     }
     transfer_request = (pdc_transfer_request *)(transferinfo->obj_ptr);
-    /* if (transfer_request->metadata_id == NULL) { */
-    /*     goto done; */
-    /* } */
-
-    // Check for consistency
-    /*
-        pdc_consistency_t consistency = transfer_request->consistency;
-        if (consistency == PDC_CONSISTENCY_POSIX || consistency == PDC_CONSISTENCY_COMMIT ||
-            consistency == PDC_CONSISTENCY_SESSION) {
-            PDCregion_transfer_wait(transfer_request_id);
-        }
-    */
     if (transfer_request->local_region_offset)
-        free(transfer_request->local_region_offset);
+        transfer_request->local_region_offset = (uint64_t *)PDC_free(transfer_request->local_region_offset);
     if (transfer_request->metadata_id)
-        free(transfer_request->metadata_id);
+        transfer_request->metadata_id = (uint64_t *)PDC_free(transfer_request->metadata_id);
     if (transfer_request)
-        free(transfer_request);
+        transfer_request = (pdc_transfer_request *)PDC_free(transfer_request);
 
     /* When the reference count reaches zero the resources are freed */
     if (PDC_dec_ref(transfer_request_id) < 0)
@@ -342,13 +330,13 @@ attach_local_transfer_request(struct _pdc_obj_info *p, pdcid_t transfer_request_
     FUNC_ENTER(NULL);
     if (p->local_transfer_request_head != NULL) {
         p->local_transfer_request_end->next =
-            (pdc_local_transfer_request *)malloc(sizeof(pdc_local_transfer_request));
+            (pdc_local_transfer_request *)PDC_malloc(sizeof(pdc_local_transfer_request));
         p->local_transfer_request_end       = p->local_transfer_request_end->next;
         p->local_transfer_request_end->next = NULL;
     }
     else {
         p->local_transfer_request_head =
-            (pdc_local_transfer_request *)malloc(sizeof(pdc_local_transfer_request));
+            (pdc_local_transfer_request *)PDC_malloc(sizeof(pdc_local_transfer_request));
         p->local_transfer_request_end       = p->local_transfer_request_head;
         p->local_transfer_request_end->next = NULL;
     }
@@ -378,12 +366,12 @@ remove_local_transfer_request(struct _pdc_obj_info *p, pdcid_t transfer_request_
                 // removing first element. Carefully set the head.
                 previous                       = p->local_transfer_request_head;
                 p->local_transfer_request_head = p->local_transfer_request_head->next;
-                free(previous);
+                previous                       = (struct pdc_local_transfer_request *)PDC_free(previous);
             }
             else {
                 // Not the first element, just take the current element away.
                 previous->next = temp->next;
-                free(temp);
+                temp           = (struct pdc_local_transfer_request *)PDC_free(temp);
             }
             p->local_transfer_request_size--;
             break;
@@ -437,13 +425,13 @@ static_region_partition(char *buf, int ndim, uint64_t unit, pdc_access_t access_
         s = 1;
     x = pdc_server_num_g - obj_dims[split_dim] % pdc_server_num_g;
 
-    *data_server_ids = (uint32_t *)malloc(sizeof(uint32_t) * pdc_server_num_g);
+    *data_server_ids = (uint32_t *)PDC_malloc(sizeof(uint32_t) * pdc_server_num_g);
 
-    *output_offsets = (uint64_t **)malloc(sizeof(uint64_t *) * pdc_server_num_g);
-    *output_sizes   = (uint64_t **)malloc(sizeof(uint64_t *) * pdc_server_num_g);
-    *sub_offsets    = (uint64_t **)malloc(sizeof(uint64_t *) * pdc_server_num_g);
+    *output_offsets = (uint64_t **)PDC_malloc(sizeof(uint64_t *) * pdc_server_num_g);
+    *output_sizes   = (uint64_t **)PDC_malloc(sizeof(uint64_t *) * pdc_server_num_g);
+    *sub_offsets    = (uint64_t **)PDC_malloc(sizeof(uint64_t *) * pdc_server_num_g);
     if (set_output_buf) {
-        *output_buf = (char **)malloc(sizeof(char *) * pdc_server_num_g);
+        *output_buf = (char **)PDC_malloc(sizeof(char *) * pdc_server_num_g);
     }
     else {
         *output_buf = NULL;
@@ -466,7 +454,7 @@ static_region_partition(char *buf, int ndim, uint64_t unit, pdc_access_t access_
             // record data server ID
             data_server_ids[0][*n_data_servers] = i;
             // The overlapping region is allocated here.
-            output_offsets[0][*n_data_servers] = (uint64_t *)malloc(sizeof(uint64_t) * ndim * 3);
+            output_offsets[0][*n_data_servers] = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim * 3);
             output_sizes[0][*n_data_servers]   = output_offsets[0][*n_data_servers] + ndim;
             sub_offsets[0][*n_data_servers]    = output_offsets[0][*n_data_servers] + ndim * 2;
             region_size                        = unit;
@@ -537,7 +525,7 @@ pack_region_buffer(char *buf, uint64_t *obj_dims, size_t total_data_size, int lo
 {
     uint64_t i, j;
     perr_t   ret_value = SUCCEED;
-    char *   ptr;
+    char    *ptr;
 
     FUNC_ENTER(NULL);
 
@@ -545,7 +533,7 @@ pack_region_buffer(char *buf, uint64_t *obj_dims, size_t total_data_size, int lo
         *new_buf = buf + local_offset[0] * unit;
     }
     else if (local_ndim == 2) {
-        *new_buf = (char *)malloc(sizeof(char) * total_data_size);
+        *new_buf = (char *)PDC_malloc(sizeof(char) * total_data_size);
         if (access_type == PDC_WRITE) {
             ptr = *new_buf;
             for (i = 0; i < local_size[0]; ++i) {
@@ -556,7 +544,7 @@ pack_region_buffer(char *buf, uint64_t *obj_dims, size_t total_data_size, int lo
         }
     }
     else if (local_ndim == 3) {
-        *new_buf = (char *)malloc(sizeof(char) * total_data_size);
+        *new_buf = (char *)PDC_malloc(sizeof(char) * total_data_size);
         if (access_type == PDC_WRITE) {
             ptr = *new_buf;
             for (i = 0; i < local_size[0]; ++i) {
@@ -585,12 +573,14 @@ set_obj_server_bufs(pdc_transfer_request *transfer_request)
     perr_t ret_value = SUCCEED;
     FUNC_ENTER(NULL);
 
-    transfer_request->bulk_buf     = (char **)malloc(sizeof(char *) * transfer_request->n_obj_servers);
-    transfer_request->bulk_buf_ref = (int **)malloc(sizeof(int *) * transfer_request->n_obj_servers);
-    transfer_request->metadata_id  = (uint64_t *)malloc(sizeof(uint64_t) * transfer_request->n_obj_servers);
+    transfer_request->bulk_buf     = (char **)PDC_malloc(sizeof(char *) * transfer_request->n_obj_servers);
+    transfer_request->bulk_buf_ref = (int **)PDC_malloc(sizeof(int *) * transfer_request->n_obj_servers);
+    transfer_request->metadata_id =
+        (uint64_t *)PDC_malloc(sizeof(uint64_t) * transfer_request->n_obj_servers);
     // read_bulk_buf is filled later when the bulk transfer is packed.
     if (transfer_request->access_type == PDC_READ) {
-        transfer_request->read_bulk_buf = (char **)malloc(sizeof(char *) * transfer_request->n_obj_servers);
+        transfer_request->read_bulk_buf =
+            (char **)PDC_malloc(sizeof(char *) * transfer_request->n_obj_servers);
     }
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -602,7 +592,7 @@ pack_region_metadata_query(pdc_transfer_request_start_all_pkg **transfer_request
 {
     perr_t   ret_value = SUCCEED;
     int      i;
-    char *   ptr;
+    char    *ptr;
     uint64_t total_buf_size;
     uint8_t  region_partition;
 
@@ -616,7 +606,7 @@ pack_region_metadata_query(pdc_transfer_request_start_all_pkg **transfer_request
                           sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint8_t) + sizeof(size_t);
     }
 
-    *buf_ptr = (char *)malloc(total_buf_size);
+    *buf_ptr = (char *)PDC_malloc(total_buf_size);
     ptr      = *buf_ptr;
     for (i = 0; i < size; ++i) {
         memcpy(ptr, &(transfer_request[i]->transfer_request->obj_id), sizeof(uint64_t));
@@ -650,13 +640,13 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
 {
     perr_t                              ret_value = SUCCEED;
     pdc_transfer_request_start_all_pkg *transfer_request_head, *transfer_request_end;
-    pdc_transfer_request *              local_request;
+    pdc_transfer_request               *local_request;
     int                                 size;
     int                                 i, j, index;
     int                                 counter;
-    char *                              ptr;
+    char                               *ptr;
     uint64_t                            region_size;
-    uint64_t *                          sub_offset;
+    uint64_t                           *sub_offset;
     FUNC_ENTER(NULL);
 
     local_request         = NULL;
@@ -670,12 +660,12 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
     for (i = 0; i < size; ++i) {
         if (transfer_request_head) {
             transfer_request_end->next =
-                (pdc_transfer_request_start_all_pkg *)malloc(sizeof(pdc_transfer_request_start_all_pkg));
+                (pdc_transfer_request_start_all_pkg *)PDC_malloc(sizeof(pdc_transfer_request_start_all_pkg));
             transfer_request_end = transfer_request_end->next;
         }
         else {
             transfer_request_head =
-                (pdc_transfer_request_start_all_pkg *)malloc(sizeof(pdc_transfer_request_start_all_pkg));
+                (pdc_transfer_request_start_all_pkg *)PDC_malloc(sizeof(pdc_transfer_request_start_all_pkg));
             transfer_request_end = transfer_request_head;
         }
         // Obj ID + Obj dim + region offset + region size
@@ -685,12 +675,13 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
             local_request                = transfer_request_input[index]->transfer_request;
             local_request->n_obj_servers = counter;
             local_request->output_offsets =
-                (uint64_t **)malloc(sizeof(uint64_t *) * local_request->n_obj_servers);
+                (uint64_t **)PDC_malloc(sizeof(uint64_t *) * local_request->n_obj_servers);
             local_request->output_sizes =
-                (uint64_t **)malloc(sizeof(uint64_t *) * local_request->n_obj_servers);
+                (uint64_t **)PDC_malloc(sizeof(uint64_t *) * local_request->n_obj_servers);
             local_request->sub_offsets =
-                (uint64_t **)malloc(sizeof(uint64_t *) * local_request->n_obj_servers);
-            local_request->obj_servers = (uint32_t *)malloc(sizeof(uint32_t) * local_request->n_obj_servers);
+                (uint64_t **)PDC_malloc(sizeof(uint64_t *) * local_request->n_obj_servers);
+            local_request->obj_servers =
+                (uint32_t *)PDC_malloc(sizeof(uint32_t) * local_request->n_obj_servers);
             set_obj_server_bufs(local_request);
         }
         transfer_request_end->next             = NULL;
@@ -699,7 +690,7 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
 
         ptr += sizeof(uint32_t);
         transfer_request_end->remote_offset =
-            (uint64_t *)malloc(sizeof(uint64_t) * local_request->remote_region_ndim * 3);
+            (uint64_t *)PDC_malloc(sizeof(uint64_t) * local_request->remote_region_ndim * 3);
         transfer_request_end->remote_size =
             transfer_request_end->remote_offset + local_request->remote_region_ndim;
         sub_offset = transfer_request_end->remote_offset + local_request->remote_region_ndim * 2;
@@ -721,7 +712,7 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
             sub_offset[j] = transfer_request_end->remote_offset[j] - local_request->remote_region_offset[j];
         }
         if (local_request->access_type == PDC_WRITE) {
-            transfer_request_end->buf = (char *)malloc(region_size);
+            transfer_request_end->buf = (char *)PDC_malloc(region_size);
             memcpy_subregion(local_request->remote_region_ndim, local_request->unit,
                              local_request->access_type, transfer_request_input[index]->buf,
                              local_request->remote_region_size, transfer_request_end->buf, sub_offset,
@@ -749,15 +740,15 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
     perr_t                               ret_value = SUCCEED;
     int                                  i, j, index, size, output_size, remain_size, n_objs;
     pdc_transfer_request_start_all_pkg **transfer_requests;
-    pdc_transfer_request_start_all_pkg * transfer_request_head, *transfer_request_front_head,
+    pdc_transfer_request_start_all_pkg  *transfer_request_head, *transfer_request_front_head,
         *transfer_request_end, **transfer_request_output, *previous = NULL;
     uint64_t total_buf_size, output_buf_size, query_id;
-    char *   buf, *output_buf;
+    char    *buf, *output_buf;
 
     FUNC_ENTER(NULL);
     transfer_request_output     = NULL;
     transfer_request_front_head = NULL;
-    transfer_requests           = (pdc_transfer_request_start_all_pkg **)malloc(
+    transfer_requests           = (pdc_transfer_request_start_all_pkg **)PDC_malloc(
         sizeof(pdc_transfer_request_start_all_pkg *) * input_size);
     size = 0;
     for (i = 0; i < input_size; ++i) {
@@ -781,15 +772,15 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
             PDC_Client_transfer_request_metadata_query(
                 buf, total_buf_size, n_objs, transfer_requests[index]->transfer_request->metadata_server_id,
                 is_write, &output_buf_size, &query_id);
-            free(buf);
+            buf = (char *)PDC_free(buf);
             if (query_id) {
-                output_buf = (char *)malloc(output_buf_size);
+                output_buf = (char *)PDC_malloc(output_buf_size);
                 PDC_Client_transfer_request_metadata_query2(
                     output_buf, output_buf_size, query_id,
                     transfer_requests[index]->transfer_request->metadata_server_id);
                 unpack_region_metadata_query(output_buf, transfer_requests + index, &transfer_request_head,
                                              &transfer_request_end, &output_size);
-                free(output_buf);
+                output_buf = (char *)PDC_free(output_buf);
                 if (transfer_request_front_head) {
                     previous->next = transfer_request_head;
                 }
@@ -808,16 +799,16 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
         PDC_Client_transfer_request_metadata_query(
             buf, total_buf_size, n_objs, transfer_requests[index]->transfer_request->metadata_server_id,
             is_write, &output_buf_size, &query_id);
-        free(buf);
+        buf = (char *)PDC_free(buf);
         // If it is a valid query ID, then it means regions are overlapping.
         if (query_id) {
-            output_buf = (char *)malloc(output_buf_size);
+            output_buf = (char *)PDC_malloc(output_buf_size);
             PDC_Client_transfer_request_metadata_query2(
                 output_buf, output_buf_size, query_id,
                 transfer_requests[index]->transfer_request->metadata_server_id);
             unpack_region_metadata_query(output_buf, transfer_requests + index, &transfer_request_head,
                                          &transfer_request_end, &output_size);
-            free(output_buf);
+            output_buf = (char *)PDC_free(output_buf);
             if (transfer_request_front_head) {
                 previous->next = transfer_request_head;
             }
@@ -829,7 +820,7 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
     }
 
     if (output_size) {
-        transfer_request_output = (pdc_transfer_request_start_all_pkg **)malloc(
+        transfer_request_output = (pdc_transfer_request_start_all_pkg **)PDC_malloc(
             sizeof(pdc_transfer_request_start_all_pkg *) * (output_size + remain_size));
         transfer_request_head = transfer_request_front_head;
         i                     = 0;
@@ -843,14 +834,15 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
             if (transfer_request_input[i]->transfer_request->region_partition == PDC_REGION_DYNAMIC ||
                 transfer_request_input[i]->transfer_request->region_partition == PDC_REGION_LOCAL) {
                 // These are replaced by newly created request pkgs.
-                free(transfer_request_input[i]);
+                transfer_request_input[i] =
+                    (pdc_transfer_request_start_all_pkg *)PDC_free(transfer_request_input[i]);
             }
             else {
                 transfer_request_output[j] = transfer_request_input[i];
                 j++;
             }
         }
-        free(transfer_request_input);
+        transfer_request_input = (pdc_transfer_request_start_all_pkg **)PDC_free(transfer_request_input);
         *transfer_request_output_ptr = transfer_request_output;
         *output_size_ptr             = j;
     }
@@ -859,7 +851,7 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
         *output_size_ptr             = input_size;
     }
 
-    free(transfer_requests);
+    transfer_requests = (pdc_transfer_request_start_all_pkg **)PDC_free(transfer_requests);
 
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -883,7 +875,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
         *read_request_pkgs, *write_request_pkgs_end, *read_request_pkgs_end, *request_pkgs,
         **transfer_request_output;
     int                   write_size, read_size, output_size;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     int                   set_output_buf = 0;
 
@@ -892,7 +884,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     write_size                     = 0;
     read_size                      = 0;
     posix_size_ptr[0]              = 0;
-    *posix_transfer_request_id_ptr = (pdcid_t *)malloc(sizeof(pdcid_t) * size);
+    *posix_transfer_request_id_ptr = (pdcid_t *)PDC_malloc(sizeof(pdcid_t) * size);
 
     for (i = 0; i < size; ++i) {
         transferinfo = PDC_find_id(transfer_request_id[i]);
@@ -932,8 +924,8 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
                 return FAIL;
             }
             for (j = 0; j < transfer_request->n_obj_servers; ++j) {
-                request_pkgs =
-                    (pdc_transfer_request_start_all_pkg *)malloc(sizeof(pdc_transfer_request_start_all_pkg));
+                request_pkgs = (pdc_transfer_request_start_all_pkg *)PDC_malloc(
+                    sizeof(pdc_transfer_request_start_all_pkg));
                 request_pkgs->transfer_request = transfer_request;
                 request_pkgs->data_server_id   = transfer_request->obj_servers[j];
                 request_pkgs->remote_offset    = transfer_request->output_offsets[j];
@@ -975,7 +967,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
                  transfer_request->region_partition == PDC_REGION_LOCAL) {
             transfer_request->n_obj_servers = 1;
             request_pkgs =
-                (pdc_transfer_request_start_all_pkg *)malloc(sizeof(pdc_transfer_request_start_all_pkg));
+                (pdc_transfer_request_start_all_pkg *)PDC_malloc(sizeof(pdc_transfer_request_start_all_pkg));
             request_pkgs->transfer_request = transfer_request;
             request_pkgs->index            = 0;
             if (transfer_request->region_partition == PDC_OBJ_STATIC) {
@@ -1021,7 +1013,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     }
 
     if (write_size) {
-        write_transfer_request = (pdc_transfer_request_start_all_pkg **)malloc(
+        write_transfer_request = (pdc_transfer_request_start_all_pkg **)PDC_malloc(
             sizeof(pdc_transfer_request_start_all_pkg *) * write_size);
         request_pkgs = write_request_pkgs;
         for (i = 0; i < write_size; ++i) {
@@ -1039,7 +1031,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     }
 
     if (read_size) {
-        read_transfer_request = (pdc_transfer_request_start_all_pkg **)malloc(
+        read_transfer_request = (pdc_transfer_request_start_all_pkg **)PDC_malloc(
             sizeof(pdc_transfer_request_start_all_pkg *) * read_size);
         request_pkgs = read_request_pkgs;
         for (i = 0; i < read_size; ++i) {
@@ -1065,17 +1057,16 @@ finish_start_all_requests(pdc_transfer_request_start_all_pkg **write_transfer_re
 {
     int i;
     for (i = 0; i < write_size; ++i) {
-        free(write_transfer_request[i]);
+        write_transfer_request[i] = (pdc_transfer_request_start_all_pkg *)PDC_free(write_transfer_request[i]);
     }
     for (i = 0; i < read_size; ++i) {
-        free(read_transfer_request[i]);
+        read_transfer_request[i] = (pdc_transfer_request_start_all_pkg *)PDC_free(read_transfer_request[i]);
     }
-    // MPI_Barrier(MPI_COMM_WORLD);
     if (write_size) {
-        free(write_transfer_request);
+        write_transfer_request = (pdc_transfer_request_start_all_pkg **)PDC_free(write_transfer_request);
     }
     if (read_size) {
-        free(read_transfer_request);
+        read_transfer_request = (pdc_transfer_request_start_all_pkg **)PDC_free(read_transfer_request);
     }
     return 0;
 }
@@ -1086,7 +1077,7 @@ PDC_Client_pack_all_requests(int n_objs, pdc_transfer_request_start_all_pkg **tr
                              char **read_bulk_buf)
 {
     perr_t ret_value = SUCCEED;
-    char * bulk_buf, *ptr, *ptr2;
+    char  *bulk_buf, *ptr, *ptr2;
     size_t total_buf_size, obj_data_size, total_obj_data_size, unit, data_size, metadata_size;
     int    i, j;
 
@@ -1138,7 +1129,7 @@ PDC_Client_pack_all_requests(int n_objs, pdc_transfer_request_start_all_pkg **tr
             total_buf_size = metadata_size + data_size;
         }
     }
-    bulk_buf      = (char *)malloc(total_buf_size);
+    bulk_buf      = (char *)PDC_malloc(total_buf_size);
     *bulk_buf_ptr = bulk_buf;
     ptr           = bulk_buf;
     ptr2          = bulk_buf;
@@ -1192,10 +1183,10 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
     int       index, i, j;
     int       n_objs;
     uint64_t *metadata_id;
-    char **   read_bulk_buf;
-    char *    bulk_buf;
+    char    **read_bulk_buf;
+    char     *bulk_buf;
     size_t    bulk_buf_size;
-    int *     bulk_buf_ref;
+    int      *bulk_buf_ref;
 
     FUNC_ENTER(NULL);
 
@@ -1208,8 +1199,8 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
     if (size == 0)
         goto done;
 
-    metadata_id   = (uint64_t *)malloc(sizeof(uint64_t) * size);
-    read_bulk_buf = (char **)malloc(sizeof(char *) * size);
+    metadata_id   = (uint64_t *)PDC_malloc(sizeof(uint64_t) * size);
+    read_bulk_buf = (char **)PDC_malloc(sizeof(char *) * size);
     index         = 0;
     for (i = 1; i < size; ++i) {
         if (transfer_requests[i]->data_server_id != transfer_requests[i - 1]->data_server_id) {
@@ -1218,7 +1209,7 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
             PDC_Client_pack_all_requests(n_objs, transfer_requests + index,
                                          transfer_requests[index]->transfer_request->access_type, &bulk_buf,
                                          &bulk_buf_size, read_bulk_buf + index);
-            bulk_buf_ref    = (int *)malloc(sizeof(int));
+            bulk_buf_ref    = (int *)PDC_malloc(sizeof(int));
             bulk_buf_ref[0] = n_objs;
             PDC_Client_transfer_request_all(n_objs, transfer_requests[index]->transfer_request->access_type,
                                             transfer_requests[index]->data_server_id, bulk_buf, bulk_buf_size,
@@ -1245,7 +1236,7 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
         PDC_Client_pack_all_requests(n_objs, transfer_requests + index,
                                      transfer_requests[index]->transfer_request->access_type, &bulk_buf,
                                      &bulk_buf_size, read_bulk_buf + index);
-        bulk_buf_ref    = (int *)malloc(sizeof(int));
+        bulk_buf_ref    = (int *)PDC_malloc(sizeof(int));
         bulk_buf_ref[0] = n_objs;
         PDC_Client_transfer_request_all(n_objs, transfer_requests[index]->transfer_request->access_type,
                                         transfer_requests[index]->data_server_id, bulk_buf, bulk_buf_size,
@@ -1264,8 +1255,8 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
         }
     }
 
-    free(read_bulk_buf);
-    free(metadata_id);
+    read_bulk_buf = (char **)PDC_free(read_bulk_buf);
+    metadata_id   = (uint64_t *)PDC_free(metadata_id);
 
 done:
     fflush(stdout);
@@ -1278,10 +1269,10 @@ static perr_t
 merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merged_request_id,
                            int *merged_size)
 {
-    struct _pdc_id_info *  transferinfo;
+    struct _pdc_id_info   *transferinfo;
     pdcid_t                obj_id, new_local_reg, new_remote_reg;
     int                    flag = 0, i;
-    void *                 new_buf;
+    void                  *new_buf;
     pdc_access_t           access_type;
     pdc_transfer_request **all_transfer_request;
     uint64_t               new_buf_size = 0, copy_off = 0;
@@ -1363,8 +1354,6 @@ merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merg
             }
         }
 
-        /* *merged_request_id = */
-        /*     PDCregion_transfer_create(new_buf, PDC_WRITE, obj_id, new_local_reg, new_remote_reg); */
         *merged_request_id = PDCregion_transfer_create(new_buf, all_transfer_request[0]->access_type, obj_id,
                                                        new_local_reg, new_remote_reg);
         *merged_size       = 1;
@@ -1372,7 +1361,7 @@ merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merg
         all_transfer_request[0]->merged_request_id = *merged_request_id;
     }
 
-    free(all_transfer_request);
+    all_transfer_request = (pdc_transfer_request **)PDC_free(all_transfer_request);
 
     return SUCCEED;
 }
@@ -1387,7 +1376,7 @@ PDCregion_transfer_start_all_common(pdcid_t *transfer_request_id, int size, int 
     perr_t                               ret_value  = SUCCEED;
     int                                  write_size = 0, read_size = 0, posix_size = 0, merged_size = 0;
     pdc_transfer_request_start_all_pkg **write_transfer_requests = NULL, **read_transfer_requests = NULL;
-    pdcid_t *                            posix_transfer_request_id, *merged_request_id;
+    pdcid_t                             *posix_transfer_request_id, *merged_request_id;
 
     FUNC_ENTER(NULL);
 
@@ -1430,7 +1419,7 @@ PDCregion_transfer_start_all_common(pdcid_t *transfer_request_id, int size, int 
     if (posix_size > 0) {
         LOG_ERROR("==PDC_CLIENT[%d]: wait for posix requests\n", pdc_client_mpi_rank_g);
         PDCregion_transfer_wait_all(posix_transfer_request_id, posix_size);
-        free(posix_transfer_request_id);
+        posix_transfer_request_id = (pdcid_t *)PDC_free(posix_transfer_request_id);
     }
 
     // Clean up memory
@@ -1469,64 +1458,6 @@ PDCregion_transfer_start_all_mpi(pdcid_t *transfer_request_id, int size, MPI_Com
 }
 #endif
 
-/**
- * Input: Sorted arrays
- * Output: A single array that is sorted, and the union of sorted arrays.
- */
-#if 0
-static int sorted_array_unions(const int **array, const int *input_size, int n_arrays, int **out_array, int *out_size) {
-    int i;
-    int total_size = 0;
-    int *size;
-    int temp_n_arrays;
-    int min;
-
-    size = calloc(n_arrays, sizeof(int));
-
-    for ( i = 0; i < n_arrays; ++i ) {
-        total_size += size[i];
-    }
-    *out_array = (int*) malloc(sizeof(int) * total_size);
-    *out_size = 0;
-
-    while (1) {
-        // check how many remaining arrays do we left.
-        temp_n_arrays = 0;
-        for ( i = 0; i < n_arrays; ++i ) {
-            if ( size[i] < input_size[i] ) {
-                temp_n_arrays++;
-                break;
-            }
-        }
-        // If no more remaining arrays, we are done.
-        if (!temp_n_arrays) {
-            break;
-        }
-        // Now we figure out the minimum element of the remaining lists and append it to the end of output array
-        min = -1;
-        for ( i = 0; i < n_arrays; ++i ) {
-            if ( size[i] == input_size[i] ) {
-                continue;
-            }
-            if ( min == -1 || min > array[i][size[i]] ) {
-                min = array[i][size[i]];
-            }
-        }
-        out_array[0][*out_size] = min;
-        out_size[0]++;
-        // Increment the arrays.
-        for ( i = 0; i < n_arrays; ++i ) {
-            if ( min == array[i][size[i]] ) {
-                size[i]++;
-            }
-        }
-    }
-    free(size);
-    *out_array = realloc(*out_array, out_size[0]);
-    return 0;
-}
-#endif
-
 perr_t
 PDCregion_transfer_start_common(pdcid_t transfer_request_id,
 #ifdef ENABLE_MPI
@@ -1536,7 +1467,7 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
 #endif
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1596,10 +1527,10 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
         }
         // The following memories will be freed in the wait function.
         transfer_request->metadata_id =
-            (uint64_t *)malloc(sizeof(uint64_t) * transfer_request->n_obj_servers);
+            (uint64_t *)PDC_malloc(sizeof(uint64_t) * transfer_request->n_obj_servers);
         if (transfer_request->access_type == PDC_READ) {
             transfer_request->read_bulk_buf =
-                (char **)malloc(sizeof(char *) * transfer_request->n_obj_servers);
+                (char **)PDC_malloc(sizeof(char *) * transfer_request->n_obj_servers);
         }
         for (i = 0; i < transfer_request->n_obj_servers; ++i) {
             if (transfer_request->access_type == PDC_READ) {
@@ -1615,11 +1546,11 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
     else if (transfer_request->region_partition == PDC_OBJ_STATIC) {
         // Static object partitioning means that all requests for the same object are sent to the same data
         // server.
-        transfer_request->metadata_id   = (uint64_t *)malloc(sizeof(uint64_t));
+        transfer_request->metadata_id   = (uint64_t *)PDC_malloc(sizeof(uint64_t));
         transfer_request->n_obj_servers = 1;
         if (transfer_request->access_type == PDC_READ) {
             transfer_request->read_bulk_buf =
-                (char **)malloc(sizeof(char *) * transfer_request->n_obj_servers);
+                (char **)PDC_malloc(sizeof(char *) * transfer_request->n_obj_servers);
             transfer_request->read_bulk_buf[0] = transfer_request->new_buf;
         }
         // Submit transfer request to server by designating data server ID, remote region info, and contiguous
@@ -1676,7 +1607,7 @@ release_region_buffer(char *buf, uint64_t *obj_dims, int local_ndim, uint64_t *l
     int      k;
 
     perr_t ret_value = SUCCEED;
-    char * ptr;
+    char  *ptr;
     FUNC_ENTER(NULL);
     if (local_ndim == 2) {
         if (access_type == PDC_READ) {
@@ -1694,21 +1625,18 @@ release_region_buffer(char *buf, uint64_t *obj_dims, int local_ndim, uint64_t *l
         for (k = 0; k < bulk_buf_size; ++k) {
             bulk_buf_ref[k][0]--;
             if (!bulk_buf_ref[k][0]) {
-                if (bulk_buf[k]) {
-                    free(bulk_buf[k]);
-                }
-                free(bulk_buf_ref[k]);
+                if (bulk_buf[k])
+                    bulk_buf[k] = (char *)PDC_free(bulk_buf[k]);
+                bulk_buf_ref[k] = (int *)PDC_free(bulk_buf_ref[k]);
             }
         }
-        free(bulk_buf_ref);
-        free(bulk_buf);
+        bulk_buf_ref = (int **)PDC_free(bulk_buf_ref);
+        bulk_buf     = (char **)PDC_free(bulk_buf);
     }
-    if (local_ndim > 1 && new_buf) {
-        free(new_buf);
-    }
-    if (read_bulk_buf) {
-        free(read_bulk_buf);
-    }
+    if (local_ndim > 1 && new_buf)
+        new_buf = (char *)PDC_free(new_buf);
+    if (read_bulk_buf)
+        read_bulk_buf = (char **)PDC_free(read_bulk_buf);
 
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -1718,7 +1646,7 @@ perr_t
 PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *completed)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1756,9 +1684,10 @@ PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *co
                                      transfer_request->sub_offsets[i], transfer_request->output_sizes[i]);
                 }
                 if (transfer_request->output_buf) {
-                    free(transfer_request->output_buf[i]);
+                    transfer_request->output_buf[i] = (char *)PDC_free(transfer_request->output_buf[i]);
                 }
-                free(transfer_request->output_offsets[i]);
+                transfer_request->output_offsets[i] =
+                    (uint64_t *)PDC_free(transfer_request->output_offsets[i]);
             }
             // Copy read data from a contiguous buffer back to the user buffer using local data information.
             release_region_buffer(
@@ -1766,13 +1695,11 @@ PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *co
                 transfer_request->local_region_offset, transfer_request->local_region_size, unit,
                 transfer_request->access_type, transfer_request->n_obj_servers, transfer_request->new_buf,
                 transfer_request->bulk_buf, transfer_request->bulk_buf_ref, transfer_request->read_bulk_buf);
-            free(transfer_request->output_offsets);
-            // free(transfer_request->output_sizes);
-            // free(transfer_request->sub_offsets);
+            transfer_request->output_offsets = (uint64_t **)PDC_free(transfer_request->output_offsets);
             if (transfer_request->output_buf) {
-                free(transfer_request->output_buf);
+                transfer_request->output_buf = (char **)PDC_free(transfer_request->output_buf);
             }
-            free(transfer_request->obj_servers);
+            transfer_request->obj_servers = (uint32_t *)PDC_free(transfer_request->obj_servers);
         }
         else if (transfer_request->region_partition == PDC_OBJ_STATIC) {
             ret_value = PDC_Client_transfer_request_status(transfer_request->metadata_id[0],
@@ -1790,7 +1717,7 @@ PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *co
                 transfer_request->access_type, transfer_request->n_obj_servers, transfer_request->new_buf,
                 transfer_request->bulk_buf, transfer_request->bulk_buf_ref, transfer_request->read_bulk_buf);
         }
-        free(transfer_request->metadata_id);
+        transfer_request->metadata_id = (uint64_t *)PDC_free(transfer_request->metadata_id);
         transfer_request->metadata_id = NULL;
         transfer_request->is_done     = 1;
         remove_local_transfer_request(transfer_request->obj_pointer, transfer_request_id);
@@ -1810,13 +1737,13 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     int                                 index, i, j, merged_xfer = 0, ori_size = size, is_first = 1;
     size_t                              unit;
     int                                 total_requests, n_objs;
-    uint64_t *                          metadata_ids, merge_off = 0, cur_off = 0;
+    uint64_t                           *metadata_ids, merge_off = 0, cur_off = 0;
     pdc_transfer_request_wait_all_pkg **transfer_requests, *transfer_request_head, *transfer_request_end,
         *temp;
 
     struct _pdc_id_info **transferinfo;
     pdc_transfer_request *transfer_request, *merged_request;
-    pdcid_t *             my_transfer_request_id = transfer_request_id;
+    pdcid_t              *my_transfer_request_id = transfer_request_id;
 
     double t0, t1;
 
@@ -1860,14 +1787,14 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
         total_requests += transfer_request->n_obj_servers;
         for (j = 0; j < transfer_request->n_obj_servers; ++j) {
             if (transfer_request_head) {
-                transfer_request_end->next =
-                    (pdc_transfer_request_wait_all_pkg *)malloc(sizeof(pdc_transfer_request_wait_all_pkg));
+                transfer_request_end->next = (pdc_transfer_request_wait_all_pkg *)PDC_malloc(
+                    sizeof(pdc_transfer_request_wait_all_pkg));
                 transfer_request_end       = transfer_request_end->next;
                 transfer_request_end->next = NULL;
             }
             else {
-                transfer_request_head =
-                    (pdc_transfer_request_wait_all_pkg *)malloc(sizeof(pdc_transfer_request_wait_all_pkg));
+                transfer_request_head = (pdc_transfer_request_wait_all_pkg *)PDC_malloc(
+                    sizeof(pdc_transfer_request_wait_all_pkg));
                 transfer_request_head->next = NULL;
                 transfer_request_end        = transfer_request_head;
             }
@@ -1883,7 +1810,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
         }
     }
 
-    transfer_requests = (pdc_transfer_request_wait_all_pkg **)malloc(
+    transfer_requests = (pdc_transfer_request_wait_all_pkg **)PDC_malloc(
         sizeof(pdc_transfer_request_wait_all_pkg *) * total_requests);
     temp = transfer_request_head;
     for (i = 0; i < total_requests; ++i) {
@@ -1894,7 +1821,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     qsort(transfer_requests, total_requests, sizeof(pdc_transfer_request_wait_all_pkg *),
           sort_by_data_server_wait_all);
 
-    metadata_ids = (uint64_t *)malloc(sizeof(uint64_t) * total_requests);
+    metadata_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * total_requests);
     index        = 0;
     for (i = 1; i < total_requests; ++i) {
         if (transfer_requests[i]->data_server_id != transfer_requests[i - 1]->data_server_id) {
@@ -2012,31 +1939,26 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
         if (transfer_request->region_partition == PDC_REGION_STATIC ||
             transfer_request->region_partition == PDC_REGION_DYNAMIC ||
             transfer_request->region_partition == PDC_REGION_LOCAL) {
-            free(transfer_request->output_offsets);
-            free(transfer_request->output_sizes);
-            free(transfer_request->sub_offsets);
+            transfer_request->output_offsets = (uint64_t **)PDC_free(transfer_request->output_offsets);
+            transfer_request->output_sizes   = (uint64_t **)PDC_free(transfer_request->output_sizes);
+            transfer_request->sub_offsets    = (uint64_t **)PDC_free(transfer_request->sub_offsets);
             if (transfer_request->output_buf) {
-                free(transfer_request->output_buf);
+                transfer_request->output_buf = (char **)PDC_free(transfer_request->output_buf);
             }
-            free(transfer_request->obj_servers);
+            transfer_request->obj_servers = (uint32_t *)PDC_free(transfer_request->obj_servers);
         }
-        free(transfer_request->metadata_id);
+        transfer_request->metadata_id = (uint64_t *)PDC_free(transfer_request->metadata_id);
         transfer_request->metadata_id = NULL;
         transfer_request->is_done     = 1;
         remove_local_transfer_request(transfer_request->obj_pointer, transfer_request_id[i]);
     }
 
     for (i = 0; i < total_requests; ++i) {
-        free(transfer_requests[i]);
+        transfer_requests[i] = (pdc_transfer_request_wait_all_pkg *)PDC_free(transfer_requests[i]);
     }
-    free(transfer_requests);
-    free(metadata_ids);
-    free(transferinfo);
-    /*
-            for (i = 0; i < size; ++i) {
-                PDCregion_transfer_wait(transfer_request_id[i]);
-            }
-    */
+    transfer_requests = (pdc_transfer_request_wait_all_pkg **)PDC_free(transfer_requests);
+    metadata_ids      = (uint64_t *)PDC_free(metadata_ids);
+    transferinfo      = (struct _pdc_id_info **)PDC_free(transferinfo);
 done:
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -2046,7 +1968,7 @@ perr_t
 PDCregion_transfer_wait(pdcid_t transfer_request_id)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info * transferinfo;
+    struct _pdc_id_info  *transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -76,7 +76,7 @@ typedef struct pdc_transfer_request {
     // For each of the contig buffer sent to a server, we have a bulk buffer.
     char **bulk_buf;
     // Reference counter for bulk_buf, if 0, we free it.
-    int                  **bulk_buf_ref;
+    int **                 bulk_buf_ref;
     pdc_region_partition_t region_partition;
 
     // Consistency semantics required by user
@@ -128,7 +128,7 @@ typedef struct pdc_transfer_request_start_all_pkg {
     int index;
     // Data buffer. This data buffer is contiguous according to the remote region. We assume this is after
     // transformation of local regions
-    char                                      *buf;
+    char *                                     buf;
     struct pdc_transfer_request_start_all_pkg *next;
 } pdc_transfer_request_start_all_pkg;
 
@@ -142,7 +142,7 @@ typedef struct pdc_transfer_request_wait_all_pkg {
     // Record the index of the metadata_id in the current transfer_request
     int index;
     // Pointer to the transfer request
-    pdc_transfer_request                     *transfer_request;
+    pdc_transfer_request *                    transfer_request;
     struct pdc_transfer_request_wait_all_pkg *next;
 } pdc_transfer_request_wait_all_pkg;
 
@@ -196,12 +196,12 @@ PDCregion_transfer_create(void *buf, pdc_access_t access_type, pdcid_t obj_id, p
                           pdcid_t remote_reg)
 {
     pdcid_t                 ret_value = SUCCEED;
-    struct _pdc_id_info    *objinfo2;
-    struct _pdc_obj_info   *obj2;
-    pdc_transfer_request   *p;
-    struct _pdc_id_info    *reginfo1, *reginfo2;
+    struct _pdc_id_info *   objinfo2;
+    struct _pdc_obj_info *  obj2;
+    pdc_transfer_request *  p;
+    struct _pdc_id_info *   reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
-    uint64_t               *ptr;
+    uint64_t *              ptr;
     uint64_t                unit;
     int                     j;
 
@@ -287,7 +287,7 @@ done:
 perr_t
 PDCregion_transfer_close(pdcid_t transfer_request_id)
 {
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     perr_t                ret_value = SUCCEED;
     FUNC_ENTER(NULL);
@@ -525,7 +525,7 @@ pack_region_buffer(char *buf, uint64_t *obj_dims, size_t total_data_size, int lo
 {
     uint64_t i, j;
     perr_t   ret_value = SUCCEED;
-    char    *ptr;
+    char *   ptr;
 
     FUNC_ENTER(NULL);
 
@@ -592,7 +592,7 @@ pack_region_metadata_query(pdc_transfer_request_start_all_pkg **transfer_request
 {
     perr_t   ret_value = SUCCEED;
     int      i;
-    char    *ptr;
+    char *   ptr;
     uint64_t total_buf_size;
     uint8_t  region_partition;
 
@@ -640,13 +640,13 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
 {
     perr_t                              ret_value = SUCCEED;
     pdc_transfer_request_start_all_pkg *transfer_request_head, *transfer_request_end;
-    pdc_transfer_request               *local_request;
+    pdc_transfer_request *              local_request;
     int                                 size;
     int                                 i, j, index;
     int                                 counter;
-    char                               *ptr;
+    char *                              ptr;
     uint64_t                            region_size;
-    uint64_t                           *sub_offset;
+    uint64_t *                          sub_offset;
     FUNC_ENTER(NULL);
 
     local_request         = NULL;
@@ -740,10 +740,10 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
     perr_t                               ret_value = SUCCEED;
     int                                  i, j, index, size, output_size, remain_size, n_objs;
     pdc_transfer_request_start_all_pkg **transfer_requests;
-    pdc_transfer_request_start_all_pkg  *transfer_request_head, *transfer_request_front_head,
+    pdc_transfer_request_start_all_pkg * transfer_request_head, *transfer_request_front_head,
         *transfer_request_end, **transfer_request_output, *previous = NULL;
     uint64_t total_buf_size, output_buf_size, query_id;
-    char    *buf, *output_buf;
+    char *   buf, *output_buf;
 
     FUNC_ENTER(NULL);
     transfer_request_output     = NULL;
@@ -875,7 +875,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
         *read_request_pkgs, *write_request_pkgs_end, *read_request_pkgs_end, *request_pkgs,
         **transfer_request_output;
     int                   write_size, read_size, output_size;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     int                   set_output_buf = 0;
 
@@ -1077,7 +1077,7 @@ PDC_Client_pack_all_requests(int n_objs, pdc_transfer_request_start_all_pkg **tr
                              char **read_bulk_buf)
 {
     perr_t ret_value = SUCCEED;
-    char  *bulk_buf, *ptr, *ptr2;
+    char * bulk_buf, *ptr, *ptr2;
     size_t total_buf_size, obj_data_size, total_obj_data_size, unit, data_size, metadata_size;
     int    i, j;
 
@@ -1183,10 +1183,10 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
     int       index, i, j;
     int       n_objs;
     uint64_t *metadata_id;
-    char    **read_bulk_buf;
-    char     *bulk_buf;
+    char **   read_bulk_buf;
+    char *    bulk_buf;
     size_t    bulk_buf_size;
-    int      *bulk_buf_ref;
+    int *     bulk_buf_ref;
 
     FUNC_ENTER(NULL);
 
@@ -1269,10 +1269,10 @@ static perr_t
 merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merged_request_id,
                            int *merged_size)
 {
-    struct _pdc_id_info   *transferinfo;
+    struct _pdc_id_info *  transferinfo;
     pdcid_t                obj_id, new_local_reg, new_remote_reg;
     int                    flag = 0, i;
-    void                  *new_buf;
+    void *                 new_buf;
     pdc_access_t           access_type;
     pdc_transfer_request **all_transfer_request;
     uint64_t               new_buf_size = 0, copy_off = 0;
@@ -1376,7 +1376,7 @@ PDCregion_transfer_start_all_common(pdcid_t *transfer_request_id, int size, int 
     perr_t                               ret_value  = SUCCEED;
     int                                  write_size = 0, read_size = 0, posix_size = 0, merged_size = 0;
     pdc_transfer_request_start_all_pkg **write_transfer_requests = NULL, **read_transfer_requests = NULL;
-    pdcid_t                             *posix_transfer_request_id, *merged_request_id;
+    pdcid_t *                            posix_transfer_request_id, *merged_request_id;
 
     FUNC_ENTER(NULL);
 
@@ -1467,7 +1467,7 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
 #endif
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1607,7 +1607,7 @@ release_region_buffer(char *buf, uint64_t *obj_dims, int local_ndim, uint64_t *l
     int      k;
 
     perr_t ret_value = SUCCEED;
-    char  *ptr;
+    char * ptr;
     FUNC_ENTER(NULL);
     if (local_ndim == 2) {
         if (access_type == PDC_READ) {
@@ -1646,7 +1646,7 @@ perr_t
 PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *completed)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1737,13 +1737,13 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     int                                 index, i, j, merged_xfer = 0, ori_size = size, is_first = 1;
     size_t                              unit;
     int                                 total_requests, n_objs;
-    uint64_t                           *metadata_ids, merge_off = 0, cur_off = 0;
+    uint64_t *                          metadata_ids, merge_off = 0, cur_off = 0;
     pdc_transfer_request_wait_all_pkg **transfer_requests, *transfer_request_head, *transfer_request_end,
         *temp;
 
     struct _pdc_id_info **transferinfo;
     pdc_transfer_request *transfer_request, *merged_request;
-    pdcid_t              *my_transfer_request_id = transfer_request_id;
+    pdcid_t *             my_transfer_request_id = transfer_request_id;
 
     double t0, t1;
 
@@ -1976,7 +1976,7 @@ perr_t
 PDCregion_transfer_wait(pdcid_t transfer_request_id)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -76,7 +76,7 @@ typedef struct pdc_transfer_request {
     // For each of the contig buffer sent to a server, we have a bulk buffer.
     char **bulk_buf;
     // Reference counter for bulk_buf, if 0, we free it.
-    int                  **bulk_buf_ref;
+    int **                 bulk_buf_ref;
     pdc_region_partition_t region_partition;
 
     // Consistency semantics required by user
@@ -128,7 +128,7 @@ typedef struct pdc_transfer_request_start_all_pkg {
     int index;
     // Data buffer. This data buffer is contiguous according to the remote region. We assume this is after
     // transformation of local regions
-    char                                      *buf;
+    char *                                     buf;
     struct pdc_transfer_request_start_all_pkg *next;
 } pdc_transfer_request_start_all_pkg;
 
@@ -142,7 +142,7 @@ typedef struct pdc_transfer_request_wait_all_pkg {
     // Record the index of the metadata_id in the current transfer_request
     int index;
     // Pointer to the transfer request
-    pdc_transfer_request                     *transfer_request;
+    pdc_transfer_request *                    transfer_request;
     struct pdc_transfer_request_wait_all_pkg *next;
 } pdc_transfer_request_wait_all_pkg;
 
@@ -196,12 +196,12 @@ PDCregion_transfer_create(void *buf, pdc_access_t access_type, pdcid_t obj_id, p
                           pdcid_t remote_reg)
 {
     pdcid_t                 ret_value = SUCCEED;
-    struct _pdc_id_info    *objinfo2;
-    struct _pdc_obj_info   *obj2;
-    pdc_transfer_request   *p;
-    struct _pdc_id_info    *reginfo1, *reginfo2;
+    struct _pdc_id_info *   objinfo2;
+    struct _pdc_obj_info *  obj2;
+    pdc_transfer_request *  p;
+    struct _pdc_id_info *   reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
-    uint64_t               *ptr;
+    uint64_t *              ptr;
     uint64_t                unit;
     int                     j;
 
@@ -287,7 +287,7 @@ done:
 perr_t
 PDCregion_transfer_close(pdcid_t transfer_request_id)
 {
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     perr_t                ret_value = SUCCEED;
     FUNC_ENTER(NULL);
@@ -525,7 +525,7 @@ pack_region_buffer(char *buf, uint64_t *obj_dims, size_t total_data_size, int lo
 {
     uint64_t i, j;
     perr_t   ret_value = SUCCEED;
-    char    *ptr;
+    char *   ptr;
 
     FUNC_ENTER(NULL);
 
@@ -592,7 +592,7 @@ pack_region_metadata_query(pdc_transfer_request_start_all_pkg **transfer_request
 {
     perr_t   ret_value = SUCCEED;
     int      i;
-    char    *ptr;
+    char *   ptr;
     uint64_t total_buf_size;
     uint8_t  region_partition;
 
@@ -640,13 +640,13 @@ unpack_region_metadata_query(char *buf, pdc_transfer_request_start_all_pkg **tra
 {
     perr_t                              ret_value = SUCCEED;
     pdc_transfer_request_start_all_pkg *transfer_request_head, *transfer_request_end;
-    pdc_transfer_request               *local_request;
+    pdc_transfer_request *              local_request;
     int                                 size;
     int                                 i, j, index;
     int                                 counter;
-    char                               *ptr;
+    char *                              ptr;
     uint64_t                            region_size;
-    uint64_t                           *sub_offset;
+    uint64_t *                          sub_offset;
     FUNC_ENTER(NULL);
 
     local_request         = NULL;
@@ -740,10 +740,10 @@ register_metadata(pdc_transfer_request_start_all_pkg **transfer_request_input, i
     perr_t                               ret_value = SUCCEED;
     int                                  i, j, index, size, output_size, remain_size, n_objs;
     pdc_transfer_request_start_all_pkg **transfer_requests;
-    pdc_transfer_request_start_all_pkg  *transfer_request_head, *transfer_request_front_head,
+    pdc_transfer_request_start_all_pkg * transfer_request_head, *transfer_request_front_head,
         *transfer_request_end, **transfer_request_output, *previous = NULL;
     uint64_t total_buf_size, output_buf_size, query_id;
-    char    *buf, *output_buf;
+    char *   buf, *output_buf;
 
     FUNC_ENTER(NULL);
     transfer_request_output     = NULL;
@@ -875,7 +875,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
         *read_request_pkgs, *write_request_pkgs_end, *read_request_pkgs_end, *request_pkgs,
         **transfer_request_output;
     int                   write_size, read_size, output_size;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     int                   set_output_buf = 0;
 
@@ -1077,7 +1077,7 @@ PDC_Client_pack_all_requests(int n_objs, pdc_transfer_request_start_all_pkg **tr
                              char **read_bulk_buf)
 {
     perr_t ret_value = SUCCEED;
-    char  *bulk_buf, *ptr, *ptr2;
+    char * bulk_buf, *ptr, *ptr2;
     size_t total_buf_size, obj_data_size, total_obj_data_size, unit, data_size, metadata_size;
     int    i, j;
 
@@ -1183,10 +1183,10 @@ PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requ
     int       index, i, j;
     int       n_objs;
     uint64_t *metadata_id;
-    char    **read_bulk_buf;
-    char     *bulk_buf;
+    char **   read_bulk_buf;
+    char *    bulk_buf;
     size_t    bulk_buf_size;
-    int      *bulk_buf_ref;
+    int *     bulk_buf_ref;
 
     FUNC_ENTER(NULL);
 
@@ -1269,10 +1269,10 @@ static perr_t
 merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merged_request_id,
                            int *merged_size)
 {
-    struct _pdc_id_info   *transferinfo;
+    struct _pdc_id_info *  transferinfo;
     pdcid_t                obj_id, new_local_reg, new_remote_reg;
     int                    flag = 0, i;
-    void                  *new_buf;
+    void *                 new_buf;
     pdc_access_t           access_type;
     pdc_transfer_request **all_transfer_request;
     uint64_t               new_buf_size = 0, copy_off = 0;
@@ -1376,7 +1376,7 @@ PDCregion_transfer_start_all_common(pdcid_t *transfer_request_id, int size, int 
     perr_t                               ret_value  = SUCCEED;
     int                                  write_size = 0, read_size = 0, posix_size = 0, merged_size = 0;
     pdc_transfer_request_start_all_pkg **write_transfer_requests = NULL, **read_transfer_requests = NULL;
-    pdcid_t                             *posix_transfer_request_id, *merged_request_id;
+    pdcid_t *                            posix_transfer_request_id, *merged_request_id;
 
     FUNC_ENTER(NULL);
 
@@ -1467,7 +1467,7 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
 #endif
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1607,7 +1607,7 @@ release_region_buffer(char *buf, uint64_t *obj_dims, int local_ndim, uint64_t *l
     int      k;
 
     perr_t ret_value = SUCCEED;
-    char  *ptr;
+    char * ptr;
     FUNC_ENTER(NULL);
     if (local_ndim == 2) {
         if (access_type == PDC_READ) {
@@ -1646,7 +1646,7 @@ perr_t
 PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *completed)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;
@@ -1737,13 +1737,13 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     int                                 index, i, j, merged_xfer = 0, ori_size = size, is_first = 1;
     size_t                              unit;
     int                                 total_requests, n_objs;
-    uint64_t                           *metadata_ids, merge_off = 0, cur_off = 0;
+    uint64_t *                          metadata_ids, merge_off = 0, cur_off = 0;
     pdc_transfer_request_wait_all_pkg **transfer_requests, *transfer_request_head, *transfer_request_end,
         *temp;
 
     struct _pdc_id_info **transferinfo;
     pdc_transfer_request *transfer_request, *merged_request;
-    pdcid_t              *my_transfer_request_id = transfer_request_id;
+    pdcid_t *             my_transfer_request_id = transfer_request_id;
 
     double t0, t1;
 
@@ -1977,7 +1977,7 @@ perr_t
 PDCregion_transfer_wait(pdcid_t transfer_request_id)
 {
     perr_t                ret_value = SUCCEED;
-    struct _pdc_id_info  *transferinfo;
+    struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     size_t                unit;
     int                   i;

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -491,7 +491,7 @@ static_region_partition(char *buf, int ndim, uint64_t unit, pdc_access_t access_
             // subregion is computed using the output region by aligning the offsets to its begining.
             if (set_output_buf) {
                 // Copy subregion from input region to the new overlapping region.
-                output_buf[0][n_data_servers[0]] = (char *)calloc(region_size * unit, sizeof(char));
+                output_buf[0][n_data_servers[0]] = (char *)PDC_calloc(region_size * unit, sizeof(char));
                 if (access_type == PDC_WRITE) {
                     memcpy_subregion(ndim, unit, PDC_WRITE, buf, size, output_buf[0][n_data_servers[0]],
                                      sub_offsets[0][n_data_servers[0]], output_sizes[0][*n_data_servers]);
@@ -502,13 +502,13 @@ static_region_partition(char *buf, int ndim, uint64_t unit, pdc_access_t access_
     }
     // Shrink memory size if necessary.
     if (*n_data_servers != pdc_server_num_g) {
-        *data_server_ids = (uint32_t *)realloc(*data_server_ids, sizeof(uint32_t) * n_data_servers[0]);
-        *output_offsets  = (uint64_t **)realloc(*output_offsets, sizeof(uint64_t *) * n_data_servers[0]);
-        *output_sizes    = (uint64_t **)realloc(*output_sizes, sizeof(uint64_t *) * n_data_servers[0]);
+        *data_server_ids = (uint32_t *)PDC_realloc(*data_server_ids, sizeof(uint32_t) * n_data_servers[0]);
+        *output_offsets  = (uint64_t **)PDC_realloc(*output_offsets, sizeof(uint64_t *) * n_data_servers[0]);
+        *output_sizes    = (uint64_t **)PDC_realloc(*output_sizes, sizeof(uint64_t *) * n_data_servers[0]);
 
-        *sub_offsets = (uint64_t **)realloc(*sub_offsets, sizeof(uint64_t *) * n_data_servers[0]);
+        *sub_offsets = (uint64_t **)PDC_realloc(*sub_offsets, sizeof(uint64_t *) * n_data_servers[0]);
         if (set_output_buf) {
-            *output_buf = (char **)realloc(*output_buf, sizeof(char *) * n_data_servers[0]);
+            *output_buf = (char **)PDC_realloc(*output_buf, sizeof(char *) * n_data_servers[0]);
         }
     }
 

--- a/src/api/pdc_transform/pdc_transform.c
+++ b/src/api/pdc_transform/pdc_transform.c
@@ -51,23 +51,23 @@ PDCobj_transform_register(char *func, pdcid_t obj_id, int current_state, int nex
                           pdc_obj_transform_t op_type, pdc_data_movement_t when)
 {
     perr_t ret_value                               = SUCCEED;
-    void  *ftnHandle                               = NULL;
+    void * ftnHandle                               = NULL;
     size_t (*ftnPtr)()                             = NULL;
     struct _pdc_region_transform_ftn_info *thisFtn = NULL;
-    struct _pdc_obj_info                  *obj1, *obj2;
-    struct _pdc_id_info                   *objinfo1;
-    struct _pdc_obj_prop                  *prop;
-    struct pdc_region_info                *reg1 = NULL, *reg2 = NULL;
+    struct _pdc_obj_info *                 obj1, *obj2;
+    struct _pdc_id_info *                  objinfo1;
+    struct _pdc_obj_prop *                 prop;
+    struct pdc_region_info *               reg1 = NULL, *reg2 = NULL;
     pdcid_t                                src_region_id = 0, dest_region_id = 0;
     pdcid_t                                dest_object_id    = 0;
-    char                                  *thisApp           = NULL;
-    char                                  *colonsep          = NULL;
-    char                                  *transformslibrary = NULL;
-    char                                  *applicationDir    = NULL;
-    char                                  *userdefinedftn    = NULL;
-    char                                  *loadpath          = NULL;
+    char *                                 thisApp           = NULL;
+    char *                                 colonsep          = NULL;
+    char *                                 transformslibrary = NULL;
+    char *                                 applicationDir    = NULL;
+    char *                                 userdefinedftn    = NULL;
+    char *                                 loadpath          = NULL;
     int                                    local_regIndex;
-    struct _pdc_id_info                   *id_info;
+    struct _pdc_id_info *                  id_info;
 
     FUNC_ENTER(NULL);
 
@@ -99,7 +99,7 @@ PDCobj_transform_register(char *func, pdcid_t obj_id, int current_state, int nex
         PGOTO_ERROR(FAIL, "PDC register_obj_transforms memory allocation failed");
 
     memset(thisFtn, 0, sizeof(struct _pdc_region_transform_ftn_info));
-    thisFtn->ftnPtr    = (size_t (*)())ftnPtr;
+    thisFtn->ftnPtr    = (size_t(*)())ftnPtr;
     thisFtn->object_id = obj_id;
     thisFtn->op_type   = op_type;
     thisFtn->when      = when;
@@ -156,9 +156,9 @@ PDCobj_transform_register(char *func, pdcid_t obj_id, int current_state, int nex
 done:
     fflush(stdout);
     if (applicationDir)
-        applicationDir = (char*)PDC_free(applicationDir);
+        applicationDir = (char *)PDC_free(applicationDir);
     if (userdefinedftn)
-        userdefinedftn = (char*)PDC_free(userdefinedftn);
+        userdefinedftn = (char *)PDC_free(userdefinedftn);
 
     FUNC_LEAVE(ret_value);
 }
@@ -169,18 +169,18 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
                               pdc_data_movement_t when)
 {
     perr_t ret_value                                   = SUCCEED; /* Return value */
-    void  *ftnHandle                                   = NULL;
+    void * ftnHandle                                   = NULL;
     size_t (*ftnPtr)()                                 = NULL;
-    struct _pdc_obj_info                  *object1     = NULL;
+    struct _pdc_obj_info *                 object1     = NULL;
     struct _pdc_region_transform_ftn_info *thisFtn     = NULL;
-    struct pdc_region_info                *region_info = NULL;
-    struct _pdc_id_info                   *id_info;
-    char                                  *thisApp           = NULL;
-    char                                  *colonsep          = NULL;
-    char                                  *transformslibrary = NULL;
-    char                                  *applicationDir    = NULL;
-    char                                  *userdefinedftn    = NULL;
-    char                                  *loadpath          = NULL;
+    struct pdc_region_info *               region_info = NULL;
+    struct _pdc_id_info *                  id_info;
+    char *                                 thisApp           = NULL;
+    char *                                 colonsep          = NULL;
+    char *                                 transformslibrary = NULL;
+    char *                                 applicationDir    = NULL;
+    char *                                 userdefinedftn    = NULL;
+    char *                                 loadpath          = NULL;
     int                                    local_regIndex;
 
     FUNC_ENTER(NULL);
@@ -212,7 +212,7 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
              sizeof(struct _pdc_region_transform_ftn_info))) == NULL)
         PGOTO_ERROR(FAIL, "PDC register_obj_transforms memory allocation failed");
 
-    thisFtn->ftnPtr    = (size_t (*)())ftnPtr;
+    thisFtn->ftnPtr    = (size_t(*)())ftnPtr;
     thisFtn->object_id = dest_object_id;
     id_info            = PDC_find_id(src_region_id);
     if (id_info && ((region_info = (struct pdc_region_info *)id_info->obj_ptr) != NULL))

--- a/src/api/pdc_transform/pdc_transform.c
+++ b/src/api/pdc_transform/pdc_transform.c
@@ -51,23 +51,23 @@ PDCobj_transform_register(char *func, pdcid_t obj_id, int current_state, int nex
                           pdc_obj_transform_t op_type, pdc_data_movement_t when)
 {
     perr_t ret_value                               = SUCCEED;
-    void * ftnHandle                               = NULL;
+    void  *ftnHandle                               = NULL;
     size_t (*ftnPtr)()                             = NULL;
     struct _pdc_region_transform_ftn_info *thisFtn = NULL;
-    struct _pdc_obj_info *                 obj1, *obj2;
-    struct _pdc_id_info *                  objinfo1;
-    struct _pdc_obj_prop *                 prop;
-    struct pdc_region_info *               reg1 = NULL, *reg2 = NULL;
+    struct _pdc_obj_info                  *obj1, *obj2;
+    struct _pdc_id_info                   *objinfo1;
+    struct _pdc_obj_prop                  *prop;
+    struct pdc_region_info                *reg1 = NULL, *reg2 = NULL;
     pdcid_t                                src_region_id = 0, dest_region_id = 0;
     pdcid_t                                dest_object_id    = 0;
-    char *                                 thisApp           = NULL;
-    char *                                 colonsep          = NULL;
-    char *                                 transformslibrary = NULL;
-    char *                                 applicationDir    = NULL;
-    char *                                 userdefinedftn    = NULL;
-    char *                                 loadpath          = NULL;
+    char                                  *thisApp           = NULL;
+    char                                  *colonsep          = NULL;
+    char                                  *transformslibrary = NULL;
+    char                                  *applicationDir    = NULL;
+    char                                  *userdefinedftn    = NULL;
+    char                                  *loadpath          = NULL;
     int                                    local_regIndex;
-    struct _pdc_id_info *                  id_info;
+    struct _pdc_id_info                   *id_info;
 
     FUNC_ENTER(NULL);
 
@@ -99,7 +99,7 @@ PDCobj_transform_register(char *func, pdcid_t obj_id, int current_state, int nex
         PGOTO_ERROR(FAIL, "PDC register_obj_transforms memory allocation failed");
 
     memset(thisFtn, 0, sizeof(struct _pdc_region_transform_ftn_info));
-    thisFtn->ftnPtr    = (size_t(*)())ftnPtr;
+    thisFtn->ftnPtr    = (size_t (*)())ftnPtr;
     thisFtn->object_id = obj_id;
     thisFtn->op_type   = op_type;
     thisFtn->when      = when;
@@ -156,9 +156,9 @@ PDCobj_transform_register(char *func, pdcid_t obj_id, int current_state, int nex
 done:
     fflush(stdout);
     if (applicationDir)
-        free(applicationDir);
+        applicationDir = (char*)PDC_free(applicationDir);
     if (userdefinedftn)
-        free(userdefinedftn);
+        userdefinedftn = (char*)PDC_free(userdefinedftn);
 
     FUNC_LEAVE(ret_value);
 }
@@ -169,18 +169,18 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
                               pdc_data_movement_t when)
 {
     perr_t ret_value                                   = SUCCEED; /* Return value */
-    void * ftnHandle                                   = NULL;
+    void  *ftnHandle                                   = NULL;
     size_t (*ftnPtr)()                                 = NULL;
-    struct _pdc_obj_info *                 object1     = NULL;
+    struct _pdc_obj_info                  *object1     = NULL;
     struct _pdc_region_transform_ftn_info *thisFtn     = NULL;
-    struct pdc_region_info *               region_info = NULL;
-    struct _pdc_id_info *                  id_info;
-    char *                                 thisApp           = NULL;
-    char *                                 colonsep          = NULL;
-    char *                                 transformslibrary = NULL;
-    char *                                 applicationDir    = NULL;
-    char *                                 userdefinedftn    = NULL;
-    char *                                 loadpath          = NULL;
+    struct pdc_region_info                *region_info = NULL;
+    struct _pdc_id_info                   *id_info;
+    char                                  *thisApp           = NULL;
+    char                                  *colonsep          = NULL;
+    char                                  *transformslibrary = NULL;
+    char                                  *applicationDir    = NULL;
+    char                                  *userdefinedftn    = NULL;
+    char                                  *loadpath          = NULL;
     int                                    local_regIndex;
 
     FUNC_ENTER(NULL);
@@ -212,7 +212,7 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
              sizeof(struct _pdc_region_transform_ftn_info))) == NULL)
         PGOTO_ERROR(FAIL, "PDC register_obj_transforms memory allocation failed");
 
-    thisFtn->ftnPtr    = (size_t(*)())ftnPtr;
+    thisFtn->ftnPtr    = (size_t (*)())ftnPtr;
     thisFtn->object_id = dest_object_id;
     id_info            = PDC_find_id(src_region_id);
     if (id_info && ((region_info = (struct pdc_region_info *)id_info->obj_ptr) != NULL))
@@ -265,11 +265,11 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
 done:
     fflush(stdout);
     if (applicationDir)
-        free(applicationDir);
+        applicationDir = (char *)PDC_free(applicationDir);
     if (userdefinedftn)
-        free(userdefinedftn);
+        userdefinedftn = (char *)PDC_free(userdefinedftn);
     if (loadpath)
-        free(loadpath);
+        loadpath = (char *)PDC_free(loadpath);
 
     FUNC_LEAVE(ret_value);
 }

--- a/src/api/pdc_transform/pdc_transforms_common.c
+++ b/src/api/pdc_transform/pdc_transforms_common.c
@@ -42,7 +42,7 @@ HG_TEST_RPC_CB(transform_ftn, handle)
     transform_ftn_in_t                     in;
     transform_ftn_out_t                    out       = {0, 0, 0, -1};
     struct _pdc_region_transform_ftn_info *thisFtn   = NULL;
-    void                                  *ftnHandle = NULL;
+    void *                                 ftnHandle = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -71,7 +71,7 @@ HG_TEST_RPC_CB(transform_ftn, handle)
          * the client to include the cached index value
          * as part of a future data movement request.
          */
-        thisFtn->ftnPtr    = (size_t (*)())ftnHandle;
+        thisFtn->ftnPtr    = (size_t(*)())ftnHandle;
         thisFtn->object_id = in.object_id;
         thisFtn->region_id = in.region_id;
         thisFtn->op_type   = (pdc_obj_transform_t)in.op_type;

--- a/src/api/pdc_transform/pdc_transforms_common.c
+++ b/src/api/pdc_transform/pdc_transforms_common.c
@@ -42,14 +42,14 @@ HG_TEST_RPC_CB(transform_ftn, handle)
     transform_ftn_in_t                     in;
     transform_ftn_out_t                    out       = {0, 0, 0, -1};
     struct _pdc_region_transform_ftn_info *thisFtn   = NULL;
-    void *                                 ftnHandle = NULL;
+    void                                  *ftnHandle = NULL;
 
     FUNC_ENTER(NULL);
 
     HG_Get_input(handle, &in);
 
     if (PDC_get_ftnPtr_(in.ftn_name, in.loadpath, &ftnHandle) >= 0) {
-        thisFtn = malloc(sizeof(struct _pdc_region_transform_ftn_info));
+        thisFtn = PDC_malloc(sizeof(struct _pdc_region_transform_ftn_info));
         if (thisFtn == NULL)
             PGOTO_ERROR(HG_OTHER_ERROR, "transform_ftn_cb: Memory allocation failed");
         /* This sets up the index return for the client!
@@ -71,7 +71,7 @@ HG_TEST_RPC_CB(transform_ftn, handle)
          * the client to include the cached index value
          * as part of a future data movement request.
          */
-        thisFtn->ftnPtr    = (size_t(*)())ftnHandle;
+        thisFtn->ftnPtr    = (size_t (*)())ftnHandle;
         thisFtn->object_id = in.object_id;
         thisFtn->region_id = in.region_id;
         thisFtn->op_type   = (pdc_obj_transform_t)in.op_type;

--- a/src/commons/collections/art.c
+++ b/src/commons/collections/art.c
@@ -98,16 +98,16 @@ destroy_node(art_node *n)
 
     // Special case leafs
     if (IS_LEAF(n)) {
-        free(LEAF_RAW(n));
+        n = (art_node *)PDC_free(LEAF_RAW(n));
         return;
     }
 
     // Handle each node type
     int i, idx;
     union {
-        art_node4 *  p1;
-        art_node16 * p2;
-        art_node48 * p3;
+        art_node4   *p1;
+        art_node16  *p2;
+        art_node48  *p3;
         art_node256 *p4;
     } p;
     switch (n->type) {
@@ -148,7 +148,7 @@ destroy_node(art_node *n)
     }
 
     // Free ourself on the way up
-    free(n);
+    n = (art_node *)PDC_free(n);
 }
 
 /**
@@ -178,9 +178,9 @@ find_child(art_node *n, unsigned char c)
 {
     int i, mask, bitfield;
     union {
-        art_node4 *  p1;
-        art_node16 * p2;
-        art_node48 * p3;
+        art_node4   *p1;
+        art_node16  *p2;
+        art_node48  *p3;
         art_node256 *p4;
     } p;
     switch (n->type) {
@@ -311,7 +311,7 @@ void *
 art_search(const art_tree *t, const unsigned char *key, int key_len)
 {
     art_node **child;
-    art_node * n = t->root;
+    art_node  *n = t->root;
     int        prefix_len, depth = 0;
     while (n) {
         // Might be a leaf
@@ -480,7 +480,7 @@ add_child48(art_node48 *n, art_node **ref, unsigned char c, void *child)
         }
         copy_header((art_node *)new_node, (art_node *)n);
         *ref = (art_node *)new_node;
-        free(n);
+        n    = (art_node48 *)PDC_free(n);
         add_child256(new_node, ref, c, child);
     }
 }
@@ -547,7 +547,7 @@ add_child16(art_node16 *n, art_node **ref, unsigned char c, void *child)
         }
         copy_header((art_node *)new_node, (art_node *)n);
         *ref = (art_node *)new_node;
-        free(n);
+        n    = (art_node16 *)PDC_free(n);
         add_child48(new_node, ref, c, child);
     }
 }
@@ -579,7 +579,7 @@ add_child4(art_node4 *n, art_node **ref, unsigned char c, void *child)
         memcpy(new_node->keys, n->keys, sizeof(unsigned char) * n->n.num_children);
         copy_header((art_node *)new_node, (art_node *)n);
         *ref = (art_node *)new_node;
-        free(n);
+        n    = (art_node4 *)PDC_free(n);
         add_child16(new_node, ref, c, child);
     }
 }
@@ -774,7 +774,7 @@ remove_child256(art_node256 *n, art_node **ref, unsigned char c)
                 pos++;
             }
         }
-        free(n);
+        n = (art_node256 *)PDC_free(n);
     }
 }
 
@@ -800,7 +800,7 @@ remove_child48(art_node48 *n, art_node **ref, unsigned char c)
                 child++;
             }
         }
-        free(n);
+        n = (art_node48 *)PDC_free(n);
     }
 }
 
@@ -818,7 +818,7 @@ remove_child16(art_node16 *n, art_node **ref, art_node **l)
         copy_header((art_node *)new_node, (art_node *)n);
         memcpy(new_node->keys, n->keys, 4);
         memcpy(new_node->children, n->children, 4 * sizeof(void *));
-        free(n);
+        n = (art_node16 *)PDC_free(n);
     }
 }
 
@@ -851,7 +851,7 @@ remove_child4(art_node4 *n, art_node **ref, art_node **l)
             child->partial_len += n->n.partial_len + 1;
         }
         *ref = child;
-        free(n);
+        n    = (art_node4 *)PDC_free(n);
     }
 }
 
@@ -934,7 +934,7 @@ art_delete(art_tree *t, const unsigned char *key, int key_len)
     if (l) {
         t->size--;
         void *old = l->value;
-        free(l);
+        l         = (art_leaf *)PDC_free(l);
         return old;
     }
     return NULL;
@@ -1045,7 +1045,7 @@ int
 art_iter_prefix(art_tree *t, const unsigned char *key, int key_len, art_callback cb, void *data)
 {
     art_node **child;
-    art_node * n = t->root;
+    art_node  *n = t->root;
     int        prefix_len, depth = 0;
     while (n) {
         // Might be a leaf

--- a/src/commons/collections/art.c
+++ b/src/commons/collections/art.c
@@ -105,9 +105,9 @@ destroy_node(art_node *n)
     // Handle each node type
     int i, idx;
     union {
-        art_node4   *p1;
-        art_node16  *p2;
-        art_node48  *p3;
+        art_node4 *  p1;
+        art_node16 * p2;
+        art_node48 * p3;
         art_node256 *p4;
     } p;
     switch (n->type) {
@@ -178,9 +178,9 @@ find_child(art_node *n, unsigned char c)
 {
     int i, mask, bitfield;
     union {
-        art_node4   *p1;
-        art_node16  *p2;
-        art_node48  *p3;
+        art_node4 *  p1;
+        art_node16 * p2;
+        art_node48 * p3;
         art_node256 *p4;
     } p;
     switch (n->type) {
@@ -311,7 +311,7 @@ void *
 art_search(const art_tree *t, const unsigned char *key, int key_len)
 {
     art_node **child;
-    art_node  *n = t->root;
+    art_node * n = t->root;
     int        prefix_len, depth = 0;
     while (n) {
         // Might be a leaf
@@ -1045,7 +1045,7 @@ int
 art_iter_prefix(art_tree *t, const unsigned char *key, int key_len, art_callback cb, void *data)
 {
     art_node **child;
-    art_node  *n = t->root;
+    art_node * n = t->root;
     int        prefix_len, depth = 0;
     while (n) {
         // Might be a leaf

--- a/src/commons/collections/libhl/linklist.c
+++ b/src/commons/collections/libhl/linklist.c
@@ -1,7 +1,7 @@
 /* linked list management library - by xant
  */
 
-//#include <stdio.h>
+// #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -14,9 +14,9 @@
 
 typedef struct _list_entry_s {
     struct _linked_list_s *list;
-    struct _list_entry_s * prev;
-    struct _list_entry_s * next;
-    void *                 value;
+    struct _list_entry_s  *prev;
+    struct _list_entry_s  *next;
+    void                  *value;
     int                    tagged;
 } list_entry_t;
 
@@ -31,7 +31,7 @@ struct _linked_list_s {
 #endif
     free_value_callback_t free_value_cb;
     int                   refcnt;
-    list_entry_t *        slices;
+    list_entry_t         *slices;
 };
 
 struct _slice_s {
@@ -74,7 +74,7 @@ list_create()
     linked_list_t *list = (linked_list_t *)PDC_calloc(1, sizeof(linked_list_t));
     if (list) {
         if (list_init(list) != 0) {
-            free(list);
+            list = (linked_list_t *)PDC_free(list);
             return NULL;
         }
     }
@@ -115,7 +115,7 @@ list_destroy(linked_list_t *list)
 #ifdef THREAD_SAFE
         MUTEX_DESTROY(list->lock);
 #endif
-        free(list);
+        list = (linked_list_t *)PDC_free(list);
     }
 }
 
@@ -123,16 +123,16 @@ static void
 list_destroy_tagged_value_internal(tagged_value_t *tval, void (*free_cb)(void *v))
 {
     if (tval) {
-        free(tval->tag);
+        tval->tag = (char *)PDC_free(tval->tag);
         if (tval->value) {
             if (tval->type == TV_TYPE_LIST)
                 list_destroy((linked_list_t *)tval->value);
             else if (free_cb)
                 free_cb(tval->value);
             else if (tval->vlen)
-                free(tval->value);
+                tval->value = (void *)PDC_free(tval->value);
         }
-        free(tval);
+        tval = (tagged_value_t *)PDC_free(tval);
     }
 }
 
@@ -217,7 +217,7 @@ destroy_entry(list_entry_t *entry)
             if (pos >= 0)
                 remove_entry(entry->list, pos);
         }
-        free(entry);
+        entry = (list_entry_t *)PDC_free(entry);
     }
 }
 
@@ -564,7 +564,7 @@ get_entry_position(list_entry_t *entry)
 {
     int            i = 0;
     linked_list_t *list;
-    list_entry_t * p;
+    list_entry_t  *p;
     list = entry->list;
 
     if (!list)
@@ -589,7 +589,7 @@ get_entry_position(list_entry_t *entry)
 void *
 list_pop_value(linked_list_t *list)
 {
-    void *        val   = NULL;
+    void         *val   = NULL;
     list_entry_t *entry = pop_entry(list);
     if (entry) {
         val = entry->value;
@@ -629,7 +629,7 @@ list_unshift_value(linked_list_t *list, void *val)
 void *
 list_shift_value(linked_list_t *list)
 {
-    void *        val   = NULL;
+    void         *val   = NULL;
     list_entry_t *entry = shift_entry(list);
     if (entry) {
         val = entry->value;
@@ -664,7 +664,7 @@ list_pick_value(linked_list_t *list, size_t pos)
 void *
 list_fetch_value(linked_list_t *list, size_t pos)
 {
-    void *        val   = NULL;
+    void         *val   = NULL;
     list_entry_t *entry = fetch_entry(list, pos);
     if (entry) {
         val = entry->value;
@@ -769,8 +769,8 @@ list_create_tagged_value(char *tag, void *val, size_t vlen)
                 newval->vlen = vlen;
             }
             else {
-                free(newval->tag);
-                free(newval);
+                newval->tag = (char *)PDC_free(newval->tag);
+                newval      = (tagged_value_t *)PDC_free(newval);
                 return NULL;
             }
             newval->type = TV_TYPE_BINARY;
@@ -997,7 +997,7 @@ list_quick_sort(list_entry_t *head, list_entry_t *tail, list_entry_t *pivot, int
         return;
     }
 
-    void *        pvalue = pivot->value;
+    void         *pvalue = pivot->value;
     list_entry_t *p1 = head, *p2 = tail;
 
     for (;;) {
@@ -1153,8 +1153,8 @@ void
 slice_destroy(slice_t *slice)
 {
     linked_list_t *list = slice->list;
-    list_entry_t * cur  = list->slices;
-    list_entry_t * prev = NULL;
+    list_entry_t  *cur  = list->slices;
+    list_entry_t  *prev = NULL;
     while (cur) {
         if (cur->value == slice) {
             if (prev) {
@@ -1170,7 +1170,7 @@ slice_destroy(slice_t *slice)
         prev = cur;
         cur  = cur->next;
     }
-    free(slice);
+    slice = (slice_t *)PDC_free(slice);
 }
 
 int

--- a/src/commons/collections/libhl/linklist.c
+++ b/src/commons/collections/libhl/linklist.c
@@ -14,9 +14,9 @@
 
 typedef struct _list_entry_s {
     struct _linked_list_s *list;
-    struct _list_entry_s  *prev;
-    struct _list_entry_s  *next;
-    void                  *value;
+    struct _list_entry_s * prev;
+    struct _list_entry_s * next;
+    void *                 value;
     int                    tagged;
 } list_entry_t;
 
@@ -31,7 +31,7 @@ struct _linked_list_s {
 #endif
     free_value_callback_t free_value_cb;
     int                   refcnt;
-    list_entry_t         *slices;
+    list_entry_t *        slices;
 };
 
 struct _slice_s {
@@ -564,7 +564,7 @@ get_entry_position(list_entry_t *entry)
 {
     int            i = 0;
     linked_list_t *list;
-    list_entry_t  *p;
+    list_entry_t * p;
     list = entry->list;
 
     if (!list)
@@ -589,7 +589,7 @@ get_entry_position(list_entry_t *entry)
 void *
 list_pop_value(linked_list_t *list)
 {
-    void         *val   = NULL;
+    void *        val   = NULL;
     list_entry_t *entry = pop_entry(list);
     if (entry) {
         val = entry->value;
@@ -629,7 +629,7 @@ list_unshift_value(linked_list_t *list, void *val)
 void *
 list_shift_value(linked_list_t *list)
 {
-    void         *val   = NULL;
+    void *        val   = NULL;
     list_entry_t *entry = shift_entry(list);
     if (entry) {
         val = entry->value;
@@ -664,7 +664,7 @@ list_pick_value(linked_list_t *list, size_t pos)
 void *
 list_fetch_value(linked_list_t *list, size_t pos)
 {
-    void         *val   = NULL;
+    void *        val   = NULL;
     list_entry_t *entry = fetch_entry(list, pos);
     if (entry) {
         val = entry->value;
@@ -997,7 +997,7 @@ list_quick_sort(list_entry_t *head, list_entry_t *tail, list_entry_t *pivot, int
         return;
     }
 
-    void         *pvalue = pivot->value;
+    void *        pvalue = pivot->value;
     list_entry_t *p1 = head, *p2 = tail;
 
     for (;;) {
@@ -1153,8 +1153,8 @@ void
 slice_destroy(slice_t *slice)
 {
     linked_list_t *list = slice->list;
-    list_entry_t  *cur  = list->slices;
-    list_entry_t  *prev = NULL;
+    list_entry_t * cur  = list->slices;
+    list_entry_t * prev = NULL;
     while (cur) {
         if (cur->value == slice) {
             if (prev) {

--- a/src/commons/collections/libhl/rbtree.c
+++ b/src/commons/collections/libhl/rbtree.c
@@ -471,8 +471,8 @@ rbt_add_internal(rbt_t *rbt, rbt_node_t *cur_node, rbt_node_t *new_node)
         if (new_node->value != cur_node->value && rbt->free_value_cb)
             rbt->free_value_cb(cur_node->value);
 
-        free(cur_node->key);
-        free(cur_node);
+        cur_node->key = (void *)PDC_free(cur_node->key);
+        cur_node      = (rbt_node_t *)PDC_free(cur_node);
         return 1;
     }
     else if (rc > 0) {
@@ -572,7 +572,7 @@ rbt_add(rbt_t *rbt, void *k, size_t klen, void *v)
     node->key = PDC_malloc(klen);
     mem_usage_by_all_rbtrees += klen;
     if (!node->key) {
-        free(node);
+        node = (rbt_node_t *)PDC_free(node);
         return -1;
     }
     memcpy(node->key, k, klen);
@@ -799,7 +799,7 @@ rbt_paint_onremove(rbt_t *rbt, rbt_node_t *node)
 void
 rbt_free_node(rbt_t *rbt, rbt_node_t **node_ptr, void **node_v, void **rtn_v)
 {
-    free((*node_ptr)->key);
+    (*node_ptr)->key = (void *)PDC_free((*node_ptr)->key);
     (*node_ptr)->key = NULL;
     if (rtn_v)
         *rtn_v = *node_v;
@@ -807,7 +807,7 @@ rbt_free_node(rbt_t *rbt, rbt_node_t **node_ptr, void **node_v, void **rtn_v)
         rbt->free_value_cb(*node_v);
         *node_v = NULL;
     }
-    free(*node_ptr);
+    *node_ptr = (rbt_node_t *)PDC_free(*node_ptr);
     *node_ptr = NULL;
 }
 

--- a/src/commons/collections/libhl/rbtree.c
+++ b/src/commons/collections/libhl/rbtree.c
@@ -52,7 +52,7 @@ struct _rbt_s {
 rbt_t *
 rbt_create_by_dtype(pdc_c_var_type_t dtype, rbt_free_value_callback_t free_value_cb)
 {
-    rbt_t *rbt = calloc(1, sizeof(rbt_t));
+    rbt_t *rbt = PDC_calloc(1, sizeof(rbt_t));
     // INIT_PERF_INFO_FIELDS(rbt, rbt_t);
     // rbt->time_for_rotate = 0;
     // mem_usage_by_all_rbtrees += sizeof(rbt_t);
@@ -68,10 +68,7 @@ rbt_create_by_dtype(pdc_c_var_type_t dtype, rbt_free_value_callback_t free_value
 rbt_t *
 rbt_create(libhl_cmp_callback_t cmp_keys_cb, rbt_free_value_callback_t free_value_cb)
 {
-    rbt_t *rbt = calloc(1, sizeof(rbt_t));
-    // INIT_PERF_INFO_FIELDS(rbt, rbt_t);
-    // rbt->time_for_rotate = 0;
-    // mem_usage_by_all_rbtrees += sizeof(rbt_t);
+    rbt_t *rbt = PDC_calloc(1, sizeof(rbt_t));
 
     if (!rbt)
         return NULL;

--- a/src/commons/collections/libhl/rbtree.c
+++ b/src/commons/collections/libhl/rbtree.c
@@ -32,16 +32,16 @@ typedef enum {
 
 typedef struct _rbt_node_s {
     rbt_color_t         color;
-    void *              key;
+    void               *key;
     size_t              klen;
-    void *              value;
+    void               *value;
     struct _rbt_node_s *left;
     struct _rbt_node_s *right;
     struct _rbt_node_s *parent;
 } rbt_node_t;
 
 struct _rbt_s {
-    rbt_node_t *              root;
+    rbt_node_t               *root;
     uint64_t                  size;
     pdc_c_var_type_t          dtype;
     libhl_cmp_callback_t      cmp_keys_cb;
@@ -113,24 +113,18 @@ rbt_destroy_internal(rbt_node_t *node, rbt_free_value_callback_t free_value_cb)
         }
     }
 
-    if (node->key == NULL) {
-        free(node);
-    }
+    if (node->key == NULL)
+        node = (rbt_node_t *)PDC_free(node);
 }
 
 void
 rbt_destroy(rbt_t *rbt)
 {
-    if (rbt == NULL) {
+    if (rbt == NULL)
         return;
-    }
-    // if (rbt->size == 0) {
-    //     goto done;
-    // }
     rbt_destroy_internal(rbt->root, rbt->free_value_cb);
-    // done:
     rbt->root = NULL;
-    free(rbt);
+    rbt       = (rbt_t *)PDC_free(rbt);
 }
 
 static int
@@ -870,18 +864,6 @@ rbt_remove(rbt_t *rbt, void *k, size_t klen, void **v)
             if (n && *n) {
                 rbt_free_node(rbt, n, &prev_value, v);
             }
-
-            // free((*n)->key);
-            // (*n)->key = NULL;
-            // if (v)
-            //     *v = prev_value;
-            // else if (rbt->free_value_cb) {
-            //     rbt->free_value_cb(prev_value);
-            //     (&prev_value)[0] = NULL;
-            // }
-
-            // free((*n));
-            // *n        = NULL;
             rbt->size = rbt->size - 1;
             return 0;
         }
@@ -908,18 +890,6 @@ rbt_remove(rbt_t *rbt, void *k, size_t klen, void **v)
             if (node && *node) {
                 rbt_free_node(rbt, node, &((*node)->value), v);
             }
-
-            // if (v)
-            //     *v = (*node)->value;
-            // else if (rbt->free_value_cb) {
-            //     rbt->free_value_cb((*node)->value);
-            //     (*node)->value = NULL;
-            // }
-
-            // free((*node)->key);
-            // (*node)->key = NULL;
-            // free((*node));
-            // *node     = NULL;
             rbt->size = rbt->size - 1;
             return 0;
         }
@@ -936,17 +906,6 @@ rbt_remove(rbt_t *rbt, void *k, size_t klen, void **v)
     if (node && *node) {
         rbt_free_node(rbt, node, &((*node)->value), v);
     }
-    // if (v)
-    //     *v = (*node)->value;
-    // else if (rbt->free_value_cb && (*node)->value) {
-    //     rbt->free_value_cb((*node)->value);
-    //     (*node)->value = NULL;
-    // }
-
-    // free(node->key);
-    // node->key = NULL;
-    // // free(node);
-    // // (&node)[0] = NULL;
     rbt->size = rbt->size - 1;
     return 0;
 }

--- a/src/commons/collections/libhl/rbtree.c
+++ b/src/commons/collections/libhl/rbtree.c
@@ -32,16 +32,16 @@ typedef enum {
 
 typedef struct _rbt_node_s {
     rbt_color_t         color;
-    void               *key;
+    void *              key;
     size_t              klen;
-    void               *value;
+    void *              value;
     struct _rbt_node_s *left;
     struct _rbt_node_s *right;
     struct _rbt_node_s *parent;
 } rbt_node_t;
 
 struct _rbt_s {
-    rbt_node_t               *root;
+    rbt_node_t *              root;
     uint64_t                  size;
     pdc_c_var_type_t          dtype;
     libhl_cmp_callback_t      cmp_keys_cb;

--- a/src/commons/collections/pdc_deque.c
+++ b/src/commons/collections/pdc_deque.c
@@ -8,7 +8,7 @@
 void
 PDC_deque_init(PDC_deque_t *deque)
 {
-    deque->data     = malloc(sizeof(void *) * DEFAULT_CAPACITY);
+    deque->data     = PDC_malloc(sizeof(void *) * DEFAULT_CAPACITY);
     deque->size     = 0;
     deque->capacity = DEFAULT_CAPACITY;
     deque->head     = 0;
@@ -18,7 +18,7 @@ PDC_deque_init(PDC_deque_t *deque)
 static void
 resize_deque(PDC_deque_t *deque, size_t new_capacity)
 {
-    void **new_data = malloc(sizeof(void *) * new_capacity);
+    void **new_data = PDC_malloc(sizeof(void *) * new_capacity);
     if (new_data == NULL) {
         LOG_ERROR("Failed to allocate memory for deque!\n");
         exit(1);

--- a/src/commons/collections/pdc_deque.c
+++ b/src/commons/collections/pdc_deque.c
@@ -1,5 +1,6 @@
 #include "pdc_deque.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 #include <stdio.h>
 
 #define DEFAULT_CAPACITY 16
@@ -29,7 +30,7 @@ resize_deque(PDC_deque_t *deque, size_t new_capacity)
         deque->head   = (deque->head + 1) % deque->capacity;
     }
 
-    free(deque->data);
+    deque->data     = (void **)PDC_free(deque->data);
     deque->data     = new_data;
     deque->capacity = new_capacity;
     deque->head     = 0;
@@ -91,5 +92,5 @@ PDC_deque_pop_back(PDC_deque_t *deque)
 void
 PDC_deque_free(PDC_deque_t *deque)
 {
-    free(deque->data);
+    deque->data = (void **)PDC_free(deque->data);
 }

--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -37,7 +37,7 @@ struct _HashTableEntry {
 };
 
 struct _HashTable {
-    HashTableEntry **      table;
+    HashTableEntry       **table;
     unsigned int           table_size;
     HashTableHashFunc      hash_func;
     HashTableEqualFunc     equal_func;
@@ -65,7 +65,7 @@ static const unsigned int hash_table_num_primes = sizeof(hash_table_primes) / si
 unsigned int
 pdc_default_string_hash_func(HashTableKey value)
 {
-    char *       str  = (char *)value;
+    char        *str  = (char *)value;
     unsigned int hash = 5381;
     int          c;
 
@@ -209,7 +209,7 @@ hash_table_free_entry(HashTable *hash_table, HashTableEntry *entry)
     }
 
     /* Free the data structure */
-    free(entry);
+    entry = (HashTableEntry *)PDC_free(entry);
 }
 
 HashTable *
@@ -218,7 +218,7 @@ hash_table_new(HashTableHashFunc hash_func, HashTableEqualFunc equal_func)
     HashTable *hash_table;
 
     /* Allocate a new hash table structure */
-    hash_table = (HashTable *)malloc(sizeof(HashTable));
+    hash_table = (HashTable *)PDC_malloc(sizeof(HashTable));
 
     if (hash_table == NULL) {
         return NULL;
@@ -233,7 +233,7 @@ hash_table_new(HashTableHashFunc hash_func, HashTableEqualFunc equal_func)
 
     /* Allocate the table */
     if (!hash_table_allocate_table(hash_table)) {
-        free(hash_table);
+        hash_table = (HashTable *)PDC_free(hash_table);
 
         return NULL;
     }
@@ -259,10 +259,10 @@ hash_table_free(HashTable *hash_table)
     }
 
     /* Free the table */
-    free(hash_table->table);
+    hash_table->table = (HashTableEntry **)PDC_free(hash_table->table);
 
     /* Free the hash table structure */
-    free(hash_table);
+    hash_table = (HashTable *)PDC_free(hash_table);
 }
 
 void
@@ -279,9 +279,9 @@ hash_table_enlarge(HashTable *hash_table)
     HashTableEntry **old_table;
     unsigned int     old_table_size;
     unsigned int     old_prime_index;
-    HashTableEntry * rover;
-    HashTablePair *  pair;
-    HashTableEntry * next;
+    HashTableEntry  *rover;
+    HashTablePair   *pair;
+    HashTableEntry  *next;
     unsigned int     index;
     unsigned int     i;
 
@@ -327,7 +327,7 @@ hash_table_enlarge(HashTable *hash_table)
     }
 
     /* Free the old table */
-    free(old_table);
+    old_table = (HashTableEntry **)PDC_free(old_table);
 
     return 1;
 }
@@ -336,7 +336,7 @@ int
 hash_table_insert(HashTable *hash_table, HashTableKey key, HashTableValue value)
 {
     HashTableEntry *rover;
-    HashTablePair * pair;
+    HashTablePair  *pair;
     HashTableEntry *newentry;
     unsigned int    index;
 
@@ -420,7 +420,7 @@ HashTableValue
 hash_table_lookup(HashTable *hash_table, HashTableKey key)
 {
     HashTableEntry *rover;
-    HashTablePair * pair;
+    HashTablePair  *pair;
     unsigned int    index;
 
     /* Generate the hash of the key and hence the index into the table */
@@ -450,8 +450,8 @@ int
 hash_table_remove(HashTable *hash_table, HashTableKey key)
 {
     HashTableEntry **rover;
-    HashTableEntry * entry;
-    HashTablePair *  pair;
+    HashTableEntry  *entry;
+    HashTablePair   *pair;
     unsigned int     index;
     int              result;
 
@@ -534,7 +534,7 @@ HashTablePair
 hash_table_iter_next(HashTableIterator *iterator)
 {
     HashTableEntry *current_entry;
-    HashTable *     hash_table;
+    HashTable      *hash_table;
     HashTablePair   pair = {NULL, NULL};
     unsigned int    chain;
 

--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -37,7 +37,7 @@ struct _HashTableEntry {
 };
 
 struct _HashTable {
-    HashTableEntry       **table;
+    HashTableEntry **      table;
     unsigned int           table_size;
     HashTableHashFunc      hash_func;
     HashTableEqualFunc     equal_func;
@@ -65,7 +65,7 @@ static const unsigned int hash_table_num_primes = sizeof(hash_table_primes) / si
 unsigned int
 pdc_default_string_hash_func(HashTableKey value)
 {
-    char        *str  = (char *)value;
+    char *       str  = (char *)value;
     unsigned int hash = 5381;
     int          c;
 
@@ -278,9 +278,9 @@ hash_table_enlarge(HashTable *hash_table)
     HashTableEntry **old_table;
     unsigned int     old_table_size;
     unsigned int     old_prime_index;
-    HashTableEntry  *rover;
-    HashTablePair   *pair;
-    HashTableEntry  *next;
+    HashTableEntry * rover;
+    HashTablePair *  pair;
+    HashTableEntry * next;
     unsigned int     index;
     unsigned int     i;
 
@@ -335,7 +335,7 @@ int
 hash_table_insert(HashTable *hash_table, HashTableKey key, HashTableValue value)
 {
     HashTableEntry *rover;
-    HashTablePair  *pair;
+    HashTablePair * pair;
     HashTableEntry *newentry;
     unsigned int    index;
 
@@ -419,7 +419,7 @@ HashTableValue
 hash_table_lookup(HashTable *hash_table, HashTableKey key)
 {
     HashTableEntry *rover;
-    HashTablePair  *pair;
+    HashTablePair * pair;
     unsigned int    index;
 
     /* Generate the hash of the key and hence the index into the table */
@@ -449,8 +449,8 @@ int
 hash_table_remove(HashTable *hash_table, HashTableKey key)
 {
     HashTableEntry **rover;
-    HashTableEntry  *entry;
-    HashTablePair   *pair;
+    HashTableEntry * entry;
+    HashTablePair *  pair;
     unsigned int     index;
     int              result;
 
@@ -533,7 +533,7 @@ HashTablePair
 hash_table_iter_next(HashTableIterator *iterator)
 {
     HashTableEntry *current_entry;
-    HashTable      *hash_table;
+    HashTable *     hash_table;
     HashTablePair   pair = {NULL, NULL};
     unsigned int    chain;
 

--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -184,7 +184,7 @@ hash_table_allocate_table(HashTable *hash_table)
     hash_table->table_size = new_table_size;
 
     /* Allocate the table and initialise to NULL for all entries */
-    hash_table->table = calloc(hash_table->table_size, sizeof(HashTableEntry *));
+    hash_table->table = PDC_calloc(hash_table->table_size, sizeof(HashTableEntry *));
 
     return hash_table->table != NULL;
 }
@@ -234,7 +234,6 @@ hash_table_new(HashTableHashFunc hash_func, HashTableEqualFunc equal_func)
     /* Allocate the table */
     if (!hash_table_allocate_table(hash_table)) {
         hash_table = (HashTable *)PDC_free(hash_table);
-
         return NULL;
     }
 

--- a/src/commons/collections/pdc_set.c
+++ b/src/commons/collections/pdc_set.c
@@ -37,7 +37,7 @@ struct _SetEntry {
 };
 
 struct _Set {
-    SetEntry   **table;
+    SetEntry **  table;
     unsigned int entries;
     unsigned int table_size;
     unsigned int prime_index;
@@ -128,8 +128,8 @@ set_new(SetHashFunc hash_func, SetEqualFunc equal_func)
 void
 set_free(Set *set)
 {
-    SetEntry    *rover;
-    SetEntry    *next;
+    SetEntry *   rover;
+    SetEntry *   next;
     unsigned int i;
 
     /* Free all entries in all chains */
@@ -166,9 +166,9 @@ set_register_free_function(Set *set, SetFreeFunc free_func)
 static int
 set_enlarge(Set *set)
 {
-    SetEntry    *rover;
-    SetEntry    *next;
-    SetEntry   **old_table;
+    SetEntry *   rover;
+    SetEntry *   next;
+    SetEntry **  old_table;
     unsigned int old_table_size;
     unsigned int old_prime_index;
     unsigned int index;
@@ -229,8 +229,8 @@ set_enlarge(Set *set)
 int
 set_insert(Set *set, SetValue data)
 {
-    SetEntry    *newentry;
-    SetEntry    *rover;
+    SetEntry *   newentry;
+    SetEntry *   rover;
     unsigned int index;
 
     /* The hash table becomes less efficient as the number of entries
@@ -297,8 +297,8 @@ set_insert(Set *set, SetValue data)
 int
 set_remove(Set *set, SetValue data)
 {
-    SetEntry   **rover;
-    SetEntry    *entry;
+    SetEntry **  rover;
+    SetEntry *   entry;
     unsigned int index;
 
     /* Look up the data by its hash key */
@@ -344,7 +344,7 @@ set_remove(Set *set, SetValue data)
 int
 set_query(Set *set, SetValue data)
 {
-    SetEntry    *rover;
+    SetEntry *   rover;
     unsigned int index;
 
     /* Look up the data by its hash key */
@@ -382,10 +382,10 @@ set_num_entries(Set *set)
 SetValue *
 set_to_array(Set *set)
 {
-    SetValue    *array;
+    SetValue *   array;
     int          array_counter;
     unsigned int i;
-    SetEntry    *rover;
+    SetEntry *   rover;
 
     /* Create an array to hold the set entries */
 
@@ -423,7 +423,7 @@ Set *
 set_union(Set *set1, Set *set2)
 {
     SetIterator iterator;
-    Set        *new_set;
+    Set *       new_set;
     SetValue    value;
 
     new_set = set_new(set1->hash_func, set1->equal_func);
@@ -483,7 +483,7 @@ set_union(Set *set1, Set *set2)
 Set *
 set_intersection(Set *set1, Set *set2)
 {
-    Set        *new_set;
+    Set *       new_set;
     SetIterator iterator;
     SetValue    value;
 
@@ -548,9 +548,9 @@ set_iterate(Set *set, SetIterator *iter)
 SetValue
 set_iter_next(SetIterator *iterator)
 {
-    Set         *set;
+    Set *        set;
     SetValue     result;
-    SetEntry    *current_entry;
+    SetEntry *   current_entry;
     unsigned int chain;
 
     set = iterator->set;

--- a/src/commons/collections/pdc_set.c
+++ b/src/commons/collections/pdc_set.c
@@ -37,7 +37,7 @@ struct _SetEntry {
 };
 
 struct _Set {
-    SetEntry **  table;
+    SetEntry   **table;
     unsigned int entries;
     unsigned int table_size;
     unsigned int prime_index;
@@ -93,7 +93,7 @@ set_free_entry(Set *set, SetEntry *entry)
 
     /* Free the entry structure */
 
-    free(entry);
+    entry = (SetEntry *)PDC_free(entry);
 }
 
 Set *
@@ -118,7 +118,7 @@ set_new(SetHashFunc hash_func, SetEqualFunc equal_func)
     /* Allocate the table */
 
     if (!set_allocate_table(new_set)) {
-        free(new_set);
+        new_set = (Set *)PDC_free(new_set);
         return NULL;
     }
 
@@ -128,8 +128,8 @@ set_new(SetHashFunc hash_func, SetEqualFunc equal_func)
 void
 set_free(Set *set)
 {
-    SetEntry *   rover;
-    SetEntry *   next;
+    SetEntry    *rover;
+    SetEntry    *next;
     unsigned int i;
 
     /* Free all entries in all chains */
@@ -151,12 +151,10 @@ set_free(Set *set)
     }
 
     /* Free the table */
-
-    free(set->table);
+    set->table = (SetEntry **)PDC_free(set->table);
 
     /* Free the set structure */
-
-    free(set);
+    set = (Set *)PDC_free(set);
 }
 
 void
@@ -168,9 +166,9 @@ set_register_free_function(Set *set, SetFreeFunc free_func)
 static int
 set_enlarge(Set *set)
 {
-    SetEntry *   rover;
-    SetEntry *   next;
-    SetEntry **  old_table;
+    SetEntry    *rover;
+    SetEntry    *next;
+    SetEntry   **old_table;
     unsigned int old_table_size;
     unsigned int old_prime_index;
     unsigned int index;
@@ -222,19 +220,17 @@ set_enlarge(Set *set)
     }
 
     /* Free back the old table */
-
-    free(old_table);
+    old_table = (SetEntry **)PDC_free(old_table);
 
     /* Resized successfully */
-
     return 1;
 }
 
 int
 set_insert(Set *set, SetValue data)
 {
-    SetEntry *   newentry;
-    SetEntry *   rover;
+    SetEntry    *newentry;
+    SetEntry    *rover;
     unsigned int index;
 
     /* The hash table becomes less efficient as the number of entries
@@ -301,8 +297,8 @@ set_insert(Set *set, SetValue data)
 int
 set_remove(Set *set, SetValue data)
 {
-    SetEntry **  rover;
-    SetEntry *   entry;
+    SetEntry   **rover;
+    SetEntry    *entry;
     unsigned int index;
 
     /* Look up the data by its hash key */
@@ -348,7 +344,7 @@ set_remove(Set *set, SetValue data)
 int
 set_query(Set *set, SetValue data)
 {
-    SetEntry *   rover;
+    SetEntry    *rover;
     unsigned int index;
 
     /* Look up the data by its hash key */
@@ -386,10 +382,10 @@ set_num_entries(Set *set)
 SetValue *
 set_to_array(Set *set)
 {
-    SetValue *   array;
+    SetValue    *array;
     int          array_counter;
     unsigned int i;
-    SetEntry *   rover;
+    SetEntry    *rover;
 
     /* Create an array to hold the set entries */
 
@@ -427,7 +423,7 @@ Set *
 set_union(Set *set1, Set *set2)
 {
     SetIterator iterator;
-    Set *       new_set;
+    Set        *new_set;
     SetValue    value;
 
     new_set = set_new(set1->hash_func, set1->equal_func);
@@ -487,7 +483,7 @@ set_union(Set *set1, Set *set2)
 Set *
 set_intersection(Set *set1, Set *set2)
 {
-    Set *       new_set;
+    Set        *new_set;
     SetIterator iterator;
     SetValue    value;
 
@@ -552,9 +548,9 @@ set_iterate(Set *set, SetIterator *iter)
 SetValue
 set_iter_next(SetIterator *iterator)
 {
-    Set *        set;
+    Set         *set;
     SetValue     result;
-    SetEntry *   current_entry;
+    SetEntry    *current_entry;
     unsigned int chain;
 
     set = iterator->set;

--- a/src/commons/collections/pdc_set.c
+++ b/src/commons/collections/pdc_set.c
@@ -76,7 +76,7 @@ set_allocate_table(Set *set)
 
     /* Allocate the table and initialise to NULL */
 
-    set->table = calloc(set->table_size, sizeof(SetEntry *));
+    set->table = PDC_calloc(set->table_size, sizeof(SetEntry *));
 
     return set->table != NULL;
 }

--- a/src/commons/collections/pdc_set_test.c
+++ b/src/commons/collections/pdc_set_test.c
@@ -19,7 +19,7 @@ int
 main(int argc, char **argv)
 {
     // read the max id from the command line
-    char    *endptr;
+    char *   endptr;
     uint64_t max_id = strtoull(argv[1], &endptr, 10);
     if (*endptr != '\0') {
         LOG_ERROR("Invalid number: %s\n", argv[1]);

--- a/src/commons/collections/pdc_set_test.c
+++ b/src/commons/collections/pdc_set_test.c
@@ -19,7 +19,7 @@ int
 main(int argc, char **argv)
 {
     // read the max id from the command line
-    char *   endptr;
+    char    *endptr;
     uint64_t max_id = strtoull(argv[1], &endptr, 10);
     if (*endptr != '\0') {
         LOG_ERROR("Invalid number: %s\n", argv[1]);
@@ -30,7 +30,7 @@ main(int argc, char **argv)
     set_register_free_function(set, set_value_free);
 
     for (uint64_t i = 0; i < max_id; i++) {
-        uint64_t *value = malloc(sizeof(uint64_t));
+        uint64_t *value = PDC_malloc(sizeof(uint64_t));
         *value          = i;
         set_insert(set, value);
     }
@@ -44,7 +44,7 @@ main(int argc, char **argv)
 
     // retrieve all values from the set
     for (uint64_t i = 0; i < max_id; i++) {
-        uint64_t *value = malloc(sizeof(uint64_t));
+        uint64_t *value = PDC_malloc(sizeof(uint64_t));
         *value          = i;
         if (!set_query(set, value)) {
             LOG_ERROR("Error: value %" PRIu64 " not found in the set\n", i);

--- a/src/commons/collections/pdc_set_test.c
+++ b/src/commons/collections/pdc_set_test.c
@@ -11,14 +11,14 @@
 void
 set_value_free(SetValue value)
 {
-    free((void *)value);
+    value = (void *)PDC_free((void *)value);
 }
 
 int
 main(int argc, char **argv)
 {
     // read the max id from the command line
-    char *   endptr;
+    char    *endptr;
     uint64_t max_id = strtoull(argv[1], &endptr, 10);
     if (*endptr != '\0') {
         LOG_ERROR("Invalid number: %s\n", argv[1]);

--- a/src/commons/collections/pdc_set_test.c
+++ b/src/commons/collections/pdc_set_test.c
@@ -2,6 +2,7 @@
 #include "pdc_compare.h"
 #include "pdc_hash.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
@@ -11,7 +12,7 @@
 void
 set_value_free(SetValue value)
 {
-    value = (void *)PDC_free((void *)value);
+    value = (SetValue)PDC_free((void *)value);
 }
 
 int

--- a/src/commons/collections/pdc_stack.c
+++ b/src/commons/collections/pdc_stack.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "pdc_logger.h"
 #include "pdc_stack.h"
+#include "pdc_malloc.h"
 
 #define DEFAULT_CAPACITY 16
 
@@ -43,5 +44,5 @@ stack_pop(PDC_stack_t *stack)
 void
 stack_free(PDC_stack_t *stack)
 {
-    free(stack->data);
+    stack->data = (void **)PDC_free(stack->data);
 }

--- a/src/commons/collections/pdc_stack.c
+++ b/src/commons/collections/pdc_stack.c
@@ -20,7 +20,7 @@ stack_push(PDC_stack_t *stack, void *value)
 {
     if (stack->size == stack->capacity) {
         size_t new_capacity = stack->capacity * 2;
-        void **new_data     = realloc(stack->data, sizeof(void *) * new_capacity);
+        void **new_data     = PDC_realloc(stack->data, sizeof(void *) * new_capacity);
         if (new_data == NULL) {
             LOG_ERROR("Failed to reallocate memory for stack!\n");
             exit(1);

--- a/src/commons/collections/pdc_stack.c
+++ b/src/commons/collections/pdc_stack.c
@@ -10,7 +10,7 @@
 void
 stack_init(PDC_stack_t *stack)
 {
-    stack->data     = malloc(sizeof(void *) * DEFAULT_CAPACITY);
+    stack->data     = PDC_malloc(sizeof(void *) * DEFAULT_CAPACITY);
     stack->size     = 0;
     stack->capacity = DEFAULT_CAPACITY;
 }

--- a/src/commons/collections/pdc_vector.c
+++ b/src/commons/collections/pdc_vector.c
@@ -1,4 +1,5 @@
 #include "pdc_vector.h"
+#include "pdc_malloc.h"
 
 PDC_VECTOR *
 pdc_vector_new()
@@ -10,15 +11,15 @@ PDC_VECTOR *
 pdc_vector_create(size_t initial_capacity, double expansion_factor)
 {
     // Allocate memory for the vector struct.
-    PDC_VECTOR *vector = (PDC_VECTOR *)malloc(sizeof(PDC_VECTOR));
+    PDC_VECTOR *vector = (PDC_VECTOR *)PDC_malloc(sizeof(PDC_VECTOR));
     if (vector == NULL) {
         return NULL;
     }
 
     // Allocate memory for the array of items.
-    vector->items = (void **)malloc(initial_capacity * sizeof(void *));
+    vector->items = (void **)PDC_malloc(initial_capacity * sizeof(void *));
     if (vector->items == NULL) {
-        free(vector);
+        vector = (PDC_VECTOR *)PDC_free(vector);
         return NULL;
     }
 
@@ -39,12 +40,12 @@ pdc_vector_destroy(PDC_VECTOR *vector)
 
     // Free all allocated memory for each item.
     for (size_t i = 0; i < vector->item_count; i++) {
-        free(vector->items[i]);
+        vector->items[i] = (void *)PDC_free(vector->items[i]);
     }
 
     // Free the array of items and the vector struct.
-    free(vector->items);
-    free(vector);
+    vector->items = (void **)PDC_free(vector->items);
+    vector        = (PDC_VECTOR *)PDC_free(vector);
 }
 
 void
@@ -119,7 +120,7 @@ pdc_vector_iterator_new(PDC_VECTOR *vector)
     }
 
     // Allocate memory for the iterator struct.
-    PDC_VECTOR_ITERATOR *iterator = (PDC_VECTOR_ITERATOR *)malloc(sizeof(PDC_VECTOR_ITERATOR));
+    PDC_VECTOR_ITERATOR *iterator = (PDC_VECTOR_ITERATOR *)PDC_malloc(sizeof(PDC_VECTOR_ITERATOR));
     if (iterator == NULL) {
         return NULL;
     }
@@ -134,12 +135,11 @@ pdc_vector_iterator_new(PDC_VECTOR *vector)
 void
 pdc_vector_iterator_destroy(PDC_VECTOR_ITERATOR *iterator)
 {
-    if (iterator == NULL) {
+    if (iterator == NULL)
         return;
-    }
 
     // Free the iterator struct.
-    free(iterator);
+    iterator = (PDC_VECTOR_ITERATOR *)PDC_free(iterator);
 }
 
 void *

--- a/src/commons/collections/pdc_vector.c
+++ b/src/commons/collections/pdc_vector.c
@@ -58,7 +58,7 @@ pdc_vector_add(PDC_VECTOR *vector, void *item)
     // Expand the array of items if necessary.
     if (vector->item_count >= vector->capacity) {
         vector->capacity *= vector->expansion_factor;
-        vector->items = (void **)realloc(vector->items, vector->capacity * sizeof(void *));
+        vector->items = (void **)PDC_realloc(vector->items, vector->capacity * sizeof(void *));
         if (vector->items == NULL) {
             return;
         }

--- a/src/commons/file/bin_file_ops.c
+++ b/src/commons/file/bin_file_ops.c
@@ -68,23 +68,23 @@ bin_read_general(int *t, size_t *len, void **data, FILE *stream)
     fread(&length, sizeof(size_t), 1, stream);
     void *_data;
     if (type == 1) {
-        _data = (int *)calloc(length, sizeof(int));
+        _data = (int *)PDC_calloc(length, sizeof(int));
         fread(_data, sizeof(int), length, stream);
     }
     else if (type == 2) {
-        _data = (double *)calloc(length, sizeof(double));
+        _data = (double *)PDC_calloc(length, sizeof(double));
         fread(_data, sizeof(double), length, stream);
     }
     else if (type == 3) {
-        _data = (char *)calloc(length + 1, sizeof(char));
+        _data = (char *)PDC_calloc(length + 1, sizeof(char));
         fread(_data, sizeof(char), length, stream);
     }
     else if (type == 4) {
-        _data = (uint64_t *)calloc(length, sizeof(uint64_t));
+        _data = (uint64_t *)PDC_calloc(length, sizeof(uint64_t));
         fread(_data, sizeof(uint64_t), length, stream);
     }
     else if (type == 5) {
-        _data = (size_t *)calloc(length, sizeof(size_t));
+        _data = (size_t *)PDC_calloc(length, sizeof(size_t));
         fread(_data, sizeof(size_t), length, stream);
     }
     data[0] = (void *)_data;
@@ -107,27 +107,27 @@ miqs_skip_field(FILE *stream)
     rst += sizeof(size_t);
     void *_data;
     if (type == 1) {
-        _data = (int *)calloc(length, sizeof(int));
+        _data = (int *)PDC_calloc(length, sizeof(int));
         fread(_data, sizeof(int), length, stream);
         rst += sizeof(int) * length;
     }
     else if (type == 2) {
-        _data = (double *)calloc(length, sizeof(double));
+        _data = (double *)PDC_calloc(length, sizeof(double));
         fread(_data, sizeof(double), length, stream);
         rst += sizeof(double) * length;
     }
     else if (type == 3) {
-        _data = (char *)calloc(length + 1, sizeof(char));
+        _data = (char *)PDC_calloc(length + 1, sizeof(char));
         fread(_data, sizeof(char), length, stream);
         rst += sizeof(char) * length;
     }
     else if (type == 4) {
-        _data = (uint64_t *)calloc(length, sizeof(uint64_t));
+        _data = (uint64_t *)PDC_calloc(length, sizeof(uint64_t));
         fread(_data, sizeof(uint64_t), length, stream);
         rst += sizeof(uint64_t) * length;
     }
     else if (type == 5) {
-        _data = (size_t *)calloc(length, sizeof(size_t));
+        _data = (size_t *)PDC_calloc(length, sizeof(size_t));
         fread(_data, sizeof(size_t), length, stream);
         rst += sizeof(size_t) * length;
     }
@@ -140,7 +140,7 @@ bin_read_index_numeric_value(int *is_float, FILE *file)
 {
     int    type = 1;
     size_t len  = 1;
-    void **data = (void **)calloc(1, sizeof(void *));
+    void **data = (void **)PDC_calloc(1, sizeof(void *));
     bin_read_general(&type, &len, data, file);
     if (len == 1) {
         if (type == 1) {
@@ -158,7 +158,7 @@ bin_read_int(FILE *file)
 {
     int    type = 1;
     size_t len  = 1;
-    void **data = (void **)calloc(1, sizeof(void *));
+    void **data = (void **)PDC_calloc(1, sizeof(void *));
     bin_read_general(&type, &len, data, file);
     if (type == 1 && len == 1) {
         return (int *)*data;
@@ -171,7 +171,7 @@ bin_read_double(FILE *file)
 {
     int    type = 2;
     size_t len  = 1;
-    void **data = (void **)calloc(1, sizeof(void *));
+    void **data = (void **)PDC_calloc(1, sizeof(void *));
     bin_read_general(&type, &len, data, file);
     if (type == 2 && len == 1) {
         return (double *)*data;
@@ -184,7 +184,7 @@ bin_read_string(FILE *file)
 {
     int    type = 3;
     size_t len  = 1;
-    void **data = (void **)calloc(1, sizeof(void *));
+    void **data = (void **)PDC_calloc(1, sizeof(void *));
     bin_read_general(&type, &len, data, file);
     if (type == 3) {
         return (char *)*data;
@@ -197,7 +197,7 @@ bin_read_uint64(FILE *file)
 {
     int    type = 4;
     size_t len  = 1;
-    void **data = (void **)calloc(1, sizeof(void *));
+    void **data = (void **)PDC_calloc(1, sizeof(void *));
     bin_read_general(&type, &len, data, file);
     if (type == 4 && len == 1) {
         return (uint64_t *)*data;
@@ -210,7 +210,7 @@ bin_read_size_t(FILE *file)
 {
     int    type = 5;
     size_t len  = 1;
-    void **data = (void **)calloc(1, sizeof(void *));
+    void **data = (void **)PDC_calloc(1, sizeof(void *));
     bin_read_general(&type, &len, data, file);
     if (type == 5 && len == 1) {
         return (size_t *)*data;

--- a/src/commons/file/bin_file_ops.c
+++ b/src/commons/file/bin_file_ops.c
@@ -1,4 +1,5 @@
 #include "bin_file_ops.h"
+#include "pdc_malloc.h"
 
 // type 1 int, 2 double, 3 string, 4 uint64, 5 size_t
 
@@ -130,7 +131,7 @@ miqs_skip_field(FILE *stream)
         fread(_data, sizeof(size_t), length, stream);
         rst += sizeof(size_t) * length;
     }
-    free(_data);
+    _data = (void *)PDC_free(_data);
     return rst;
 }
 

--- a/src/commons/file/common_io.c
+++ b/src/commons/file/common_io.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 FILE *
 open_file(char *filename, char *mode)
@@ -36,7 +37,7 @@ read_file(FILE *fp, io_buffer_t *buffer)
     rewind(fp);
 
     // Allocate memory for the buffer
-    buffer->buffer = (char *)malloc(buffer->size + 1);
+    buffer->buffer = (char *)PDC_malloc(buffer->size + 1);
     if (buffer->buffer == NULL) {
         LOG_ERROR("Error allocating memory for file buffer\n");
         return 1;
@@ -105,8 +106,8 @@ print_error(char *message)
 int
 read_text_file(char *filename, void (*callback)(char *line))
 {
-    FILE *  fp   = open_file(filename, IO_MODE_READ);
-    char *  line = NULL;
+    FILE   *fp   = open_file(filename, IO_MODE_READ);
+    char   *line = NULL;
     size_t  len  = 0;
     ssize_t read;
     while ((read = getline(&line, &len, fp)) != -1) {
@@ -119,7 +120,7 @@ read_text_file(char *filename, void (*callback)(char *line))
         LOG_ERROR("Error reading file\n");
         return 1;
     }
-    free(line);
+    line = (char *)PDC_free(line);
     close_file(fp);
     return 0;
 }

--- a/src/commons/file/common_io.c
+++ b/src/commons/file/common_io.c
@@ -106,8 +106,8 @@ print_error(char *message)
 int
 read_text_file(char *filename, void (*callback)(char *line))
 {
-    FILE   *fp   = open_file(filename, IO_MODE_READ);
-    char   *line = NULL;
+    FILE *  fp   = open_file(filename, IO_MODE_READ);
+    char *  line = NULL;
     size_t  len  = 0;
     ssize_t read;
     while ((read = getline(&line, &len, fp)) != -1) {

--- a/src/commons/generic/pdc_generic.c
+++ b/src/commons/generic/pdc_generic.c
@@ -8,10 +8,10 @@ get_number_from_string(char *str, pdc_c_var_type_t type, void **val_ptr)
         return 0;
     }
 
-    void * k       = NULL;
+    void  *k       = NULL;
     size_t key_len = get_size_by_dtype(type);
 
-    k = malloc(key_len);
+    k = PDC_malloc(key_len);
 
     switch (type) {
         case PDC_SHORT:

--- a/src/commons/generic/pdc_generic.c
+++ b/src/commons/generic/pdc_generic.c
@@ -8,7 +8,7 @@ get_number_from_string(char *str, pdc_c_var_type_t type, void **val_ptr)
         return 0;
     }
 
-    void  *k       = NULL;
+    void * k       = NULL;
     size_t key_len = get_size_by_dtype(type);
 
     k = PDC_malloc(key_len);

--- a/src/commons/generic/pdc_generic.c
+++ b/src/commons/generic/pdc_generic.c
@@ -1,4 +1,5 @@
 #include "pdc_generic.h"
+#include "pdc_malloc.h"
 
 size_t
 get_number_from_string(char *str, pdc_c_var_type_t type, void **val_ptr)
@@ -7,7 +8,7 @@ get_number_from_string(char *str, pdc_c_var_type_t type, void **val_ptr)
         return 0;
     }
 
-    void * k       = NULL;
+    void  *k       = NULL;
     size_t key_len = get_size_by_dtype(type);
 
     k = malloc(key_len);
@@ -52,7 +53,7 @@ get_number_from_string(char *str, pdc_c_var_type_t type, void **val_ptr)
             *((double *)k) = strtod(str, NULL);
             break;
         default:
-            free(k);
+            k = (void *)PDC_free(k);
             return 0;
     }
 

--- a/src/commons/generic/pdc_generic.c
+++ b/src/commons/generic/pdc_generic.c
@@ -8,7 +8,7 @@ get_number_from_string(char *str, pdc_c_var_type_t type, void **val_ptr)
         return 0;
     }
 
-    void  *k       = NULL;
+    void * k       = NULL;
     size_t key_len = get_size_by_dtype(type);
 
     k = malloc(key_len);

--- a/src/commons/index/dart/dart_algo.c
+++ b/src/commons/index/dart/dart_algo.c
@@ -1,4 +1,5 @@
 #include "dart_algo.h"
+#include "pdc_malloc.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -110,7 +111,7 @@ md5(const uint8_t *initial_msg, size_t initial_len, uint8_t *digest)
     for (new_len = initial_len + 1; new_len % (512 / 8) != 448 / 8; new_len++)
         ;
 
-    msg = (uint8_t *)malloc(new_len + 8);
+    msg = (uint8_t *)PDC_malloc(new_len + 8);
     memcpy(msg, initial_msg, initial_len);
     msg[initial_len] = 0x80; // append the "1" bit; most significant bit is "first"
     for (offset = initial_len + 1; offset < new_len; offset++)
@@ -170,7 +171,7 @@ md5(const uint8_t *initial_msg, size_t initial_len, uint8_t *digest)
     }
 
     // cleanup
-    free(msg);
+    msg = (uint8_t *)PDC_free(msg);
 
     // var char digest[16] := h0 append h1 append h2 append h3 //(Output is in little-endian)
     to_bytes(h0, digest);

--- a/src/commons/index/dart/dart_algo.c
+++ b/src/commons/index/dart/dart_algo.c
@@ -204,7 +204,7 @@ uint32_t
 md5_hash(int prefix_len, char *word)
 {
 
-    char *prefix = (char *)calloc(prefix_len + 1, sizeof(char));
+    char *prefix = (char *)PDC_calloc(prefix_len + 1, sizeof(char));
     strncpy(prefix, word, prefix_len);
     uint8_t digest;
     md5((uint8_t *)prefix, strlen(prefix), &digest);

--- a/src/commons/index/dart/dart_core.c
+++ b/src/commons/index/dart/dart_core.c
@@ -2,6 +2,7 @@
 #include "dart_algo.h"
 #include "dart_math.h"
 #include "dart_core.h"
+#include "pdc_malloc.h"
 
 #ifdef PDC_DART_MAX_SERVER_NUM_TO_ADAPT
 #define DART_MAX_SERVER_NUM_TO_ADAPT PDC_DART_MAX_SERVER_NUM_TO_ADAPT
@@ -107,7 +108,7 @@ dart_determine_query_token_by_key_query(char *k_query, char **out_token, dart_op
             break;
     }
     if (affix != NULL) {
-        free(affix);
+        affix = (char *)PDC_free(affix);
         affix = NULL;
     }
 }
@@ -140,7 +141,7 @@ get_vnode_ids_by_serverID(DART *dart, uint32_t serverID, uint64_t **out)
     }
     out[0] = (uint64_t *)calloc(num_result, sizeof(uint64_t));
     memcpy(out[0], temp_out, num_result * sizeof(uint64_t));
-    free(temp_out);
+    temp_out = (uint64_t *)PDC_free(temp_out);
     return num_result;
 }
 
@@ -532,7 +533,7 @@ DART_hash(DART *dart_g, char *key, dart_op_type_t op_type, get_server_info_callb
 
     uint64_t *temp_out    = NULL;
     int       tmp_out_len = 0;
-    char *    tok         = NULL;
+    char     *tok         = NULL;
     *out                  = NULL;
 
     // regardless of suffix tree mode, we only need to get the DART hash result for one time for query
@@ -586,7 +587,7 @@ DART_hash(DART *dart_g, char *key, dart_op_type_t op_type, get_server_info_callb
             (*out)[ret_value - tmp_out_len + j].is_suffix = is_suffix;
         }
         if (temp_out != NULL)
-            free(temp_out);
+            temp_out = (uint64_t *)PDC_free(temp_out);
     }
     return ret_value;
 }

--- a/src/commons/index/dart/dart_core.c
+++ b/src/commons/index/dart/dart_core.c
@@ -533,7 +533,7 @@ DART_hash(DART *dart_g, char *key, dart_op_type_t op_type, get_server_info_callb
 
     uint64_t *temp_out    = NULL;
     int       tmp_out_len = 0;
-    char     *tok         = NULL;
+    char *    tok         = NULL;
     *out                  = NULL;
 
     // regardless of suffix tree mode, we only need to get the DART hash result for one time for query

--- a/src/commons/index/dart/dart_core.c
+++ b/src/commons/index/dart/dart_core.c
@@ -54,7 +54,7 @@ __dart_space_init(DART *dart, int num_server, int alphabet_size, int extra_tree_
                   int replication_factor, int max_server_num_to_adapt)
 {
     if (dart == NULL) {
-        dart = (DART *)calloc(1, sizeof(DART));
+        dart = (DART *)PDC_calloc(1, sizeof(DART));
     }
     dart->alphabet_size = alphabet_size;
     // initialize servers;
@@ -131,7 +131,7 @@ get_vnode_ids_by_serverID(DART *dart, uint32_t serverID, uint64_t **out)
         return 0;
     }
     size_t    num_result = 0;
-    uint64_t *temp_out   = (uint64_t *)calloc(dart->num_vnode, sizeof(uint64_t));
+    uint64_t *temp_out   = (uint64_t *)PDC_calloc(dart->num_vnode, sizeof(uint64_t));
     int       vid        = 0;
     for (vid = 0; vid < dart->num_vnode; vid++) {
         if (get_server_id_by_vnode_id(dart, vid) == serverID) {
@@ -139,7 +139,7 @@ get_vnode_ids_by_serverID(DART *dart, uint32_t serverID, uint64_t **out)
             num_result++;
         }
     }
-    out[0] = (uint64_t *)calloc(num_result, sizeof(uint64_t));
+    out[0] = (uint64_t *)PDC_calloc(num_result, sizeof(uint64_t));
     memcpy(out[0], temp_out, num_result * sizeof(uint64_t));
     temp_out = (uint64_t *)PDC_free(temp_out);
     return num_result;
@@ -315,7 +315,7 @@ get_replica_node_ids(DART *dart, uint64_t master_node_id, int is_physical, uint6
     if (out == NULL) {
         return 0;
     }
-    out[0] = (uint64_t *)calloc(dart->replication_factor, sizeof(uint64_t));
+    out[0] = (uint64_t *)PDC_calloc(dart->replication_factor, sizeof(uint64_t));
 
     out[0][0] = master_node_id;
 
@@ -406,7 +406,7 @@ get_server_ids_for_query(DART *dart_g, char *token, dart_op_type_t op_type, uint
     // Note: if suffix tree mode is ON, we don't have to search all servers.
 #ifndef PDC_DART_SFX_TREE
     if (op_type == OP_INFIX_QUERY) {
-        out[0] = (uint64_t *)calloc(dart_g->num_server, sizeof(uint64_t));
+        out[0] = (uint64_t *)PDC_calloc(dart_g->num_server, sizeof(uint64_t));
         int i  = 0;
         for (i = 0; i < dart_g->num_server; i++) {
             out[0][i] = i;
@@ -435,7 +435,7 @@ get_server_ids_for_query(DART *dart_g, char *token, dart_op_type_t op_type, uint
         uint64_t server_end   = get_server_id_by_vnode_id(dart_g, region_start + region_size - 1);
 
         int num_srvs    = server_end - server_start + 1;
-        out[0]          = (uint64_t *)calloc(num_srvs, sizeof(uint64_t));
+        out[0]          = (uint64_t *)PDC_calloc(num_srvs, sizeof(uint64_t));
         int num_srv_ids = 0;
 
         uint64_t srvId = server_start;
@@ -475,7 +475,7 @@ get_server_ids_for_query(DART *dart_g, char *token, dart_op_type_t op_type, uint
         int num_alter_reps = get_replica_node_ids(dart_g, reconciled_vnode_id, is_physical, &alter_replicas);
         if (op_type == OP_DELETE) {
             // for delete operations, we need to perform delete on all replicas
-            out[0] = (uint64_t *)calloc(num_base_reps + num_alter_reps, sizeof(uint64_t));
+            out[0] = (uint64_t *)PDC_calloc(num_base_reps + num_alter_reps, sizeof(uint64_t));
             int i  = 0;
             for (i = 0; i < num_base_reps; i++) {
                 out[0][i] = base_replicas[i];
@@ -490,7 +490,7 @@ get_server_ids_for_query(DART *dart_g, char *token, dart_op_type_t op_type, uint
             // and the server has to be any two of the possible replicas.
             int req_count = dart_client_request_count_incr(dart_g);
             int rep_index = req_count % num_base_reps;
-            out[0]        = (uint64_t *)calloc(2, sizeof(uint64_t));
+            out[0]        = (uint64_t *)PDC_calloc(2, sizeof(uint64_t));
             int rst_size  = 1;
             out[0][0]     = base_replicas[rep_index];
             if (base_replicas[rep_index] != alter_replicas[rep_index]) {
@@ -575,10 +575,10 @@ DART_hash(DART *dart_g, char *key, dart_op_type_t op_type, get_server_info_callb
         // now we have the result of DART hash, we need to merge it with the previous results.
         ret_value += tmp_out_len;
         if (*out == NULL) {
-            *out = (index_hash_result_t *)calloc(ret_value, sizeof(index_hash_result_t));
+            *out = (index_hash_result_t *)PDC_calloc(ret_value, sizeof(index_hash_result_t));
         }
         else {
-            *out = (index_hash_result_t *)realloc(*out, ret_value * sizeof(index_hash_result_t));
+            *out = (index_hash_result_t *)PDC_realloc(*out, ret_value * sizeof(index_hash_result_t));
         }
         for (int j = 0; j < tmp_out_len; j++) {
             (*out)[ret_value - tmp_out_len + j].virtual_node_id = temp_out[j];
@@ -630,7 +630,7 @@ DHT_hash(DART *dart_g, size_t len, char *key, dart_op_type_t op_type, index_hash
     // according to different scan type, we return different results.
     if (is_full_scan) {
         ret_value = dart_g->num_server;
-        *out      = (index_hash_result_t *)calloc(ret_value, sizeof(index_hash_result_t));
+        *out      = (index_hash_result_t *)PDC_calloc(ret_value, sizeof(index_hash_result_t));
         for (i = 0; i < dart_g->num_server; i++) {
             (*out)[i].server_id = i;
             (*out)[i].key       = key;
@@ -638,7 +638,7 @@ DHT_hash(DART *dart_g, size_t len, char *key, dart_op_type_t op_type, index_hash
     }
     else {
         ret_value           = 1;
-        *out                = (index_hash_result_t *)calloc(ret_value, sizeof(index_hash_result_t));
+        *out                = (index_hash_result_t *)PDC_calloc(ret_value, sizeof(index_hash_result_t));
         (*out)[0].server_id = server_id;
         (*out)[0].key       = key;
     }

--- a/src/commons/index/dart/dart_core_test.c
+++ b/src/commons/index/dart/dart_core_test.c
@@ -1,5 +1,6 @@
 #include "dart_core.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 int32_t request_count_g;
 
@@ -30,7 +31,7 @@ main(int argc, char *argv[])
     replication_factor       = replication_factor == 0 ? num_server / 10 : replication_factor;
 
     // Init all servers
-    all_servers = (dart_server *)malloc(num_server * sizeof(dart_server));
+    all_servers = (dart_server *)PDC_malloc(num_server * sizeof(dart_server));
     for (int i = 0; i < num_server; i++) {
         all_servers[i].id                 = i;
         all_servers[i].indexed_word_count = 0;
@@ -53,7 +54,7 @@ main(int argc, char *argv[])
     }
     LOG_JUST_PRINT("\n}\n");
 
-    free(out);
+    out = (index_hash_result_t *)PDC_free(out);
 
     array_len = DART_hash(&dart, query_str, OP_EXACT_QUERY, NULL, &out);
     LOG_JUST_PRINT("server ids for exact search (%d): \n{", array_len);
@@ -62,7 +63,7 @@ main(int argc, char *argv[])
     }
     LOG_JUST_PRINT("\n}\n");
 
-    free(out);
+    out = (index_hash_result_t *)PDC_free(out);
 
     array_len = DART_hash(&dart, substring(query_str, 0, strlen(query_str) - 3), OP_PREFIX_QUERY, NULL, &out);
     LOG_JUST_PRINT("server ids for prefix search (%d): \n{", array_len);
@@ -71,7 +72,7 @@ main(int argc, char *argv[])
     }
     LOG_JUST_PRINT("\n}\n");
 
-    free(out);
+    out = (index_hash_result_t *)PDC_free(out);
 
     array_len = DART_hash(&dart, substring(query_str, 3, strlen(query_str)), OP_SUFFIX_QUERY, NULL, &out);
     LOG_JUST_PRINT("server ids for suffix search (%d): \n{", array_len);
@@ -80,7 +81,7 @@ main(int argc, char *argv[])
     }
     LOG_JUST_PRINT("\n}\n");
 
-    free(out);
+    out = (index_hash_result_t *)PDC_free(out);
 
     array_len = DART_hash(&dart, substring(query_str, 2, strlen(query_str) - 2), OP_INFIX_QUERY, NULL, &out);
     LOG_JUST_PRINT("server ids for infix search (%d): \n{", array_len);

--- a/src/commons/index/dart/index/idioms/idioms_local_index.c
+++ b/src/commons/index/dart/index/idioms/idioms_local_index.c
@@ -19,17 +19,17 @@
 IDIOMS_t *
 IDIOMS_init(uint32_t server_id, uint32_t num_servers)
 {
-    IDIOMS_t *idioms              = (IDIOMS_t *)calloc(1, sizeof(IDIOMS_t));
-    idioms->art_key_prefix_tree_g = (art_tree *)calloc(1, sizeof(art_tree));
+    IDIOMS_t *idioms              = (IDIOMS_t *)PDC_calloc(1, sizeof(IDIOMS_t));
+    idioms->art_key_prefix_tree_g = (art_tree *)PDC_calloc(1, sizeof(art_tree));
     art_tree_init(idioms->art_key_prefix_tree_g);
 
-    idioms->art_key_suffix_tree_g = (art_tree *)calloc(1, sizeof(art_tree));
+    idioms->art_key_suffix_tree_g = (art_tree *)PDC_calloc(1, sizeof(art_tree));
     art_tree_init(idioms->art_key_suffix_tree_g);
 
     idioms->server_id_g   = server_id;
     idioms->num_servers_g = num_servers;
 
-    idioms->dart_info_g = (DART *)calloc(1, sizeof(DART));
+    idioms->dart_info_g = (DART *)PDC_calloc(1, sizeof(DART));
     _init_dart_space_via_idioms(idioms->dart_info_g, idioms->num_servers_g);
 
     return idioms;
@@ -500,9 +500,9 @@ collect_obj_ids(value_index_leaf_content_t *value_index_leaf, IDIOMS_md_idx_reco
     int num_obj_ids = set_num_entries(obj_id_set);
 
     // realloc the obj_ids array in idx_record
-    idx_record->obj_ids =
-        (uint64_t *)realloc(idx_record->obj_ids, sizeof(uint64_t) * (idx_record->num_obj_ids + num_obj_ids));
-    size_t      offset = idx_record->num_obj_ids;
+    idx_record->obj_ids = (uint64_t *)PDC_realloc(idx_record->obj_ids,
+                                                  sizeof(uint64_t) * (idx_record->num_obj_ids + num_obj_ids));
+    size_t      offset  = idx_record->num_obj_ids;
     SetIterator value_set_iter;
     set_iterate(obj_id_set, &value_set_iter);
     while (set_iter_has_more(&value_set_iter)) {

--- a/src/commons/index/dart/index/idioms/idioms_local_index.c
+++ b/src/commons/index/dart/index/idioms/idioms_local_index.c
@@ -87,7 +87,7 @@ insert_obj_ids_into_value_leaf(void *index, void *attr_val, int is_trie, size_t 
 
 perr_t
 insert_value_into_second_level_index(key_index_leaf_content_t *leaf_content,
-                                     IDIOMS_md_idx_record_t *  idx_record)
+                                     IDIOMS_md_idx_record_t   *idx_record)
 {
     perr_t ret = SUCCEED;
     if (leaf_content == NULL) {
@@ -97,11 +97,11 @@ insert_value_into_second_level_index(key_index_leaf_content_t *leaf_content,
 
     if (_getCompoundTypeFromBitmap(leaf_content->val_idx_dtype) == PDC_STRING &&
         is_PDC_STRING(idx_record->type)) {
-        void * attr_val      = stripQuotes(idx_record->value);
+        void  *attr_val      = stripQuotes(idx_record->value);
         size_t value_str_len = strlen(attr_val);
         ret                  = insert_obj_ids_into_value_leaf(leaf_content->primary_trie, attr_val,
-                                             idx_record->type == PDC_STRING, value_str_len,
-                                             idx_record->obj_ids, idx_record->num_obj_ids);
+                                                              idx_record->type == PDC_STRING, value_str_len,
+                                                              idx_record->obj_ids, idx_record->num_obj_ids);
         if (ret == FAIL) {
             return ret;
         }
@@ -317,7 +317,7 @@ delete_obj_ids_from_value_leaf(void *index, void *attr_val, int is_trie, size_t 
 
 perr_t
 delete_value_from_second_level_index(key_index_leaf_content_t *leaf_content,
-                                     IDIOMS_md_idx_record_t *  idx_record)
+                                     IDIOMS_md_idx_record_t   *idx_record)
 {
     perr_t ret = SUCCEED;
     if (leaf_content == NULL) {
@@ -331,8 +331,8 @@ delete_value_from_second_level_index(key_index_leaf_content_t *leaf_content,
 
         size_t value_str_len = strlen(attr_val);
         ret                  = delete_obj_ids_from_value_leaf(leaf_content->primary_trie, attr_val,
-                                             idx_record->type == PDC_STRING, value_str_len,
-                                             idx_record->obj_ids, idx_record->num_obj_ids);
+                                                              idx_record->type == PDC_STRING, value_str_len,
+                                                              idx_record->obj_ids, idx_record->num_obj_ids);
         if (ret == FAIL) {
             return ret;
         }
@@ -350,8 +350,8 @@ delete_value_from_second_level_index(key_index_leaf_content_t *leaf_content,
         for (int j = 0; j < sub_loop_count; j++) {
             char *suffix = substring(attr_val, j, value_str_len);
             ret          = delete_obj_ids_from_value_leaf(leaf_content->secondary_trie, suffix,
-                                                 idx_record->type == PDC_STRING, value_str_len - j,
-                                                 idx_record->obj_ids, idx_record->num_obj_ids);
+                                                          idx_record->type == PDC_STRING, value_str_len - j,
+                                                          idx_record->obj_ids, idx_record->num_obj_ids);
         }
 #endif
     }
@@ -426,8 +426,7 @@ delete_from_key_trie(art_tree *key_trie, char *key, int len, IDIOMS_md_idx_recor
 
     if (is_key_leaf_cnt_empty(key_leaf_content)) {
         // delete the key from the the key trie along with the key_leaf_content.
-        free(key_leaf_content);
-        // LOG_DEBUG("Deleted key %s from the key trie\n", key);
+        key_leaf_content = (key_index_leaf_content_t *)PDC_free(key_leaf_content);
         art_delete(key_trie, (unsigned char *)key, len);
         return SUCCEED;
     }
@@ -524,9 +523,9 @@ int
 value_trie_callback(void *data, const unsigned char *key, uint32_t key_len, void *value)
 {
     value_index_leaf_content_t *value_index_leaf = (value_index_leaf_content_t *)(value);
-    IDIOMS_md_idx_record_t *    idx_record       = (IDIOMS_md_idx_record_t *)(data);
+    IDIOMS_md_idx_record_t     *idx_record       = (IDIOMS_md_idx_record_t *)(data);
 
-    char *         v_query          = (char *)idx_record->value;
+    char          *v_query          = (char *)idx_record->value;
     pattern_type_t value_query_type = determine_pattern_type(v_query);
     if (value_query_type == PATTERN_MIDDLE) {
         char *infix = substring(v_query, 1, strlen(v_query) - 1);
@@ -545,7 +544,7 @@ rbt_walk_return_code_t
 value_rbt_callback(rbt_t *rbt, void *key, size_t klen, void *value, void *priv)
 {
     value_index_leaf_content_t *value_index_leaf = (value_index_leaf_content_t *)(value);
-    IDIOMS_md_idx_record_t *    idx_record       = (IDIOMS_md_idx_record_t *)(priv);
+    IDIOMS_md_idx_record_t     *idx_record       = (IDIOMS_md_idx_record_t *)(priv);
     if (value_index_leaf != NULL) {
         collect_obj_ids(value_index_leaf, idx_record);
     }
@@ -579,7 +578,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
     void *val2;
     if (startsWith(secondary_query, "|") && startsWith(secondary_query, "|")) {
         // exact number search
-        char * num_str = substring(secondary_query, 1, strlen(secondary_query) - 1);
+        char  *num_str = substring(secondary_query, 1, strlen(secondary_query) - 1);
         size_t klen1 =
             get_number_from_string(num_str, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         value_index_leaf_content_t *value_index_leaf = NULL;
@@ -592,7 +591,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         int endInclusive = secondary_query[1] == '|';
         // find all numbers that are smaller than the given number
         int    beginPos = endInclusive ? 2 : 1;
-        char * numstr   = substring(secondary_query, beginPos, strlen(secondary_query));
+        char  *numstr   = substring(secondary_query, beginPos, strlen(secondary_query));
         size_t klen1 =
             get_number_from_string(numstr, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         rbt_range_lt(leafcnt->primary_rbt, val1, klen1, value_rbt_callback, idx_record, endInclusive);
@@ -601,7 +600,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         int beginInclusive = secondary_query[strlen(secondary_query) - 2] == '|';
         int endPos         = beginInclusive ? strlen(secondary_query) - 2 : strlen(secondary_query) - 1;
         // find all numbers that are greater than the given number
-        char * numstr = substring(secondary_query, 0, endPos);
+        char  *numstr = substring(secondary_query, 0, endPos);
         size_t klen1 =
             get_number_from_string(numstr, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         rbt_range_gt(leafcnt->primary_rbt, val1, klen1, value_rbt_callback, idx_record, beginInclusive);
@@ -620,8 +619,8 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         // lo_tok might be ended with '|', and hi_tok might be started with '|', to indicate inclusivity.
         int    beginInclusive = endsWith(lo_tok, "|");
         int    endInclusive   = startsWith(hi_tok, "|");
-        char * lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
-        char * hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
+        char  *lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
+        char  *hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
         size_t klen1 =
             get_number_from_string(lo_num_str, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         size_t klen2 =
@@ -634,7 +633,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
     else {
         // exact query by default
         // exact number search
-        char * num_str = strdup(secondary_query);
+        char  *num_str = strdup(secondary_query);
         size_t klen1 =
             get_number_from_string(num_str, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         value_index_leaf_content_t *value_index_leaf = NULL;
@@ -642,7 +641,6 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         if (value_index_leaf != NULL) {
             collect_obj_ids(value_index_leaf, idx_record);
         }
-        // free(num_str);
     }
     return 0;
 }
@@ -652,7 +650,7 @@ value_string_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
                    IDIOMS_md_idx_record_t *idx_record)
 {
     pattern_type_t level_two_ptn_type = determine_pattern_type(secondary_query);
-    char *         tok                = NULL;
+    char          *tok                = NULL;
     switch (level_two_ptn_type) {
         case PATTERN_EXACT:
             tok = secondary_query;
@@ -713,7 +711,7 @@ int
 key_index_search_callback(void *data, const unsigned char *key, uint32_t key_len, void *value)
 {
     key_index_leaf_content_t *leafcnt    = (key_index_leaf_content_t *)value;
-    IDIOMS_md_idx_record_t *  idx_record = (IDIOMS_md_idx_record_t *)(data);
+    IDIOMS_md_idx_record_t   *idx_record = (IDIOMS_md_idx_record_t *)(data);
 
     char *k_query = idx_record->key;
     char *v_query = idx_record->value;
@@ -798,8 +796,8 @@ idioms_local_index_search(IDIOMS_t *idioms, IDIOMS_md_idx_record_t *idx_record)
 
     timer_start(&index_timer);
 
-    char *                    qType_string = "Exact";
-    char *                    tok;
+    char                     *qType_string = "Exact";
+    char                     *tok;
     pattern_type_t            level_one_ptn_type = determine_pattern_type(k_query);
     key_index_leaf_content_t *leafcnt            = NULL;
     // if (index_type == DHT_FULL_HASH || index_type == DHT_INITIAL_HASH) {
@@ -811,7 +809,7 @@ idioms_local_index_search(IDIOMS_t *idioms, IDIOMS_md_idx_record_t *idx_record)
             qType_string = "Exact";
             tok          = k_query;
             leafcnt      = (key_index_leaf_content_t *)art_search(idioms->art_key_prefix_tree_g,
-                                                             (unsigned char *)tok, strlen(tok));
+                                                                  (unsigned char *)tok, strlen(tok));
             if (leafcnt != NULL) {
                 key_index_search_callback((void *)idx_record, (unsigned char *)tok, strlen(tok),
                                           (void *)leafcnt);

--- a/src/commons/index/dart/index/idioms/idioms_local_index.c
+++ b/src/commons/index/dart/index/idioms/idioms_local_index.c
@@ -87,7 +87,7 @@ insert_obj_ids_into_value_leaf(void *index, void *attr_val, int is_trie, size_t 
 
 perr_t
 insert_value_into_second_level_index(key_index_leaf_content_t *leaf_content,
-                                     IDIOMS_md_idx_record_t   *idx_record)
+                                     IDIOMS_md_idx_record_t *  idx_record)
 {
     perr_t ret = SUCCEED;
     if (leaf_content == NULL) {
@@ -97,11 +97,11 @@ insert_value_into_second_level_index(key_index_leaf_content_t *leaf_content,
 
     if (_getCompoundTypeFromBitmap(leaf_content->val_idx_dtype) == PDC_STRING &&
         is_PDC_STRING(idx_record->type)) {
-        void  *attr_val      = stripQuotes(idx_record->value);
+        void * attr_val      = stripQuotes(idx_record->value);
         size_t value_str_len = strlen(attr_val);
         ret                  = insert_obj_ids_into_value_leaf(leaf_content->primary_trie, attr_val,
-                                                              idx_record->type == PDC_STRING, value_str_len,
-                                                              idx_record->obj_ids, idx_record->num_obj_ids);
+                                             idx_record->type == PDC_STRING, value_str_len,
+                                             idx_record->obj_ids, idx_record->num_obj_ids);
         if (ret == FAIL) {
             return ret;
         }
@@ -317,7 +317,7 @@ delete_obj_ids_from_value_leaf(void *index, void *attr_val, int is_trie, size_t 
 
 perr_t
 delete_value_from_second_level_index(key_index_leaf_content_t *leaf_content,
-                                     IDIOMS_md_idx_record_t   *idx_record)
+                                     IDIOMS_md_idx_record_t *  idx_record)
 {
     perr_t ret = SUCCEED;
     if (leaf_content == NULL) {
@@ -331,8 +331,8 @@ delete_value_from_second_level_index(key_index_leaf_content_t *leaf_content,
 
         size_t value_str_len = strlen(attr_val);
         ret                  = delete_obj_ids_from_value_leaf(leaf_content->primary_trie, attr_val,
-                                                              idx_record->type == PDC_STRING, value_str_len,
-                                                              idx_record->obj_ids, idx_record->num_obj_ids);
+                                             idx_record->type == PDC_STRING, value_str_len,
+                                             idx_record->obj_ids, idx_record->num_obj_ids);
         if (ret == FAIL) {
             return ret;
         }
@@ -350,8 +350,8 @@ delete_value_from_second_level_index(key_index_leaf_content_t *leaf_content,
         for (int j = 0; j < sub_loop_count; j++) {
             char *suffix = substring(attr_val, j, value_str_len);
             ret          = delete_obj_ids_from_value_leaf(leaf_content->secondary_trie, suffix,
-                                                          idx_record->type == PDC_STRING, value_str_len - j,
-                                                          idx_record->obj_ids, idx_record->num_obj_ids);
+                                                 idx_record->type == PDC_STRING, value_str_len - j,
+                                                 idx_record->obj_ids, idx_record->num_obj_ids);
         }
 #endif
     }
@@ -523,9 +523,9 @@ int
 value_trie_callback(void *data, const unsigned char *key, uint32_t key_len, void *value)
 {
     value_index_leaf_content_t *value_index_leaf = (value_index_leaf_content_t *)(value);
-    IDIOMS_md_idx_record_t     *idx_record       = (IDIOMS_md_idx_record_t *)(data);
+    IDIOMS_md_idx_record_t *    idx_record       = (IDIOMS_md_idx_record_t *)(data);
 
-    char          *v_query          = (char *)idx_record->value;
+    char *         v_query          = (char *)idx_record->value;
     pattern_type_t value_query_type = determine_pattern_type(v_query);
     if (value_query_type == PATTERN_MIDDLE) {
         char *infix = substring(v_query, 1, strlen(v_query) - 1);
@@ -544,7 +544,7 @@ rbt_walk_return_code_t
 value_rbt_callback(rbt_t *rbt, void *key, size_t klen, void *value, void *priv)
 {
     value_index_leaf_content_t *value_index_leaf = (value_index_leaf_content_t *)(value);
-    IDIOMS_md_idx_record_t     *idx_record       = (IDIOMS_md_idx_record_t *)(priv);
+    IDIOMS_md_idx_record_t *    idx_record       = (IDIOMS_md_idx_record_t *)(priv);
     if (value_index_leaf != NULL) {
         collect_obj_ids(value_index_leaf, idx_record);
     }
@@ -578,7 +578,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
     void *val2;
     if (startsWith(secondary_query, "|") && startsWith(secondary_query, "|")) {
         // exact number search
-        char  *num_str = substring(secondary_query, 1, strlen(secondary_query) - 1);
+        char * num_str = substring(secondary_query, 1, strlen(secondary_query) - 1);
         size_t klen1 =
             get_number_from_string(num_str, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         value_index_leaf_content_t *value_index_leaf = NULL;
@@ -591,7 +591,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         int endInclusive = secondary_query[1] == '|';
         // find all numbers that are smaller than the given number
         int    beginPos = endInclusive ? 2 : 1;
-        char  *numstr   = substring(secondary_query, beginPos, strlen(secondary_query));
+        char * numstr   = substring(secondary_query, beginPos, strlen(secondary_query));
         size_t klen1 =
             get_number_from_string(numstr, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         rbt_range_lt(leafcnt->primary_rbt, val1, klen1, value_rbt_callback, idx_record, endInclusive);
@@ -600,7 +600,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         int beginInclusive = secondary_query[strlen(secondary_query) - 2] == '|';
         int endPos         = beginInclusive ? strlen(secondary_query) - 2 : strlen(secondary_query) - 1;
         // find all numbers that are greater than the given number
-        char  *numstr = substring(secondary_query, 0, endPos);
+        char * numstr = substring(secondary_query, 0, endPos);
         size_t klen1 =
             get_number_from_string(numstr, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         rbt_range_gt(leafcnt->primary_rbt, val1, klen1, value_rbt_callback, idx_record, beginInclusive);
@@ -619,8 +619,8 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
         // lo_tok might be ended with '|', and hi_tok might be started with '|', to indicate inclusivity.
         int    beginInclusive = endsWith(lo_tok, "|");
         int    endInclusive   = startsWith(hi_tok, "|");
-        char  *lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
-        char  *hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
+        char * lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
+        char * hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
         size_t klen1 =
             get_number_from_string(lo_num_str, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         size_t klen2 =
@@ -633,7 +633,7 @@ value_number_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
     else {
         // exact query by default
         // exact number search
-        char  *num_str = strdup(secondary_query);
+        char * num_str = strdup(secondary_query);
         size_t klen1 =
             get_number_from_string(num_str, _getNumericalTypeFromBitmap(leafcnt->val_idx_dtype), &val1);
         value_index_leaf_content_t *value_index_leaf = NULL;
@@ -650,7 +650,7 @@ value_string_query(char *secondary_query, key_index_leaf_content_t *leafcnt,
                    IDIOMS_md_idx_record_t *idx_record)
 {
     pattern_type_t level_two_ptn_type = determine_pattern_type(secondary_query);
-    char          *tok                = NULL;
+    char *         tok                = NULL;
     switch (level_two_ptn_type) {
         case PATTERN_EXACT:
             tok = secondary_query;
@@ -711,7 +711,7 @@ int
 key_index_search_callback(void *data, const unsigned char *key, uint32_t key_len, void *value)
 {
     key_index_leaf_content_t *leafcnt    = (key_index_leaf_content_t *)value;
-    IDIOMS_md_idx_record_t   *idx_record = (IDIOMS_md_idx_record_t *)(data);
+    IDIOMS_md_idx_record_t *  idx_record = (IDIOMS_md_idx_record_t *)(data);
 
     char *k_query = idx_record->key;
     char *v_query = idx_record->value;
@@ -796,8 +796,8 @@ idioms_local_index_search(IDIOMS_t *idioms, IDIOMS_md_idx_record_t *idx_record)
 
     timer_start(&index_timer);
 
-    char                     *qType_string = "Exact";
-    char                     *tok;
+    char *                    qType_string = "Exact";
+    char *                    tok;
     pattern_type_t            level_one_ptn_type = determine_pattern_type(k_query);
     key_index_leaf_content_t *leafcnt            = NULL;
     // if (index_type == DHT_FULL_HASH || index_type == DHT_INITIAL_HASH) {
@@ -809,7 +809,7 @@ idioms_local_index_search(IDIOMS_t *idioms, IDIOMS_md_idx_record_t *idx_record)
             qType_string = "Exact";
             tok          = k_query;
             leafcnt      = (key_index_leaf_content_t *)art_search(idioms->art_key_prefix_tree_g,
-                                                                  (unsigned char *)tok, strlen(tok));
+                                                             (unsigned char *)tok, strlen(tok));
             if (leafcnt != NULL) {
                 key_index_search_callback((void *)idx_record, (unsigned char *)tok, strlen(tok),
                                           (void *)leafcnt);

--- a/src/commons/index/dart/index/idioms/idioms_local_index_test.c
+++ b/src/commons/index/dart/index/idioms/idioms_local_index_test.c
@@ -8,23 +8,23 @@ typedef enum { IDIOMS_INSERT = 1, IDIOMS_DELETE = 2, IDIOMS_QUERY = 3 } IDIOMS_O
 
 typedef struct {
     IDIOMS_t *idioms;
-    void     *buffer_in;
+    void *    buffer_in;
     size_t    buffer_in_size;
-    void     *buffer_out;
+    void *    buffer_out;
     size_t    buffer_out_size;
     int       id;
 } dummy_server_t;
 
 typedef struct {
-    DART  *dart;
+    DART * dart;
     int    DART_ALPHABET_SIZE;
     int    num_servers;
     int    extra_tree_height;
     int    replication_factor;
     int    dart_insert_count;
-    void  *buffer_in;
+    void * buffer_in;
     size_t buffer_in_size;
-    void  *buffer_out;
+    void * buffer_out;
     size_t buffer_out_size;
     int    id;
 } dummy_client_t;
@@ -105,7 +105,7 @@ client_select_server(dummy_client_t *client, char *attr_key, IDIOMS_OP_TYPE op_t
 {
     // select a server based on the key
     dart_op_type_t           dart_op   = OP_INSERT;
-    char                    *input_key = attr_key;
+    char *                   input_key = attr_key;
     get_server_info_callback gsi_cp    = NULL;
     if (op_type == IDIOMS_INSERT) {
         dart_op = OP_INSERT;
@@ -188,14 +188,14 @@ server_perform_delete(dummy_server_t *server, char *key, BULKI_Entity *value_ent
 void
 server_perform_operation(dummy_server_t *server)
 {
-    BULKI_Entity  *resultBent  = empty_Bent_Array_Entity();
-    BULKI_Entity  *bentArr     = BULKI_Entity_deserialize(server->buffer_in);
-    BULKI_Entity  *opType_ent  = BULKI_ENTITY_get_BULKI_Entity(bentArr, 0);
-    BULKI_Entity  *key_ent     = BULKI_ENTITY_get_BULKI_Entity(bentArr, 1);
-    char          *key         = (char *)key_ent->data;
+    BULKI_Entity * resultBent  = empty_Bent_Array_Entity();
+    BULKI_Entity * bentArr     = BULKI_Entity_deserialize(server->buffer_in);
+    BULKI_Entity * opType_ent  = BULKI_ENTITY_get_BULKI_Entity(bentArr, 0);
+    BULKI_Entity * key_ent     = BULKI_ENTITY_get_BULKI_Entity(bentArr, 1);
+    char *         key         = (char *)key_ent->data;
     perr_t         result      = SUCCEED;
     IDIOMS_OP_TYPE opType      = *(int8_t *)opType_ent->data;
-    uint64_t      *obj_id_list = NULL;
+    uint64_t *     obj_id_list = NULL;
     uint64_t       count       = 0;
     if (opType == IDIOMS_QUERY) {
         result = server_perform_query(server, key, &obj_id_list, &count);

--- a/src/commons/index/dart/index/idioms/idioms_local_index_test.c
+++ b/src/commons/index/dart/index/idioms/idioms_local_index_test.c
@@ -52,7 +52,7 @@ init_clients(int num_clients, int num_servers)
     // initialize each client, simulating the initialization of every single process
     for (int i = 0; i < num_clients; i++) {
         clients[i].id                 = i;
-        clients[i].dart               = (DART *)calloc(1, sizeof(DART));
+        clients[i].dart               = (DART *)PDC_calloc(1, sizeof(DART));
         clients[i].num_servers        = num_servers;
         clients[i].DART_ALPHABET_SIZE = 27;
         clients[i].extra_tree_height  = 0;
@@ -137,14 +137,15 @@ get_response_from_server(dummy_client_t *client, dummy_server_t *server)
     client->buffer_in_size = server->buffer_out_size;
     client->buffer_in      = (void *)PDC_malloc(client->buffer_in_size);
     memcpy(client->buffer_in, server->buffer_out, client->buffer_in_size);
-    server->buffer_out = (void*)PDC_free(server->buffer_out);
+    server->buffer_out = (void *)PDC_free(server->buffer_out);
 }
 
 perr_t
 server_perform_query(dummy_server_t *server, char *query_str, uint64_t **object_id_list, uint64_t *count)
 {
-    IDIOMS_md_idx_record_t *idx_record = (IDIOMS_md_idx_record_t *)calloc(1, sizeof(IDIOMS_md_idx_record_t));
-    idx_record->key                    = query_str;
+    IDIOMS_md_idx_record_t *idx_record =
+        (IDIOMS_md_idx_record_t *)PDC_calloc(1, sizeof(IDIOMS_md_idx_record_t));
+    idx_record->key = query_str;
     idioms_local_index_search(server->idioms, idx_record);
     *object_id_list = idx_record->obj_ids;
     *count          = idx_record->num_obj_ids;
@@ -155,14 +156,15 @@ perr_t
 server_perform_insert(dummy_server_t *server, char *key, BULKI_Entity *value_ent, uint64_t id)
 {
     // we assume that the count of value_ent is 1.
-    IDIOMS_md_idx_record_t *idx_record = (IDIOMS_md_idx_record_t *)calloc(1, sizeof(IDIOMS_md_idx_record_t));
-    idx_record->key                    = key;
-    idx_record->value                  = value_ent->data;
-    idx_record->value_len              = value_ent->size;
-    idx_record->type                   = value_ent->pdc_type;
-    idx_record->num_obj_ids            = 1;
-    idx_record->obj_ids                = (uint64_t *)calloc(1, sizeof(uint64_t));
-    idx_record->obj_ids[0]             = id;
+    IDIOMS_md_idx_record_t *idx_record =
+        (IDIOMS_md_idx_record_t *)PDC_calloc(1, sizeof(IDIOMS_md_idx_record_t));
+    idx_record->key         = key;
+    idx_record->value       = value_ent->data;
+    idx_record->value_len   = value_ent->size;
+    idx_record->type        = value_ent->pdc_type;
+    idx_record->num_obj_ids = 1;
+    idx_record->obj_ids     = (uint64_t *)PDC_calloc(1, sizeof(uint64_t));
+    idx_record->obj_ids[0]  = id;
     idioms_local_index_create(server->idioms, idx_record);
     return SUCCEED;
 }
@@ -170,14 +172,15 @@ server_perform_insert(dummy_server_t *server, char *key, BULKI_Entity *value_ent
 perr_t
 server_perform_delete(dummy_server_t *server, char *key, BULKI_Entity *value_ent, uint64_t id)
 {
-    IDIOMS_md_idx_record_t *idx_record = (IDIOMS_md_idx_record_t *)calloc(1, sizeof(IDIOMS_md_idx_record_t));
-    idx_record->key                    = key;
-    idx_record->value                  = value_ent->data;
-    idx_record->value_len              = value_ent->size;
-    idx_record->type                   = value_ent->pdc_type;
-    idx_record->num_obj_ids            = 1;
-    idx_record->obj_ids                = (uint64_t *)calloc(1, sizeof(uint64_t));
-    idx_record->obj_ids[0]             = id;
+    IDIOMS_md_idx_record_t *idx_record =
+        (IDIOMS_md_idx_record_t *)PDC_calloc(1, sizeof(IDIOMS_md_idx_record_t));
+    idx_record->key         = key;
+    idx_record->value       = value_ent->data;
+    idx_record->value_len   = value_ent->size;
+    idx_record->type        = value_ent->pdc_type;
+    idx_record->num_obj_ids = 1;
+    idx_record->obj_ids     = (uint64_t *)PDC_calloc(1, sizeof(uint64_t));
+    idx_record->obj_ids[0]  = id;
     idioms_local_index_delete(server->idioms, idx_record);
     return SUCCEED;
 }
@@ -305,7 +308,7 @@ client_perform_search(dummy_client_t *client, char *query, uint64_t **rst_ids)
                 *rst_ids = (uint64_t *)PDC_malloc(rst_count * sizeof(uint64_t));
             }
             else {
-                *rst_ids = (uint64_t *)realloc(*rst_ids, rst_count * sizeof(uint64_t));
+                *rst_ids = (uint64_t *)PDC_realloc(*rst_ids, rst_count * sizeof(uint64_t));
             }
             memcpy(*rst_ids + rst_count - count, obj_id_list, count * sizeof(uint64_t));
         }

--- a/src/commons/index/dart/index/idioms/idioms_local_index_test.c
+++ b/src/commons/index/dart/index/idioms/idioms_local_index_test.c
@@ -8,23 +8,23 @@ typedef enum { IDIOMS_INSERT = 1, IDIOMS_DELETE = 2, IDIOMS_QUERY = 3 } IDIOMS_O
 
 typedef struct {
     IDIOMS_t *idioms;
-    void *    buffer_in;
+    void     *buffer_in;
     size_t    buffer_in_size;
-    void *    buffer_out;
+    void     *buffer_out;
     size_t    buffer_out_size;
     int       id;
 } dummy_server_t;
 
 typedef struct {
-    DART * dart;
+    DART  *dart;
     int    DART_ALPHABET_SIZE;
     int    num_servers;
     int    extra_tree_height;
     int    replication_factor;
     int    dart_insert_count;
-    void * buffer_in;
+    void  *buffer_in;
     size_t buffer_in_size;
-    void * buffer_out;
+    void  *buffer_out;
     size_t buffer_out_size;
     int    id;
 } dummy_client_t;
@@ -36,7 +36,7 @@ void
 init_servers(int num_servers)
 {
     // create an array of dummy_server_t
-    servers = (dummy_server_t *)malloc(num_servers * sizeof(dummy_server_t));
+    servers = (dummy_server_t *)PDC_malloc(num_servers * sizeof(dummy_server_t));
     // initialize each server, simulating the initialization of every single process
     for (int i = 0; i < num_servers; i++) {
         servers[i].id     = i;
@@ -48,7 +48,7 @@ void
 init_clients(int num_clients, int num_servers)
 {
     // create an array of dummy_client_t
-    clients = (dummy_client_t *)malloc(num_clients * sizeof(dummy_client_t));
+    clients = (dummy_client_t *)PDC_malloc(num_clients * sizeof(dummy_client_t));
     // initialize each client, simulating the initialization of every single process
     for (int i = 0; i < num_clients; i++) {
         clients[i].id                 = i;
@@ -105,7 +105,7 @@ client_select_server(dummy_client_t *client, char *attr_key, IDIOMS_OP_TYPE op_t
 {
     // select a server based on the key
     dart_op_type_t           dart_op   = OP_INSERT;
-    char *                   input_key = attr_key;
+    char                    *input_key = attr_key;
     get_server_info_callback gsi_cp    = NULL;
     if (op_type == IDIOMS_INSERT) {
         dart_op = OP_INSERT;
@@ -125,9 +125,9 @@ sending_request_to_server(dummy_client_t *client, dummy_server_t *server)
 {
     // memcpy to simulate the sending of the request to the server
     server->buffer_in_size = client->buffer_out_size;
-    server->buffer_in      = (void *)malloc(server->buffer_in_size);
+    server->buffer_in      = (void *)PDC_malloc(server->buffer_in_size);
     memcpy(server->buffer_in, client->buffer_out, server->buffer_in_size);
-    free(client->buffer_out);
+    client->buffer_out = (void *)PDC_free(client->buffer_out);
 }
 
 void
@@ -135,9 +135,9 @@ get_response_from_server(dummy_client_t *client, dummy_server_t *server)
 {
     // memcpy to simulate the receiving of the response from the server
     client->buffer_in_size = server->buffer_out_size;
-    client->buffer_in      = (void *)malloc(client->buffer_in_size);
+    client->buffer_in      = (void *)PDC_malloc(client->buffer_in_size);
     memcpy(client->buffer_in, server->buffer_out, client->buffer_in_size);
-    free(server->buffer_out);
+    server->buffer_out = (void*)PDC_free(server->buffer_out);
 }
 
 perr_t
@@ -185,14 +185,14 @@ server_perform_delete(dummy_server_t *server, char *key, BULKI_Entity *value_ent
 void
 server_perform_operation(dummy_server_t *server)
 {
-    BULKI_Entity * resultBent  = empty_Bent_Array_Entity();
-    BULKI_Entity * bentArr     = BULKI_Entity_deserialize(server->buffer_in);
-    BULKI_Entity * opType_ent  = BULKI_ENTITY_get_BULKI_Entity(bentArr, 0);
-    BULKI_Entity * key_ent     = BULKI_ENTITY_get_BULKI_Entity(bentArr, 1);
-    char *         key         = (char *)key_ent->data;
+    BULKI_Entity  *resultBent  = empty_Bent_Array_Entity();
+    BULKI_Entity  *bentArr     = BULKI_Entity_deserialize(server->buffer_in);
+    BULKI_Entity  *opType_ent  = BULKI_ENTITY_get_BULKI_Entity(bentArr, 0);
+    BULKI_Entity  *key_ent     = BULKI_ENTITY_get_BULKI_Entity(bentArr, 1);
+    char          *key         = (char *)key_ent->data;
     perr_t         result      = SUCCEED;
     IDIOMS_OP_TYPE opType      = *(int8_t *)opType_ent->data;
-    uint64_t *     obj_id_list = NULL;
+    uint64_t      *obj_id_list = NULL;
     uint64_t       count       = 0;
     if (opType == IDIOMS_QUERY) {
         result = server_perform_query(server, key, &obj_id_list, &count);
@@ -214,7 +214,7 @@ server_perform_operation(dummy_server_t *server)
                                          BULKI_ENTITY(obj_id_list, count, PDC_UINT64, PDC_CLS_ARRAY));
     }
     server->buffer_out = BULKI_Entity_serialize(resultBent, &server->buffer_out_size);
-    free(server->buffer_in);
+    server->buffer_in  = (void *)PDC_free(server->buffer_in);
 }
 
 perr_t
@@ -229,7 +229,7 @@ client_parse_response(dummy_client_t *client, uint64_t **obj_id_list, uint64_t *
             *count       = obj_id_bent->count;
         }
     }
-    free(client->buffer_in);
+    client->buffer_in = (void *)PDC_free(client->buffer_in);
     return result;
 }
 
@@ -302,7 +302,7 @@ client_perform_search(dummy_client_t *client, char *query, uint64_t **rst_ids)
         if (result == SUCCEED && count > 0) {
             rst_count += count;
             if (*rst_ids == NULL) {
-                *rst_ids = (uint64_t *)malloc(rst_count * sizeof(uint64_t));
+                *rst_ids = (uint64_t *)PDC_malloc(rst_count * sizeof(uint64_t));
             }
             else {
                 *rst_ids = (uint64_t *)realloc(*rst_ids, rst_count * sizeof(uint64_t));

--- a/src/commons/index/dart/index/idioms/idioms_persistence.c
+++ b/src/commons/index/dart/index/idioms/idioms_persistence.c
@@ -33,7 +33,7 @@ append_obj_id_set(Set *obj_id_set, BULKI_Entity *id_set_entity)
     SetIterator iter;
     set_iterate(obj_id_set, &iter);
     while (set_iter_has_more(&iter)) {
-        uint64_t *    item      = (uint64_t *)set_iter_next(&iter);
+        uint64_t     *item      = (uint64_t *)set_iter_next(&iter);
         BULKI_Entity *id_entity = BULKI_ENTITY(item, 1, PDC_UINT64, PDC_CLS_ITEM);
         BULKI_ENTITY_append_BULKI_Entity(id_set_entity, id_entity);
     }
@@ -119,7 +119,7 @@ append_attr_name_node(void *data, const unsigned char *key, uint32_t key_len, vo
     int rst = 0;
 
     key_index_leaf_content_t *leafcnt      = (key_index_leaf_content_t *)value;
-    HashTable *               vnode_buf_ht = (HashTable *)data; // data is the parameter passed in
+    HashTable                *vnode_buf_ht = (HashTable *)data; // data is the parameter passed in
     // the hash table is used to store the buffer struct related to each vnode id.
     BULKI *kv_bulki = hash_table_lookup(vnode_buf_ht, &(leafcnt->virtural_node_id));
     // index_buffer_t *buffer = hash_table_lookup(vnode_buf_ht, &(leafcnt->virtural_node_id));
@@ -190,7 +190,7 @@ dump_attr_root_tree(art_tree *art, char *dir_path, char *base_name, uint32_t ser
         HashTablePair pair = hash_table_iter_next(&iter);
         // vnode ID.  On different server, there can be the same vnode ID at this line below
         uint64_t *vid   = pair.key;
-        BULKI *   bulki = pair.value;
+        BULKI    *bulki = pair.value;
         char      file_name[1024];
         // and this is why do we need to differentiate the file name by the server ID.
         sprintf(file_name, "%s/%s_%" PRIu32 "_%" PRIu64 ".bin", dir_path, base_name, serverID, *vid);
@@ -208,7 +208,7 @@ dump_dart_info(DART *dart, char *dir_path, uint32_t serverID)
         char file_name[1024];
         sprintf(file_name, "%s/%s.bin", dir_path, "dart_info");
         LOG_INFO("Writing DART info to file_name: %s\n", file_name);
-        FILE *        stream   = fopen(file_name, "wb");
+        FILE         *stream   = fopen(file_name, "wb");
         BULKI_Entity *dart_ent = empty_Bent_Array_Entity();
         BULKI_ENTITY_append_BULKI_Entity(dart_ent,
                                          BULKI_ENTITY(&(dart->alphabet_size), 1, PDC_INT, PDC_CLS_ITEM));
@@ -256,7 +256,7 @@ fill_set_from_BULKI_Entity(value_index_leaf_content_t *value_index_leaf, BULKI_E
     BULKI_Entity_Iterator *it = Bent_iterator_init(data_entity, NULL, PDC_UNKNOWN);
     while (Bent_iterator_has_next_Bent(it)) {
         BULKI_Entity *id_entity = Bent_iterator_next_Bent(it);
-        uint64_t *    obj_id    = calloc(1, sizeof(uint64_t));
+        uint64_t     *obj_id    = PDC_calloc(1, sizeof(uint64_t));
         memcpy(obj_id, id_entity->data, sizeof(uint64_t));
         set_insert(value_index_leaf->obj_id_set, obj_id);
         value_index_leaf->indexed_item_count++;
@@ -273,11 +273,11 @@ read_attr_value_node(key_index_leaf_content_t *leaf_cnt, int value_tree_idx, BUL
     BULKI_KV_Pair_Iterator *it  = BULKI_KV_Pair_iterator_init(v_id_bulki);
     while (BULKI_KV_Pair_iterator_has_next(it)) {
         BULKI_KV_Pair *kv_pair     = BULKI_KV_Pair_iterator_next(it);
-        BULKI_Entity * key_entity  = &(kv_pair->key);
-        BULKI_Entity * data_entity = &(kv_pair->value);
+        BULKI_Entity  *key_entity  = &(kv_pair->key);
+        BULKI_Entity  *data_entity = &(kv_pair->value);
 
         value_index_leaf_content_t *value_index_leaf =
-            (value_index_leaf_content_t *)calloc(1, sizeof(value_index_leaf_content_t));
+            (value_index_leaf_content_t *)PDC_calloc(1, sizeof(value_index_leaf_content_t));
         value_index_leaf->obj_id_set = set_new(ui64_hash, ui64_equal);
         set_register_free_function(value_index_leaf->obj_id_set, free);
 
@@ -315,13 +315,13 @@ read_value_tree(key_index_leaf_content_t *leaf_cnt, int value_tree_idx, BULKI *v
 
     switch (value_tree_idx) {
         case 0:
-            leaf_cnt->primary_trie = (art_tree *)calloc(1, sizeof(art_tree));
+            leaf_cnt->primary_trie = (art_tree *)PDC_calloc(1, sizeof(art_tree));
             art_tree_init(leaf_cnt->primary_trie);
             _encodeTypeToBitmap(&(leaf_cnt->val_idx_dtype), PDC_STRING);
             rst = read_attr_value_node(leaf_cnt, 0, v_id_bulki, index_record_count);
             break;
         case 1:
-            leaf_cnt->secondary_trie = (art_tree *)calloc(1, sizeof(art_tree));
+            leaf_cnt->secondary_trie = (art_tree *)PDC_calloc(1, sizeof(art_tree));
             art_tree_init(leaf_cnt->secondary_trie);
             _encodeTypeToBitmap(&(leaf_cnt->val_idx_dtype), PDC_STRING);
             rst = read_attr_value_node(leaf_cnt, 1, v_id_bulki, index_record_count);
@@ -383,11 +383,11 @@ read_attr_name_node(IDIOMS_t *idioms, char *dir_path, char *base_name, uint32_t 
     BULKI_KV_Pair_Iterator *it = BULKI_KV_Pair_iterator_init(bulki);
     while (BULKI_KV_Pair_iterator_has_next(it)) {
         BULKI_KV_Pair *kv_pair     = BULKI_KV_Pair_iterator_next(it);
-        BULKI_Entity * key_entity  = &(kv_pair->key);
-        BULKI_Entity * data_entity = &(kv_pair->value);
+        BULKI_Entity  *key_entity  = &(kv_pair->key);
+        BULKI_Entity  *data_entity = &(kv_pair->value);
 
         key_index_leaf_content_t *leafcnt =
-            (key_index_leaf_content_t *)calloc(1, sizeof(key_index_leaf_content_t));
+            (key_index_leaf_content_t *)PDC_calloc(1, sizeof(key_index_leaf_content_t));
         art_insert(art_key_index, (const unsigned char *)key_entity->data, strlen(key_entity->data), leafcnt);
 
         BULKI *tree_bulki = (BULKI *)data_entity->data;
@@ -433,7 +433,7 @@ load_dart_info(DART *dart, char *dir_path, uint32_t serverID)
         if (stream == NULL) {
             return;
         }
-        BULKI_Entity *         dart_ent = BULKI_Entity_deserialize_from_file(stream);
+        BULKI_Entity          *dart_ent = BULKI_Entity_deserialize_from_file(stream);
         BULKI_Entity_Iterator *it       = Bent_iterator_init(dart_ent, NULL, PDC_UNKNOWN);
         int                    i        = 0;
         while (Bent_iterator_has_next_Bent(it)) {

--- a/src/commons/index/dart/index/idioms/idioms_persistence.c
+++ b/src/commons/index/dart/index/idioms/idioms_persistence.c
@@ -33,7 +33,7 @@ append_obj_id_set(Set *obj_id_set, BULKI_Entity *id_set_entity)
     SetIterator iter;
     set_iterate(obj_id_set, &iter);
     while (set_iter_has_more(&iter)) {
-        uint64_t     *item      = (uint64_t *)set_iter_next(&iter);
+        uint64_t *    item      = (uint64_t *)set_iter_next(&iter);
         BULKI_Entity *id_entity = BULKI_ENTITY(item, 1, PDC_UINT64, PDC_CLS_ITEM);
         BULKI_ENTITY_append_BULKI_Entity(id_set_entity, id_entity);
     }
@@ -119,7 +119,7 @@ append_attr_name_node(void *data, const unsigned char *key, uint32_t key_len, vo
     int rst = 0;
 
     key_index_leaf_content_t *leafcnt      = (key_index_leaf_content_t *)value;
-    HashTable                *vnode_buf_ht = (HashTable *)data; // data is the parameter passed in
+    HashTable *               vnode_buf_ht = (HashTable *)data; // data is the parameter passed in
     // the hash table is used to store the buffer struct related to each vnode id.
     BULKI *kv_bulki = hash_table_lookup(vnode_buf_ht, &(leafcnt->virtural_node_id));
     // index_buffer_t *buffer = hash_table_lookup(vnode_buf_ht, &(leafcnt->virtural_node_id));
@@ -190,7 +190,7 @@ dump_attr_root_tree(art_tree *art, char *dir_path, char *base_name, uint32_t ser
         HashTablePair pair = hash_table_iter_next(&iter);
         // vnode ID.  On different server, there can be the same vnode ID at this line below
         uint64_t *vid   = pair.key;
-        BULKI    *bulki = pair.value;
+        BULKI *   bulki = pair.value;
         char      file_name[1024];
         // and this is why do we need to differentiate the file name by the server ID.
         sprintf(file_name, "%s/%s_%" PRIu32 "_%" PRIu64 ".bin", dir_path, base_name, serverID, *vid);
@@ -208,7 +208,7 @@ dump_dart_info(DART *dart, char *dir_path, uint32_t serverID)
         char file_name[1024];
         sprintf(file_name, "%s/%s.bin", dir_path, "dart_info");
         LOG_INFO("Writing DART info to file_name: %s\n", file_name);
-        FILE         *stream   = fopen(file_name, "wb");
+        FILE *        stream   = fopen(file_name, "wb");
         BULKI_Entity *dart_ent = empty_Bent_Array_Entity();
         BULKI_ENTITY_append_BULKI_Entity(dart_ent,
                                          BULKI_ENTITY(&(dart->alphabet_size), 1, PDC_INT, PDC_CLS_ITEM));
@@ -256,7 +256,7 @@ fill_set_from_BULKI_Entity(value_index_leaf_content_t *value_index_leaf, BULKI_E
     BULKI_Entity_Iterator *it = Bent_iterator_init(data_entity, NULL, PDC_UNKNOWN);
     while (Bent_iterator_has_next_Bent(it)) {
         BULKI_Entity *id_entity = Bent_iterator_next_Bent(it);
-        uint64_t     *obj_id    = PDC_calloc(1, sizeof(uint64_t));
+        uint64_t *    obj_id    = PDC_calloc(1, sizeof(uint64_t));
         memcpy(obj_id, id_entity->data, sizeof(uint64_t));
         set_insert(value_index_leaf->obj_id_set, obj_id);
         value_index_leaf->indexed_item_count++;
@@ -273,8 +273,8 @@ read_attr_value_node(key_index_leaf_content_t *leaf_cnt, int value_tree_idx, BUL
     BULKI_KV_Pair_Iterator *it  = BULKI_KV_Pair_iterator_init(v_id_bulki);
     while (BULKI_KV_Pair_iterator_has_next(it)) {
         BULKI_KV_Pair *kv_pair     = BULKI_KV_Pair_iterator_next(it);
-        BULKI_Entity  *key_entity  = &(kv_pair->key);
-        BULKI_Entity  *data_entity = &(kv_pair->value);
+        BULKI_Entity * key_entity  = &(kv_pair->key);
+        BULKI_Entity * data_entity = &(kv_pair->value);
 
         value_index_leaf_content_t *value_index_leaf =
             (value_index_leaf_content_t *)PDC_calloc(1, sizeof(value_index_leaf_content_t));
@@ -383,8 +383,8 @@ read_attr_name_node(IDIOMS_t *idioms, char *dir_path, char *base_name, uint32_t 
     BULKI_KV_Pair_Iterator *it = BULKI_KV_Pair_iterator_init(bulki);
     while (BULKI_KV_Pair_iterator_has_next(it)) {
         BULKI_KV_Pair *kv_pair     = BULKI_KV_Pair_iterator_next(it);
-        BULKI_Entity  *key_entity  = &(kv_pair->key);
-        BULKI_Entity  *data_entity = &(kv_pair->value);
+        BULKI_Entity * key_entity  = &(kv_pair->key);
+        BULKI_Entity * data_entity = &(kv_pair->value);
 
         key_index_leaf_content_t *leafcnt =
             (key_index_leaf_content_t *)PDC_calloc(1, sizeof(key_index_leaf_content_t));
@@ -433,7 +433,7 @@ load_dart_info(DART *dart, char *dir_path, uint32_t serverID)
         if (stream == NULL) {
             return;
         }
-        BULKI_Entity          *dart_ent = BULKI_Entity_deserialize_from_file(stream);
+        BULKI_Entity *         dart_ent = BULKI_Entity_deserialize_from_file(stream);
         BULKI_Entity_Iterator *it       = Bent_iterator_init(dart_ent, NULL, PDC_UNKNOWN);
         int                    i        = 0;
         while (Bent_iterator_has_next_Bent(it)) {

--- a/src/commons/profiling/pdc_stack_ops.c
+++ b/src/commons/profiling/pdc_stack_ops.c
@@ -4,6 +4,7 @@
 #include "pdc_stack_ops.h"
 #include "pdc_logger.h"
 #include "pdc_hashtab.h"
+#include "pdc_malloc.h"
 
 profileEntry_t *calltree = NULL;
 profileEntry_t *freelist = NULL;
@@ -92,7 +93,7 @@ push(const char *ftnkey, const char *tags)
         freelist  = thisEntry->next;
     }
     else {
-        if ((thisEntry = (profileEntry_t *)malloc(sizeof(profileEntry_t))) == NULL) {
+        if ((thisEntry = (profileEntry_t *)PDC_malloc(sizeof(profileEntry_t))) == NULL) {
             perror("malloc");
             profilerrors++;
         }
@@ -134,7 +135,7 @@ pop()
     void **tableEntry = htab_find_slot(thisHashTable, thisEntry, INSERT);
     if (*tableEntry == NULL) {
         /* No table entry found so add it now ... */
-        master = (profileEntry_t *)malloc(sizeof(profileEntry_t));
+        master = (profileEntry_t *)PDC_malloc(sizeof(profileEntry_t));
         if (master) {
             thisEntry->count = 1;
             memcpy(master, thisEntry, sizeof(profileEntry_t));
@@ -187,8 +188,8 @@ int
 show_profile_info(void **ht_live_entry, void *extraInfo ATTRIBUTE(unused))
 {
     static int count     = 0;
-    char *     LineBreak = "------------------------------------------------------------------------------";
-    char *     header    = " item  calls Time/call [Sec,nSec]\tftn_name";
+    char      *LineBreak = "------------------------------------------------------------------------------";
+    char      *header    = " item  calls Time/call [Sec,nSec]\tftn_name";
     const profileEntry_t *thisEntry = *(const profileEntry_t **)ht_live_entry;
 
     if (thisEntry) {
@@ -225,7 +226,8 @@ toggle_profile_enable()
  * hashtable.
  */
 
-void __attribute__((constructor)) profile_init(void)
+void __attribute__((constructor))
+profile_init(void)
 {
     int   default_HashtableSize = 128;
     char *size_override         = NULL;
@@ -256,7 +258,8 @@ void __attribute__((constructor)) profile_init(void)
     initialize_profile(&hashtable, default_HashtableSize);
 }
 
-void __attribute__((destructor)) finalize_profile(void)
+void __attribute__((destructor))
+finalize_profile(void)
 {
     int count = 1;
     if (thisHashTable != NULL) {

--- a/src/commons/profiling/pdc_stack_ops.c
+++ b/src/commons/profiling/pdc_stack_ops.c
@@ -188,8 +188,8 @@ int
 show_profile_info(void **ht_live_entry, void *extraInfo ATTRIBUTE(unused))
 {
     static int count     = 0;
-    char      *LineBreak = "------------------------------------------------------------------------------";
-    char      *header    = " item  calls Time/call [Sec,nSec]\tftn_name";
+    char *     LineBreak = "------------------------------------------------------------------------------";
+    char *     header    = " item  calls Time/call [Sec,nSec]\tftn_name";
     const profileEntry_t *thisEntry = *(const profileEntry_t **)ht_live_entry;
 
     if (thisEntry) {
@@ -226,8 +226,7 @@ toggle_profile_enable()
  * hashtable.
  */
 
-void __attribute__((constructor))
-profile_init(void)
+void __attribute__((constructor)) profile_init(void)
 {
     int   default_HashtableSize = 128;
     char *size_override         = NULL;
@@ -258,8 +257,7 @@ profile_init(void)
     initialize_profile(&hashtable, default_HashtableSize);
 }
 
-void __attribute__((destructor))
-finalize_profile(void)
+void __attribute__((destructor)) finalize_profile(void)
 {
     int count = 1;
     if (thisHashTable != NULL) {

--- a/src/commons/query/qc_parser.c
+++ b/src/commons/query/qc_parser.c
@@ -213,10 +213,10 @@ subClauseExtractor(char *expression, int start, int end, int level, subClause **
             levelCounter++;
             if (levelCounter == level + 1) {
                 // Allocate or reallocate space for a new subclause.
-                *subPtr              = (subClause *)realloc(*subPtr, sizeof(subClause) * (numSubClauses + 1));
-                subClause *newClause = &((*subPtr)[numSubClauses]);
-                newClause->start     = i + 1;
-                newClause->level     = levelCounter;
+                *subPtr = (subClause *)PDC_realloc(*subPtr, sizeof(subClause) * (numSubClauses + 1));
+                subClause *newClause      = &((*subPtr)[numSubClauses]);
+                newClause->start          = i + 1;
+                newClause->level          = levelCounter;
                 newClause->subClauseArray = NULL; // Important to initialize.
             }
         }

--- a/src/commons/query/qc_parser.c
+++ b/src/commons/query/qc_parser.c
@@ -1,5 +1,6 @@
 #include "qc_parser.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 void
 printSubExpression(char *expression, Condition *condition)
@@ -24,7 +25,7 @@ printSubExpression(char *expression, Condition *condition)
 Condition *
 createSubCondition(int start, int end, int level)
 {
-    Condition *condition = (Condition *)malloc(sizeof(Condition));
+    Condition *condition = (Condition *)PDC_malloc(sizeof(Condition));
     condition->start     = start;
     condition->end       = end;
     condition->level     = level;

--- a/src/commons/serde/bulki/bulki.c
+++ b/src/commons/serde/bulki/bulki.c
@@ -1,6 +1,7 @@
 #include "bulki.h"
 #include "bulki_vle_util.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 size_t
 get_BULKI_Entity_size(BULKI_Entity *bulk_entity)

--- a/src/commons/serde/bulki/bulki.c
+++ b/src/commons/serde/bulki/bulki.c
@@ -131,7 +131,7 @@ BULKI_print(BULKI *bulki)
 BULKI_Entity *
 empty_BULKI_Array_Entity()
 {
-    BULKI_Entity *bulki_entity = (BULKI_Entity *)calloc(1, sizeof(BULKI_Entity));
+    BULKI_Entity *bulki_entity = (BULKI_Entity *)PDC_calloc(1, sizeof(BULKI_Entity));
     bulki_entity->pdc_type     = PDC_BULKI;
     bulki_entity->pdc_class    = PDC_CLS_ARRAY;
     bulki_entity->count        = 0;
@@ -143,7 +143,7 @@ empty_BULKI_Array_Entity()
 BULKI_Entity *
 empty_Bent_Array_Entity()
 {
-    BULKI_Entity *bulki_entity = (BULKI_Entity *)calloc(1, sizeof(BULKI_Entity));
+    BULKI_Entity *bulki_entity = (BULKI_Entity *)PDC_calloc(1, sizeof(BULKI_Entity));
     bulki_entity->pdc_type     = PDC_BULKI_ENT;
     bulki_entity->pdc_class    = PDC_CLS_ARRAY;
     bulki_entity->count        = 0;
@@ -164,7 +164,7 @@ BULKI_ENTITY_append_BULKI(BULKI_Entity *dest, BULKI *src)
         return NULL;
     }
     dest->count = dest->count + 1;
-    dest->data  = realloc(dest->data, dest->count * sizeof(BULKI));
+    dest->data  = PDC_realloc(dest->data, dest->count * sizeof(BULKI));
     memcpy(dest->data + (dest->count - 1) * sizeof(BULKI), src, sizeof(BULKI));
     get_BULKI_Entity_size(dest);
     return dest;
@@ -201,7 +201,7 @@ BULKI_ENTITY_append_BULKI_Entity(BULKI_Entity *dest, BULKI_Entity *src)
         return NULL;
     }
     dest->count = dest->count + 1;
-    dest->data  = realloc(dest->data, dest->count * sizeof(BULKI_Entity));
+    dest->data  = PDC_realloc(dest->data, dest->count * sizeof(BULKI_Entity));
     memcpy(dest->data + (dest->count - 1) * sizeof(BULKI_Entity), src, sizeof(BULKI_Entity));
     get_BULKI_Entity_size(dest);
     return dest;
@@ -231,7 +231,7 @@ BULKI_ENTITY(void *data, uint64_t count, pdc_c_var_type_t pdc_type, pdc_c_var_cl
         LOG_ERROR("Error: BULKI_Entity cannot be an single item in another BULKI_Entity\n");
         return NULL;
     }
-    BULKI_Entity *bulki_entity = (BULKI_Entity *)calloc(1, sizeof(BULKI_Entity));
+    BULKI_Entity *bulki_entity = (BULKI_Entity *)PDC_calloc(1, sizeof(BULKI_Entity));
     bulki_entity->pdc_type     = pdc_type;
     bulki_entity->pdc_class    = pdc_class;
     bulki_entity->count        = (pdc_class == PDC_CLS_ITEM) ? 1 : count;
@@ -245,7 +245,7 @@ BULKI_ENTITY(void *data, uint64_t count, pdc_c_var_type_t pdc_type, pdc_c_var_cl
         bulki_entity->data = data;
     }
     else {
-        bulki_entity->data = calloc(1, size);
+        bulki_entity->data = PDC_calloc(1, size);
         memcpy(bulki_entity->data, data, size);
     }
 
@@ -268,14 +268,14 @@ BULKI_array_ENTITY(void *data, uint64_t count, pdc_c_var_type_t pdc_type)
 BULKI *
 BULKI_init(int initial_field_count)
 {
-    BULKI *buiki              = calloc(1, sizeof(BULKI));
+    BULKI *buiki              = PDC_calloc(1, sizeof(BULKI));
     buiki->numKeys            = 0;
     buiki->capacity           = initial_field_count;
-    buiki->header             = calloc(1, sizeof(BULKI_Header));
-    buiki->header->keys       = calloc(buiki->capacity, sizeof(BULKI_Entity));
+    buiki->header             = PDC_calloc(1, sizeof(BULKI_Header));
+    buiki->header->keys       = PDC_calloc(buiki->capacity, sizeof(BULKI_Entity));
     buiki->header->headerSize = 0;
-    buiki->data               = calloc(1, sizeof(BULKI_Data));
-    buiki->data->values       = calloc(buiki->capacity, sizeof(BULKI_Entity));
+    buiki->data               = PDC_calloc(1, sizeof(BULKI_Data));
+    buiki->data->values       = PDC_calloc(buiki->capacity, sizeof(BULKI_Entity));
     buiki->data->dataSize     = 0;
     get_BULKI_size(buiki);
     return buiki;
@@ -368,8 +368,8 @@ BULKI_put(BULKI *bulki, BULKI_Entity *key, BULKI_Entity *value)
     }
     if (bulki->numKeys >= bulki->capacity) {
         bulki->capacity *= 2;
-        bulki->header->keys = realloc(bulki->header->keys, bulki->capacity * sizeof(BULKI_Entity));
-        bulki->data->values = realloc(bulki->data->values, bulki->capacity * sizeof(BULKI_Entity));
+        bulki->header->keys = PDC_realloc(bulki->header->keys, bulki->capacity * sizeof(BULKI_Entity));
+        bulki->data->values = PDC_realloc(bulki->data->values, bulki->capacity * sizeof(BULKI_Entity));
     }
     memcpy(&bulki->header->keys[bulki->numKeys], key, sizeof(BULKI_Entity));
     // append bytes for type, size, and key
@@ -409,7 +409,7 @@ Bent_iterator_init(BULKI_Entity *array, void *filter, pdc_c_var_type_t filter_ty
         LOG_ERROR("Error: not a proper array\n");
         return NULL;
     }
-    BULKI_Entity_Iterator *iter = (BULKI_Entity_Iterator *)calloc(1, sizeof(BULKI_Entity_Iterator));
+    BULKI_Entity_Iterator *iter = (BULKI_Entity_Iterator *)PDC_calloc(1, sizeof(BULKI_Entity_Iterator));
     iter->entity_array          = array;
     iter->total_size            = array->count;
     iter->current_idx           = 0;
@@ -496,7 +496,7 @@ BULKI_KV_Pair_iterator_init(BULKI *bulki)
         LOG_ERROR("Error: bulki is NULL\n");
         return NULL;
     }
-    BULKI_KV_Pair_Iterator *iter = (BULKI_KV_Pair_Iterator *)calloc(1, sizeof(BULKI_KV_Pair_Iterator));
+    BULKI_KV_Pair_Iterator *iter = (BULKI_KV_Pair_Iterator *)PDC_calloc(1, sizeof(BULKI_KV_Pair_Iterator));
     iter->bulki                  = bulki;
     iter->total_size             = bulki->numKeys;
     iter->current_idx            = 0;
@@ -513,7 +513,7 @@ BULKI_KV_Pair *
 BULKI_KV_Pair_iterator_next(BULKI_KV_Pair_Iterator *it)
 {
     if (it->current_idx < it->total_size) {
-        BULKI_KV_Pair *pair = (BULKI_KV_Pair *)calloc(1, sizeof(BULKI_KV_Pair));
+        BULKI_KV_Pair *pair = (BULKI_KV_Pair *)PDC_calloc(1, sizeof(BULKI_KV_Pair));
         pair->key           = it->bulki->header->keys[it->current_idx];
         pair->value         = it->bulki->data->values[it->current_idx];
         it->current_idx++;

--- a/src/commons/serde/bulki/bulki.c
+++ b/src/commons/serde/bulki/bulki.c
@@ -567,11 +567,11 @@ BULKI_Entity_free(BULKI_Entity *bulk_entity, int free_struct)
                 "bulki_entity->class: %d, bulki_entity->class: %d, bulki_entity->data: %p, bulki_entity: "
                 "%p\n",
                 bulk_entity->pdc_class, bulk_entity->pdc_type, bulk_entity->data, bulk_entity);
-            free(bulk_entity->data);
+            bulk_entity->data = (void *)PDC_free(bulk_entity->data);
             bulk_entity->data = NULL;
         }
         if (free_struct) {
-            free(bulk_entity);
+            bulk_entity = (BULKI_Entity *)PDC_free(bulk_entity);
             bulk_entity = NULL;
         }
     }
@@ -586,10 +586,10 @@ BULKI_free(BULKI *bulki, int free_struct)
                 for (size_t i = 0; i < bulki->numKeys; i++) {
                     BULKI_Entity_free(&bulki->header->keys[i], 0);
                 }
-                free(bulki->header->keys);
+                bulki->header->keys = (BULKI_Entity *)PDC_free(bulki->header->keys);
                 bulki->header->keys = NULL;
             }
-            free(bulki->header);
+            bulki->header = (BULKI_Header *)PDC_free(bulki->header);
             bulki->header = NULL;
         }
         if (bulki->data != NULL) {
@@ -597,14 +597,14 @@ BULKI_free(BULKI *bulki, int free_struct)
                 for (size_t i = 0; i < bulki->numKeys; i++) {
                     BULKI_Entity_free(&bulki->data->values[i], 0);
                 }
-                free(bulki->data->values);
+                bulki->data->values = (BULKI_Entity *)PDC_free(bulki->data->values);
                 bulki->data->values = NULL;
             }
-            free(bulki->data);
+            bulki->data = (BULKI_Data *)PDC_free(bulki->data);
             bulki->data = NULL;
         }
         if (free_struct) {
-            free(bulki);
+            bulki = (BULKI *)PDC_free(bulki);
             bulki = NULL;
         }
     }

--- a/src/commons/serde/bulki/bulki_serde.c
+++ b/src/commons/serde/bulki/bulki_serde.c
@@ -115,11 +115,11 @@ void *
 BULKI_Entity_serialize(BULKI_Entity *entity, size_t *size)
 {
     size_t estimated_size = get_BULKI_Entity_size(entity);
-    void  *buffer         = calloc(1, estimated_size);
+    void  *buffer         = PDC_calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_Entity_serialize_to_buffer(entity, buffer, &offset);
     if (offset < estimated_size) {
-        void *small_buffer = realloc(buffer, offset);
+        void *small_buffer = PDC_realloc(buffer, offset);
         if (small_buffer != NULL) {
             buffer = small_buffer;
         }
@@ -168,11 +168,11 @@ void *
 BULKI_serialize(BULKI *data, size_t *size)
 {
     size_t estimated_size = get_BULKI_size(data);
-    void  *buffer         = calloc(1, estimated_size);
+    void  *buffer         = PDC_calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_serialize_to_buffer(data, buffer, &offset);
     if (offset < estimated_size) {
-        void *small_buffer = realloc(buffer, offset);
+        void *small_buffer = PDC_realloc(buffer, offset);
         if (small_buffer != NULL) {
             buffer = small_buffer;
         }

--- a/src/commons/serde/bulki/bulki_serde.c
+++ b/src/commons/serde/bulki/bulki_serde.c
@@ -1,6 +1,7 @@
 #include "bulki_serde.h"
 #include "bulki_vle_util.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 // clang-format off
 /**
@@ -114,7 +115,7 @@ void *
 BULKI_Entity_serialize(BULKI_Entity *entity, size_t *size)
 {
     size_t estimated_size = get_BULKI_Entity_size(entity);
-    void * buffer         = calloc(1, estimated_size);
+    void  *buffer         = calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_Entity_serialize_to_buffer(entity, buffer, &offset);
     if (offset < estimated_size) {
@@ -167,7 +168,7 @@ void *
 BULKI_serialize(BULKI *data, size_t *size)
 {
     size_t estimated_size = get_BULKI_size(data);
-    void * buffer         = calloc(1, estimated_size);
+    void  *buffer         = calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_serialize_to_buffer(data, buffer, &offset);
     if (offset < estimated_size) {
@@ -184,9 +185,9 @@ void
 BULKI_Entity_serialize_to_file(BULKI_Entity *entity, FILE *fp)
 {
     size_t size;
-    void * buffer = BULKI_Entity_serialize(entity, &size);
+    void  *buffer = BULKI_Entity_serialize(entity, &size);
     fwrite(buffer, size, 1, fp);
-    free(buffer);
+    buffer = (void *)PDC_free(buffer);
     fclose(fp);
 }
 
@@ -194,9 +195,9 @@ void
 BULKI_serialize_to_file(BULKI *bulki, FILE *fp)
 {
     size_t size   = 0;
-    void * buffer = BULKI_serialize(bulki, &size);
+    void  *buffer = BULKI_serialize(bulki, &size);
     fwrite(buffer, size, 1, fp);
-    free(buffer);
+    buffer = (void *)PDC_free(buffer);
     fclose(fp);
 }
 
@@ -369,7 +370,7 @@ BULKI_Entity_deserialize_from_file(FILE *fp)
     fread(buffer, fsize, 1, fp);
     fclose(fp);
     BULKI_Entity *rst = BULKI_Entity_deserialize(buffer);
-    free(buffer);
+    buffer            = (void *)PDC_free(buffer);
     return rst;
 }
 
@@ -384,6 +385,6 @@ BULKI_deserialize_from_file(FILE *fp)
     fread(buffer, fsize, 1, fp);
     fclose(fp);
     BULKI *rst = BULKI_deserialize(buffer);
-    free(buffer);
+    buffer     = (void *)PDC_free(buffer);
     return rst;
 }

--- a/src/commons/serde/bulki/bulki_serde.c
+++ b/src/commons/serde/bulki/bulki_serde.c
@@ -115,7 +115,7 @@ void *
 BULKI_Entity_serialize(BULKI_Entity *entity, size_t *size)
 {
     size_t estimated_size = get_BULKI_Entity_size(entity);
-    void * buffer         = PDC_calloc(1, estimated_size);
+    void  *buffer         = PDC_calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_Entity_serialize_to_buffer(entity, buffer, &offset);
     if (offset < estimated_size) {
@@ -168,7 +168,7 @@ void *
 BULKI_serialize(BULKI *data, size_t *size)
 {
     size_t estimated_size = get_BULKI_size(data);
-    void * buffer         = PDC_calloc(1, estimated_size);
+    void  *buffer         = PDC_calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_serialize_to_buffer(data, buffer, &offset);
     if (offset < estimated_size) {
@@ -185,7 +185,7 @@ void
 BULKI_Entity_serialize_to_file(BULKI_Entity *entity, FILE *fp)
 {
     size_t size;
-    void * buffer = BULKI_Entity_serialize(entity, &size);
+    void  *buffer = BULKI_Entity_serialize(entity, &size);
     fwrite(buffer, size, 1, fp);
     buffer = (void *)PDC_free(buffer);
     fclose(fp);
@@ -195,7 +195,7 @@ void
 BULKI_serialize_to_file(BULKI *bulki, FILE *fp)
 {
     size_t size   = 0;
-    void * buffer = BULKI_serialize(bulki, &size);
+    void  *buffer = BULKI_serialize(bulki, &size);
     fwrite(buffer, size, 1, fp);
     buffer = (void *)PDC_free(buffer);
     fclose(fp);
@@ -214,7 +214,7 @@ deserialize_type_class(uint8_t byte, pdc_c_var_type_t *type, pdc_c_var_class_t *
 BULKI_Entity *
 BULKI_Entity_deserialize_from_buffer(void *buffer, size_t *offset)
 {
-    BULKI_Entity *entity = malloc(sizeof(BULKI_Entity));
+    BULKI_Entity *entity = PDC_malloc(sizeof(BULKI_Entity));
     // deserialize the size
     size_t   bytes_read;
     uint64_t size = BULKI_vle_decode_uint(buffer + *offset, &bytes_read);
@@ -241,21 +241,21 @@ BULKI_Entity_deserialize_from_buffer(void *buffer, size_t *offset)
             entity->data = BULKI_Entity_deserialize_from_buffer(buffer, offset);
         }
         else { // all base types
-            entity->data = malloc(entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
+            entity->data = PDC_malloc(entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
             memcpy(entity->data, buffer + *offset, entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
             *offset += (entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
         }
     }
     else if (entity->pdc_class <= PDC_CLS_ARRAY) {
         if (entity->pdc_type == PDC_BULKI) { // BULKI
-            BULKI *bulki_array = malloc(sizeof(BULKI) * entity->count);
+            BULKI *bulki_array = PDC_malloc(sizeof(BULKI) * entity->count);
             for (size_t i = 0; i < entity->count; i++) {
                 memcpy(bulki_array + i, BULKI_deserialize_from_buffer(buffer, offset), sizeof(BULKI));
             }
             entity->data = bulki_array;
         }
         else if (entity->pdc_type == PDC_BULKI_ENT) { // BULKI_Entity
-            BULKI_Entity *bulki_entity_array = malloc(sizeof(BULKI_Entity) * entity->count);
+            BULKI_Entity *bulki_entity_array = PDC_malloc(sizeof(BULKI_Entity) * entity->count);
             for (size_t i = 0; i < entity->count; i++) {
                 memcpy(bulki_entity_array + i, BULKI_Entity_deserialize_from_buffer(buffer, offset),
                        sizeof(BULKI_Entity));
@@ -263,7 +263,7 @@ BULKI_Entity_deserialize_from_buffer(void *buffer, size_t *offset)
             entity->data = bulki_entity_array;
         }
         else { // all base types
-            entity->data = malloc(entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
+            entity->data = PDC_malloc(entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
             memcpy(entity->data, buffer + *offset, entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
             *offset += (entity->size - sizeof(uint8_t) * 2 - sizeof(uint64_t) * 2);
         }
@@ -278,7 +278,7 @@ BULKI_Entity_deserialize_from_buffer(void *buffer, size_t *offset)
 BULKI *
 BULKI_deserialize_from_buffer(void *buffer, size_t *offset)
 {
-    BULKI *bulki = malloc(sizeof(BULKI));
+    BULKI *bulki = PDC_malloc(sizeof(BULKI));
     // deserialize the total size
     size_t   bytes_read;
     uint64_t totalSize = BULKI_vle_decode_uint(buffer + *offset, &bytes_read);
@@ -299,8 +299,8 @@ BULKI_deserialize_from_buffer(void *buffer, size_t *offset)
     *offset += bytes_read;
 
     // deserialize the header
-    BULKI_Header *header = malloc(sizeof(BULKI_Header));
-    header->keys         = malloc(sizeof(BULKI_Entity) * numKeys);
+    BULKI_Header *header = PDC_malloc(sizeof(BULKI_Header));
+    header->keys         = PDC_malloc(sizeof(BULKI_Entity) * numKeys);
     header->headerSize   = headerSize;
     for (size_t i = 0; i < numKeys; i++) {
         memcpy(&(header->keys[i]), BULKI_Entity_deserialize_from_buffer(buffer, offset),
@@ -321,8 +321,8 @@ BULKI_deserialize_from_buffer(void *buffer, size_t *offset)
     bulki->header = header;
 
     // deserialize the data
-    BULKI_Data *data = malloc(sizeof(BULKI_Data));
-    data->values     = malloc(sizeof(BULKI_Entity) * numKeys);
+    BULKI_Data *data = PDC_malloc(sizeof(BULKI_Data));
+    data->values     = PDC_malloc(sizeof(BULKI_Entity) * numKeys);
     data->dataSize   = dataSize;
     for (size_t i = 0; i < numKeys; i++) {
         memcpy(&(data->values[i]), BULKI_Entity_deserialize_from_buffer(buffer, offset),
@@ -366,7 +366,7 @@ BULKI_Entity_deserialize_from_file(FILE *fp)
     size_t fsize = ftell(fp);
     fseek(fp, 0, SEEK_SET); /* same as rewind(f); */
     // read the file into the buffer
-    void *buffer = malloc(fsize + 1);
+    void *buffer = PDC_malloc(fsize + 1);
     fread(buffer, fsize, 1, fp);
     fclose(fp);
     BULKI_Entity *rst = BULKI_Entity_deserialize(buffer);
@@ -381,7 +381,7 @@ BULKI_deserialize_from_file(FILE *fp)
     size_t fsize = ftell(fp);
     fseek(fp, 0, SEEK_SET); /* same as rewind(f); */
     // read the file into the buffer
-    void *buffer = malloc(fsize + 1);
+    void *buffer = PDC_malloc(fsize + 1);
     fread(buffer, fsize, 1, fp);
     fclose(fp);
     BULKI *rst = BULKI_deserialize(buffer);

--- a/src/commons/serde/bulki/bulki_serde.c
+++ b/src/commons/serde/bulki/bulki_serde.c
@@ -115,7 +115,7 @@ void *
 BULKI_Entity_serialize(BULKI_Entity *entity, size_t *size)
 {
     size_t estimated_size = get_BULKI_Entity_size(entity);
-    void  *buffer         = PDC_calloc(1, estimated_size);
+    void * buffer         = PDC_calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_Entity_serialize_to_buffer(entity, buffer, &offset);
     if (offset < estimated_size) {
@@ -168,7 +168,7 @@ void *
 BULKI_serialize(BULKI *data, size_t *size)
 {
     size_t estimated_size = get_BULKI_size(data);
-    void  *buffer         = PDC_calloc(1, estimated_size);
+    void * buffer         = PDC_calloc(1, estimated_size);
     size_t offset         = 0;
     BULKI_serialize_to_buffer(data, buffer, &offset);
     if (offset < estimated_size) {
@@ -185,7 +185,7 @@ void
 BULKI_Entity_serialize_to_file(BULKI_Entity *entity, FILE *fp)
 {
     size_t size;
-    void  *buffer = BULKI_Entity_serialize(entity, &size);
+    void * buffer = BULKI_Entity_serialize(entity, &size);
     fwrite(buffer, size, 1, fp);
     buffer = (void *)PDC_free(buffer);
     fclose(fp);
@@ -195,7 +195,7 @@ void
 BULKI_serialize_to_file(BULKI *bulki, FILE *fp)
 {
     size_t size   = 0;
-    void  *buffer = BULKI_serialize(bulki, &size);
+    void * buffer = BULKI_serialize(bulki, &size);
     fwrite(buffer, size, 1, fp);
     buffer = (void *)PDC_free(buffer);
     fclose(fp);

--- a/src/commons/serde/bulki/bulki_serde_test.c
+++ b/src/commons/serde/bulki/bulki_serde_test.c
@@ -9,7 +9,7 @@ test_base_type()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str = "int";
+    char         *intKey_str = "int";
     int           intVal     = 42;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *intValue   = BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ITEM);
@@ -25,21 +25,21 @@ test_base_type()
     // freeing issue.
     BULKI_put(bulki, intArrKey, BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ARRAY));
 
-    char *        doubleKey_str = "double";
+    char         *doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *doubleValue   = BULKI_ENTITY(&doubleVal, 1, PDC_DOUBLE, PDC_CLS_ITEM);
     BULKI_put(bulki, doubleKey, doubleValue);
 
-    char *        strKey_str = "string";
-    char *        strVal     = "Hello, World!";
+    char         *strKey_str = "string";
+    char         *strVal     = "Hello, World!";
     BULKI_Entity *strKey     = BULKI_ENTITY(strKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *strValue   = BULKI_ENTITY(strVal, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_put(bulki, strKey, strValue);
 
     // Serialize the data
     size_t size;
-    void * buffer = BULKI_serialize(bulki, &size);
+    void  *buffer = BULKI_serialize(bulki, &size);
 
     // Do some I/O if you like
     FILE *fp = fopen("test_bulki.bin", "wb");
@@ -54,7 +54,7 @@ test_base_type()
     long fsize = ftell(fp);
     fseek(fp, 0, SEEK_SET); /* same as rewind(f); */
     // read the file into the buffer
-    void *buffer2 = malloc(fsize + 1);
+    void *buffer2 = PDC_malloc(fsize + 1);
     fread(buffer2, fsize, 1, fp);
     fclose(fp);
 
@@ -105,7 +105,7 @@ test_base_array_entitiy()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str = "int";
+    char         *intKey_str = "int";
     int           intVal     = 42;
     uint64_t      intObjID   = 12416574651687;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -114,7 +114,7 @@ test_base_array_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(intArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, intKey, intArr);
 
-    char *        doubleKey_str = "double";
+    char         *doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     uint64_t      doubleObjID   = 564987951987494;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -132,7 +132,7 @@ test_base_array_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(strArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, strKey, strArr);
 
-    char *        mixedKey_str = "mixed";
+    char         *mixedKey_str = "mixed";
     BULKI_Entity *mixedKey     = BULKI_ENTITY(mixedKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *mixedArr     = empty_Bent_Array_Entity();
     BULKI_ENTITY_append_BULKI_Entity(mixedArr, BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ITEM));
@@ -145,7 +145,7 @@ test_base_array_entitiy()
     BULKI *bulki2 = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str2 = "int";
+    char         *intKey_str2 = "int";
     int           intVal2     = 42;
     BULKI_Entity *intKey2     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *intArr2     = empty_BULKI_Array_Entity();
@@ -155,7 +155,7 @@ test_base_array_entitiy()
 
     // Serialize the data
     size_t size;
-    void * buffer = BULKI_serialize(bulki2, &size);
+    void  *buffer = BULKI_serialize(bulki2, &size);
 
     // Deserialize the buffer
     BULKI *deserializedBulki = BULKI_deserialize(buffer);
@@ -178,7 +178,7 @@ test_embedded_entitiy()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str = "int";
+    char         *intKey_str = "int";
     int           intVal     = 42;
     uint64_t      intObjID   = 12416574651687;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -187,7 +187,7 @@ test_embedded_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(intArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, intKey, intArr);
 
-    char *        doubleKey_str = "double";
+    char         *doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     uint64_t      doubleObjID   = 564987951987494;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -207,7 +207,7 @@ test_embedded_entitiy()
 
     // Serialize the data
     size_t size;
-    void * buffer = BULKI_serialize(bulki, &size);
+    void  *buffer = BULKI_serialize(bulki, &size);
 
     // Deserialize the buffer
     BULKI *deserializedBulki = BULKI_deserialize(buffer);
@@ -232,7 +232,7 @@ test_bulki_in_entitiy()
     // BULKI in BULKI_Entity
     BULKI_Entity *nestEntity = BULKI_ENTITY(bulki, 1, PDC_BULKI, PDC_CLS_ITEM);
     size_t        size;
-    void *        buffer         = BULKI_Entity_serialize(nestEntity, &size);
+    void         *buffer         = BULKI_Entity_serialize(nestEntity, &size);
     BULKI_Entity *des_nestEntity = BULKI_Entity_deserialize(buffer);
 
     int equal = BULKI_Entity_equal(nestEntity, des_nestEntity);
@@ -302,7 +302,7 @@ bulki_small_json_serialization_test()
 
     BULKI_Entity *property_array = empty_BULKI_Array_Entity();
 
-    BULKI *       property1 = BULKI_init(2); // 2 fields: name, value
+    BULKI        *property1 = BULKI_init(2); // 2 fields: name, value
     BULKI_Entity *name      = BULKI_singleton_ENTITY("AIRMASS", PDC_STRING);
     BULKI_Entity *data      = BULKI_ENTITY(&(float){1.19428}, 1, PDC_FLOAT, PDC_CLS_ITEM);
     BULKI_put(property1, name, data);

--- a/src/commons/serde/bulki/bulki_serde_test.c
+++ b/src/commons/serde/bulki/bulki_serde_test.c
@@ -9,7 +9,7 @@ test_base_type()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char         *intKey_str = "int";
+    char *        intKey_str = "int";
     int           intVal     = 42;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *intValue   = BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ITEM);
@@ -25,21 +25,21 @@ test_base_type()
     // freeing issue.
     BULKI_put(bulki, intArrKey, BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ARRAY));
 
-    char         *doubleKey_str = "double";
+    char *        doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *doubleValue   = BULKI_ENTITY(&doubleVal, 1, PDC_DOUBLE, PDC_CLS_ITEM);
     BULKI_put(bulki, doubleKey, doubleValue);
 
-    char         *strKey_str = "string";
-    char         *strVal     = "Hello, World!";
+    char *        strKey_str = "string";
+    char *        strVal     = "Hello, World!";
     BULKI_Entity *strKey     = BULKI_ENTITY(strKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *strValue   = BULKI_ENTITY(strVal, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_put(bulki, strKey, strValue);
 
     // Serialize the data
     size_t size;
-    void  *buffer = BULKI_serialize(bulki, &size);
+    void * buffer = BULKI_serialize(bulki, &size);
 
     // Do some I/O if you like
     FILE *fp = fopen("test_bulki.bin", "wb");
@@ -105,7 +105,7 @@ test_base_array_entitiy()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char         *intKey_str = "int";
+    char *        intKey_str = "int";
     int           intVal     = 42;
     uint64_t      intObjID   = 12416574651687;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -114,7 +114,7 @@ test_base_array_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(intArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, intKey, intArr);
 
-    char         *doubleKey_str = "double";
+    char *        doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     uint64_t      doubleObjID   = 564987951987494;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -132,7 +132,7 @@ test_base_array_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(strArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, strKey, strArr);
 
-    char         *mixedKey_str = "mixed";
+    char *        mixedKey_str = "mixed";
     BULKI_Entity *mixedKey     = BULKI_ENTITY(mixedKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *mixedArr     = empty_Bent_Array_Entity();
     BULKI_ENTITY_append_BULKI_Entity(mixedArr, BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ITEM));
@@ -145,7 +145,7 @@ test_base_array_entitiy()
     BULKI *bulki2 = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char         *intKey_str2 = "int";
+    char *        intKey_str2 = "int";
     int           intVal2     = 42;
     BULKI_Entity *intKey2     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *intArr2     = empty_BULKI_Array_Entity();
@@ -155,7 +155,7 @@ test_base_array_entitiy()
 
     // Serialize the data
     size_t size;
-    void  *buffer = BULKI_serialize(bulki2, &size);
+    void * buffer = BULKI_serialize(bulki2, &size);
 
     // Deserialize the buffer
     BULKI *deserializedBulki = BULKI_deserialize(buffer);
@@ -178,7 +178,7 @@ test_embedded_entitiy()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char         *intKey_str = "int";
+    char *        intKey_str = "int";
     int           intVal     = 42;
     uint64_t      intObjID   = 12416574651687;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -187,7 +187,7 @@ test_embedded_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(intArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, intKey, intArr);
 
-    char         *doubleKey_str = "double";
+    char *        doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     uint64_t      doubleObjID   = 564987951987494;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -207,7 +207,7 @@ test_embedded_entitiy()
 
     // Serialize the data
     size_t size;
-    void  *buffer = BULKI_serialize(bulki, &size);
+    void * buffer = BULKI_serialize(bulki, &size);
 
     // Deserialize the buffer
     BULKI *deserializedBulki = BULKI_deserialize(buffer);
@@ -232,7 +232,7 @@ test_bulki_in_entitiy()
     // BULKI in BULKI_Entity
     BULKI_Entity *nestEntity = BULKI_ENTITY(bulki, 1, PDC_BULKI, PDC_CLS_ITEM);
     size_t        size;
-    void         *buffer         = BULKI_Entity_serialize(nestEntity, &size);
+    void *        buffer         = BULKI_Entity_serialize(nestEntity, &size);
     BULKI_Entity *des_nestEntity = BULKI_Entity_deserialize(buffer);
 
     int equal = BULKI_Entity_equal(nestEntity, des_nestEntity);
@@ -302,7 +302,7 @@ bulki_small_json_serialization_test()
 
     BULKI_Entity *property_array = empty_BULKI_Array_Entity();
 
-    BULKI        *property1 = BULKI_init(2); // 2 fields: name, value
+    BULKI *       property1 = BULKI_init(2); // 2 fields: name, value
     BULKI_Entity *name      = BULKI_singleton_ENTITY("AIRMASS", PDC_STRING);
     BULKI_Entity *data      = BULKI_ENTITY(&(float){1.19428}, 1, PDC_FLOAT, PDC_CLS_ITEM);
     BULKI_put(property1, name, data);

--- a/src/commons/serde/bulki/bulki_serde_test.c
+++ b/src/commons/serde/bulki/bulki_serde_test.c
@@ -1,5 +1,6 @@
 #include "bulki_serde.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 int
 test_base_type()
@@ -8,13 +9,13 @@ test_base_type()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str = "int";
+    char         *intKey_str = "int";
     int           intVal     = 42;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *intValue   = BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ITEM);
     BULKI_put(bulki, intKey, intValue);
 
-    int *intArrVal          = (int *)malloc(3 * sizeof(int));
+    int *intArrVal          = (int *)PDC_malloc(3 * sizeof(int));
     intArrVal[0]            = 9; // x
     intArrVal[1]            = 8; // y
     intArrVal[2]            = 7; // z
@@ -24,21 +25,21 @@ test_base_type()
     // freeing issue.
     BULKI_put(bulki, intArrKey, BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ARRAY));
 
-    char *        doubleKey_str = "double";
+    char         *doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *doubleValue   = BULKI_ENTITY(&doubleVal, 1, PDC_DOUBLE, PDC_CLS_ITEM);
     BULKI_put(bulki, doubleKey, doubleValue);
 
-    char *        strKey_str = "string";
-    char *        strVal     = "Hello, World!";
+    char         *strKey_str = "string";
+    char         *strVal     = "Hello, World!";
     BULKI_Entity *strKey     = BULKI_ENTITY(strKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *strValue   = BULKI_ENTITY(strVal, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_put(bulki, strKey, strValue);
 
     // Serialize the data
     size_t size;
-    void * buffer = BULKI_serialize(bulki, &size);
+    void  *buffer = BULKI_serialize(bulki, &size);
 
     // Do some I/O if you like
     FILE *fp = fopen("test_bulki.bin", "wb");
@@ -66,7 +67,7 @@ test_base_type()
     // Free the memory
     BULKI_free(deserializedBulki, 1);
 
-    free(buffer);
+    buffer = (void *)PDC_free(buffer);
 
     return equal;
 }
@@ -104,7 +105,7 @@ test_base_array_entitiy()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str = "int";
+    char         *intKey_str = "int";
     int           intVal     = 42;
     uint64_t      intObjID   = 12416574651687;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -113,7 +114,7 @@ test_base_array_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(intArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, intKey, intArr);
 
-    char *        doubleKey_str = "double";
+    char         *doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     uint64_t      doubleObjID   = 564987951987494;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -131,7 +132,7 @@ test_base_array_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(strArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, strKey, strArr);
 
-    char *        mixedKey_str = "mixed";
+    char         *mixedKey_str = "mixed";
     BULKI_Entity *mixedKey     = BULKI_ENTITY(mixedKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *mixedArr     = empty_Bent_Array_Entity();
     BULKI_ENTITY_append_BULKI_Entity(mixedArr, BULKI_ENTITY(&intVal, 1, PDC_INT, PDC_CLS_ITEM));
@@ -144,7 +145,7 @@ test_base_array_entitiy()
     BULKI *bulki2 = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str2 = "int";
+    char         *intKey_str2 = "int";
     int           intVal2     = 42;
     BULKI_Entity *intKey2     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
     BULKI_Entity *intArr2     = empty_BULKI_Array_Entity();
@@ -154,7 +155,7 @@ test_base_array_entitiy()
 
     // Serialize the data
     size_t size;
-    void * buffer = BULKI_serialize(bulki2, &size);
+    void  *buffer = BULKI_serialize(bulki2, &size);
 
     // Deserialize the buffer
     BULKI *deserializedBulki = BULKI_deserialize(buffer);
@@ -165,7 +166,7 @@ test_base_array_entitiy()
     // Free the memory
     BULKI_free(deserializedBulki, 1);
     BULKI_free(bulki, 1);
-    free(buffer);
+    buffer = (void *)PDC_free(buffer);
 
     return equal;
 }
@@ -177,7 +178,7 @@ test_embedded_entitiy()
     BULKI *bulki = BULKI_init(2);
 
     // Create and append key-value pairs for different data types
-    char *        intKey_str = "int";
+    char         *intKey_str = "int";
     int           intVal     = 42;
     uint64_t      intObjID   = 12416574651687;
     BULKI_Entity *intKey     = BULKI_ENTITY(intKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -186,7 +187,7 @@ test_embedded_entitiy()
     BULKI_ENTITY_append_BULKI_Entity(intArr, BULKI_ENTITY(&intObjID, 1, PDC_UINT64, PDC_CLS_ITEM));
     BULKI_put(bulki, intKey, intArr);
 
-    char *        doubleKey_str = "double";
+    char         *doubleKey_str = "double";
     double        doubleVal     = 3.14159;
     uint64_t      doubleObjID   = 564987951987494;
     BULKI_Entity *doubleKey     = BULKI_ENTITY(doubleKey_str, 1, PDC_STRING, PDC_CLS_ITEM);
@@ -206,7 +207,7 @@ test_embedded_entitiy()
 
     // Serialize the data
     size_t size;
-    void * buffer = BULKI_serialize(bulki, &size);
+    void  *buffer = BULKI_serialize(bulki, &size);
 
     // Deserialize the buffer
     BULKI *deserializedBulki = BULKI_deserialize(buffer);
@@ -217,7 +218,7 @@ test_embedded_entitiy()
     // Free the memory
     BULKI_free(deserializedBulki, 1);
     BULKI_free(bulki, 1);
-    free(buffer);
+    buffer = (void *)PDC_free(buffer);
 
     return equal;
 }
@@ -231,7 +232,7 @@ test_bulki_in_entitiy()
     // BULKI in BULKI_Entity
     BULKI_Entity *nestEntity = BULKI_ENTITY(bulki, 1, PDC_BULKI, PDC_CLS_ITEM);
     size_t        size;
-    void *        buffer         = BULKI_Entity_serialize(nestEntity, &size);
+    void         *buffer         = BULKI_Entity_serialize(nestEntity, &size);
     BULKI_Entity *des_nestEntity = BULKI_Entity_deserialize(buffer);
 
     int equal = BULKI_Entity_equal(nestEntity, des_nestEntity);
@@ -301,7 +302,7 @@ bulki_small_json_serialization_test()
 
     BULKI_Entity *property_array = empty_BULKI_Array_Entity();
 
-    BULKI *       property1 = BULKI_init(2); // 2 fields: name, value
+    BULKI        *property1 = BULKI_init(2); // 2 fields: name, value
     BULKI_Entity *name      = BULKI_singleton_ENTITY("AIRMASS", PDC_STRING);
     BULKI_Entity *data      = BULKI_ENTITY(&(float){1.19428}, 1, PDC_FLOAT, PDC_CLS_ITEM);
     BULKI_put(property1, name, data);

--- a/src/commons/utils/pdc_malloc.c
+++ b/src/commons/utils/pdc_malloc.c
@@ -132,7 +132,7 @@ void *
 PDC_realloc_addsize_knowing_oldsize(void *ptr, size_t size, size_t old_size, size_t *mem_usage_ptr)
 {
     size_t _old_size = old_size;
-    void * ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
+    void  *ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
     if (ret_value && mem_usage_ptr) {
         *mem_usage_ptr += size;
         if (_old_size) {

--- a/src/commons/utils/pdc_malloc.c
+++ b/src/commons/utils/pdc_malloc.c
@@ -104,7 +104,7 @@ PDC_realloc_knowing_oldsize(void *ptr, size_t size, size_t old_size)
     assert(size);
     size_t _old_size = old_size;
     if (size)
-        ret_value = realloc(ptr, size);
+        ret_value = PDC_realloc(ptr, size);
     else
         ret_value = NULL;
 
@@ -162,7 +162,7 @@ PDC_free_knowing_old_size(void *mem, size_t old_size)
     FUNC_ENTER(NULL);
 
     if (mem) {
-        mem = (void *)PDC_free(mem);
+        free(mem);
         if (_old_size)
             PDC_mem_usage_g -= _old_size;
     }

--- a/src/commons/utils/pdc_malloc.c
+++ b/src/commons/utils/pdc_malloc.c
@@ -132,7 +132,7 @@ void *
 PDC_realloc_addsize_knowing_oldsize(void *ptr, size_t size, size_t old_size, size_t *mem_usage_ptr)
 {
     size_t _old_size = old_size;
-    void * ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
+    void  *ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
     if (ret_value && mem_usage_ptr) {
         *mem_usage_ptr += size;
         if (_old_size) {
@@ -162,10 +162,9 @@ PDC_free_knowing_old_size(void *mem, size_t old_size)
     FUNC_ENTER(NULL);
 
     if (mem) {
-        free(mem);
-        if (_old_size) {
+        mem = (void *)PDC_free(mem);
+        if (_old_size)
             PDC_mem_usage_g -= _old_size;
-        }
     }
 
     FUNC_LEAVE(ret_value);

--- a/src/commons/utils/pdc_malloc.c
+++ b/src/commons/utils/pdc_malloc.c
@@ -132,7 +132,7 @@ void *
 PDC_realloc_addsize_knowing_oldsize(void *ptr, size_t size, size_t old_size, size_t *mem_usage_ptr)
 {
     size_t _old_size = old_size;
-    void  *ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
+    void * ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
     if (ret_value && mem_usage_ptr) {
         *mem_usage_ptr += size;
         if (_old_size) {

--- a/src/commons/utils/pdc_malloc.c
+++ b/src/commons/utils/pdc_malloc.c
@@ -104,7 +104,7 @@ PDC_realloc_knowing_oldsize(void *ptr, size_t size, size_t old_size)
     assert(size);
     size_t _old_size = old_size;
     if (size)
-        ret_value = PDC_realloc(ptr, size);
+        ret_value = realloc(ptr, size);
     else
         ret_value = NULL;
 
@@ -132,7 +132,7 @@ void *
 PDC_realloc_addsize_knowing_oldsize(void *ptr, size_t size, size_t old_size, size_t *mem_usage_ptr)
 {
     size_t _old_size = old_size;
-    void * ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
+    void  *ret_value = PDC_realloc_knowing_oldsize(ptr, size, _old_size);
     if (ret_value && mem_usage_ptr) {
         *mem_usage_ptr += size;
         if (_old_size) {

--- a/src/commons/utils/pdc_timing.c
+++ b/src/commons/utils/pdc_timing.c
@@ -41,6 +41,7 @@ PDC_timing_init()
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     gethostname(hostname, HOST_NAME_MAX);
+    strcpy(hostname, "eno1");
     if (!(rank % 31)) {
         LOG_INFO("client process rank %d, hostname = %s\n", rank, hostname);
     }
@@ -119,13 +120,14 @@ PDC_timing_report(const char *prefix)
     pdc_timing max_timings;
     int        rank;
     char       filename[256], header[256];
-    FILE *     stream;
+    FILE      *stream;
     char       hostname[HOST_NAME_MAX];
     time_t     now;
 
     time(&now);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     gethostname(hostname, HOST_NAME_MAX);
+    strcpy(hostname, "eno1");
     if (!(rank % 32)) {
         LOG_INFO("client process rank %d, hostname = %s\n", rank, hostname);
     }
@@ -261,17 +263,9 @@ PDC_server_timing_init()
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     gethostname(hostname, HOST_NAME_MAX);
+    strcpy(hostname, "eno1");
 
     LOG_INFO("server process rank %d, hostname = %s\n", rank, hostname);
-    /*
-        LOG_INFO("rank = %d, hostname = %s, PDCbuf_obj_map_rpc = %lf, PDCreg_obtain_lock_rpc = %lf, "
-               "PDCreg_release_lock_write_rpc = "
-               "%lf, PDCreg_release_lock_read_rpc = %lf, PDCbuf_obj_unmap_rpc = %lf, "
-               "region_release_bulk_transfer_cb = %lf\n",
-               rank, hostname, server_timings->PDCbuf_obj_map_rpc, server_timings->PDCreg_obtain_lock_rpc,
-               server_timings->PDCreg_release_lock_write_rpc, server_timings->PDCreg_release_lock_read_rpc,
-               server_timings->PDCbuf_obj_unmap_rpc, server_timings->PDCreg_release_lock_bulk_transfer_rpc);
-    */
     MPI_Barrier(MPI_COMM_WORLD);
 
     pdc_server_timings         = calloc(1, sizeof(pdc_server_timing));
@@ -342,12 +336,12 @@ pdc_timestamp_register(pdc_timestamp *timestamp, double start, double end)
 
     if (timestamp->timestamp_max_size == 0) {
         timestamp->timestamp_max_size = 256;
-        timestamp->start              = (double *)malloc(sizeof(double) * timestamp->timestamp_max_size * 2);
-        timestamp->end                = timestamp->start + timestamp->timestamp_max_size;
-        timestamp->timestamp_size     = 0;
+        timestamp->start          = (double *)PDC_malloc(sizeof(double) * timestamp->timestamp_max_size * 2);
+        timestamp->end            = timestamp->start + timestamp->timestamp_max_size;
+        timestamp->timestamp_size = 0;
     }
     else if (timestamp->timestamp_size == timestamp->timestamp_max_size) {
-        temp = (double *)malloc(sizeof(double) * timestamp->timestamp_max_size * 4);
+        temp = (double *)PDC_malloc(sizeof(double) * timestamp->timestamp_max_size * 4);
         memcpy(temp, timestamp->start, sizeof(double) * timestamp->timestamp_max_size);
         memcpy(temp + timestamp->timestamp_max_size * 2, timestamp->end,
                sizeof(double) * timestamp->timestamp_max_size);
@@ -367,7 +361,7 @@ PDC_server_timing_report()
     pdc_server_timing max_timings;
     int               rank;
     char              filename[256];
-    FILE *            stream;
+    FILE             *stream;
 
     //    char              hostname[HOST_NAME_MAX];
     time_t now;

--- a/src/commons/utils/pdc_timing.c
+++ b/src/commons/utils/pdc_timing.c
@@ -121,7 +121,7 @@ PDC_timing_report(const char *prefix)
     pdc_timing max_timings;
     int        rank;
     char       filename[256], header[256];
-    FILE *     stream;
+    FILE      *stream;
     char       hostname[HOST_NAME_MAX];
     time_t     now;
 
@@ -360,7 +360,7 @@ PDC_server_timing_report()
     pdc_server_timing max_timings;
     int               rank;
     char              filename[256];
-    FILE *            stream;
+    FILE             *stream;
 
     //    char              hostname[HOST_NAME_MAX];
     time_t now;

--- a/src/commons/utils/pdc_timing.c
+++ b/src/commons/utils/pdc_timing.c
@@ -1,4 +1,6 @@
 #include "pdc_timing.h"
+#include "pdc_malloc.h"
+#include "pdc_logger.h"
 #include "assert.h"
 #include "mpi.h"
 
@@ -9,7 +11,7 @@ static int
 pdc_timestamp_clean(pdc_timestamp *timestamp)
 {
     if (timestamp->timestamp_size) {
-        free(timestamp->start);
+        timestamp->start = (double *)PDC_free(timestamp->start);
     }
     return 0;
 }
@@ -110,7 +112,7 @@ PDC_timing_finalize()
     pdc_timestamp_clean(pdc_client_transfer_request_wait_all_timestamps);
     pdc_timestamp_clean(pdc_client_transfer_request_metadata_query_timestamps);
 
-    free(pdc_client_buf_obj_map_timestamps);
+    pdc_client_buf_obj_map_timestamps = (pdc_timestamp *)PDC_free(pdc_client_buf_obj_map_timestamps);
     return 0;
 }
 
@@ -487,7 +489,7 @@ PDC_server_timing_report()
 
     fclose(stream);
 
-    free(pdc_server_timings);
+    pdc_server_timings = (pdc_server_timing *)PDC_free(pdc_server_timings);
     pdc_timestamp_clean(pdc_buf_obj_map_timestamps);
     pdc_timestamp_clean(pdc_buf_obj_unmap_timestamps);
 
@@ -520,7 +522,7 @@ PDC_server_timing_report()
     /* pdc_timestamp_clean(pdc_create_obj_timestamps); */
     /* pdc_timestamp_clean(pdc_create_cont_timestamps); */
 
-    free(pdc_buf_obj_map_timestamps);
+    pdc_buf_obj_map_timestamps = (pdc_timestamp *)PDC_free(pdc_buf_obj_map_timestamps);
     return 0;
 }
 

--- a/src/commons/utils/pdc_timing.c
+++ b/src/commons/utils/pdc_timing.c
@@ -43,7 +43,6 @@ PDC_timing_init()
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     gethostname(hostname, HOST_NAME_MAX);
-    strcpy(hostname, "eno1");
     if (!(rank % 31)) {
         LOG_INFO("client process rank %d, hostname = %s\n", rank, hostname);
     }
@@ -51,7 +50,7 @@ PDC_timing_init()
 
     memset(&pdc_timings, 0, sizeof(pdc_timing));
 
-    pdc_client_buf_obj_map_timestamps   = calloc(16, sizeof(pdc_timestamp));
+    pdc_client_buf_obj_map_timestamps   = PDC_calloc(16, sizeof(pdc_timestamp));
     ptr                                 = pdc_client_buf_obj_map_timestamps + 1;
     pdc_client_buf_obj_unmap_timestamps = ptr;
     ptr++;
@@ -129,7 +128,6 @@ PDC_timing_report(const char *prefix)
     time(&now);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     gethostname(hostname, HOST_NAME_MAX);
-    strcpy(hostname, "eno1");
     if (!(rank % 32)) {
         LOG_INFO("client process rank %d, hostname = %s\n", rank, hostname);
     }
@@ -265,13 +263,12 @@ PDC_server_timing_init()
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     gethostname(hostname, HOST_NAME_MAX);
-    strcpy(hostname, "eno1");
 
     LOG_INFO("server process rank %d, hostname = %s\n", rank, hostname);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    pdc_server_timings         = calloc(1, sizeof(pdc_server_timing));
-    pdc_timestamp *ptr         = calloc(25, sizeof(pdc_timestamp));
+    pdc_server_timings         = PDC_calloc(1, sizeof(pdc_server_timing));
+    pdc_timestamp *ptr         = PDC_calloc(25, sizeof(pdc_timestamp));
     pdc_buf_obj_map_timestamps = ptr;
     ptr++;
     pdc_buf_obj_unmap_timestamps = ptr;

--- a/src/commons/utils/pdc_timing.c
+++ b/src/commons/utils/pdc_timing.c
@@ -121,7 +121,7 @@ PDC_timing_report(const char *prefix)
     pdc_timing max_timings;
     int        rank;
     char       filename[256], header[256];
-    FILE      *stream;
+    FILE *     stream;
     char       hostname[HOST_NAME_MAX];
     time_t     now;
 
@@ -360,7 +360,7 @@ PDC_server_timing_report()
     pdc_server_timing max_timings;
     int               rank;
     char              filename[256];
-    FILE             *stream;
+    FILE *            stream;
 
     //    char              hostname[HOST_NAME_MAX];
     time_t now;

--- a/src/commons/utils/query_utils.c
+++ b/src/commons/utils/query_utils.c
@@ -21,7 +21,7 @@ _gen_affix_for_token(char *token_str, int affix_type, size_t affix_len, char **o
     affix_len        = affix_len < token_len ? affix_len : token_len;
     size_t copy_len  = affix_type == 0 ? token_len : affix_len;
     char  *source    = affix_type <= 1 ? token_str : &(token_str[token_len - affix_len]);
-    char  *affix_str = (char *)calloc(copy_len + 3, sizeof(char));
+    char  *affix_str = (char *)PDC_calloc(copy_len + 3, sizeof(char));
 
     strncpy(affix_str, source, copy_len + 1);
 
@@ -66,14 +66,14 @@ gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
     size_t value_ptr_len = 0;
     // check base_tag->name length
     if (strlen(input->base_tag->name) < 3) {
-        char *new_tag_name = (char *)calloc(4, sizeof(char));
+        char *new_tag_name = (char *)PDC_calloc(4, sizeof(char));
         memset(new_tag_name, input->base_tag->name[0], 3);
         input->base_tag->name = new_tag_name;
         input->affix_len      = 1;
     }
     // check base_tag->value length if it is a string
     if (input->base_tag->type == PDC_STRING && strlen((char *)input->base_tag->value) < 3) {
-        char *new_tag_value = (char *)calloc(4, sizeof(char));
+        char *new_tag_value = (char *)PDC_calloc(4, sizeof(char));
         memset(new_tag_value, ((char *)input->base_tag->value)[0], 3);
         input->base_tag->value = (void *)new_tag_value;
         input->affix_len       = 1;
@@ -92,7 +92,7 @@ gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
         char *temp_value = NULL;
         value_ptr_len    = _gen_affix_for_token((char *)input->base_tag->value, input->value_query_type,
                                                 affix_len, &temp_value);
-        value_ptr        = (char *)calloc(value_ptr_len + 3, sizeof(char));
+        value_ptr        = (char *)PDC_calloc(value_ptr_len + 3, sizeof(char));
         value_ptr[0]     = '"';
         strcat(value_ptr, temp_value);
         value_ptr[value_ptr_len + 1] = '"';
@@ -120,14 +120,14 @@ gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
         char *format_str = get_format_by_dtype(input->base_tag->type);
         if (input->value_query_type == 4) {
             value_ptr_len = snprintf(NULL, 0, format_str, ((int64_t *)input->base_tag->value)[0]);
-            value_ptr     = (char *)calloc(value_ptr_len + 1, sizeof(char));
+            value_ptr     = (char *)PDC_calloc(value_ptr_len + 1, sizeof(char));
             snprintf(value_ptr, value_ptr_len + 1, format_str, ((int64_t *)input->base_tag->value)[0]);
         }
         else if (input->value_query_type == 5) {
             size_t lo_len = snprintf(NULL, 0, format_str, input->range_lo);
             size_t hi_len = snprintf(NULL, 0, format_str, input->range_hi);
             value_ptr_len = lo_len + hi_len + 1;
-            value_ptr     = (char *)calloc(value_ptr_len + 1, sizeof(char));
+            value_ptr     = (char *)PDC_calloc(value_ptr_len + 1, sizeof(char));
             char fmt_str[20];
             snprintf(fmt_str, 20, "%s~%s", format_str, format_str);
             snprintf(value_ptr, value_ptr_len + 1, fmt_str, input->range_lo, input->range_hi);
@@ -147,8 +147,8 @@ gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
 char *
 gen_query_str(query_gen_output_t *query_gen_output)
 {
-    char *final_query_str =
-        (char *)calloc(query_gen_output->key_query_len + query_gen_output->value_query_len + 2, sizeof(char));
+    char *final_query_str = (char *)PDC_calloc(
+        query_gen_output->key_query_len + query_gen_output->value_query_len + 2, sizeof(char));
     strcat(final_query_str, query_gen_output->key_query);
     strcat(final_query_str, "=");
     strcat(final_query_str, query_gen_output->value_query);

--- a/src/commons/utils/query_utils.c
+++ b/src/commons/utils/query_utils.c
@@ -159,10 +159,10 @@ void
 free_query_output(query_gen_output_t *output)
 {
     if (output->key_query != NULL) {
-        free(output->key_query);
+        output->key_query = (char *)PDC_free(output->key_query);
     }
     if (output->value_query != NULL) {
-        free(output->value_query);
+        output->value_query = (char *)PDC_free(output->value_query);
     }
 }
 

--- a/src/commons/utils/query_utils.c
+++ b/src/commons/utils/query_utils.c
@@ -20,8 +20,8 @@ _gen_affix_for_token(char *token_str, int affix_type, size_t affix_len, char **o
 
     affix_len        = affix_len < token_len ? affix_len : token_len;
     size_t copy_len  = affix_type == 0 ? token_len : affix_len;
-    char  *source    = affix_type <= 1 ? token_str : &(token_str[token_len - affix_len]);
-    char  *affix_str = (char *)PDC_calloc(copy_len + 3, sizeof(char));
+    char * source    = affix_type <= 1 ? token_str : &(token_str[token_len - affix_len]);
+    char * affix_str = (char *)PDC_calloc(copy_len + 3, sizeof(char));
 
     strncpy(affix_str, source, copy_len + 1);
 
@@ -60,9 +60,9 @@ _gen_affix_for_token(char *token_str, int affix_type, size_t affix_len, char **o
 void
 gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
 {
-    char  *key_ptr       = NULL;
+    char * key_ptr       = NULL;
     size_t key_ptr_len   = 0;
-    char  *value_ptr     = NULL;
+    char * value_ptr     = NULL;
     size_t value_ptr_len = 0;
     // check base_tag->name length
     if (strlen(input->base_tag->name) < 3) {
@@ -91,7 +91,7 @@ gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
     if (is_PDC_STRING(input->base_tag->type)) {
         char *temp_value = NULL;
         value_ptr_len    = _gen_affix_for_token((char *)input->base_tag->value, input->value_query_type,
-                                                affix_len, &temp_value);
+                                             affix_len, &temp_value);
         value_ptr        = (char *)PDC_calloc(value_ptr_len + 3, sizeof(char));
         value_ptr[0]     = '"';
         strcat(value_ptr, temp_value);
@@ -357,7 +357,7 @@ int
 is_value_in_range(const char *tagslist, const char *tagname, int from, int to)
 {
     const char *matched_kv = k_v_matches_p(tagslist, tagname, NULL);
-    char       *value      = get_value(matched_kv, '=');
+    char *      value      = get_value(matched_kv, '=');
     int         v          = atoi(value);
     return (v >= from && v <= to);
 }
@@ -393,7 +393,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
     void *val2;
     if (startsWith(num_val_query, "|") && startsWith(num_val_query, "|")) { // EXACT
         // exact number search
-        char  *num_str = substring(num_val_query, 1, strlen(num_val_query) - 1);
+        char * num_str = substring(num_val_query, 1, strlen(num_val_query) - 1);
         size_t klen1   = get_number_from_string(num_str, num_type, &val1);
 
         action_collection->exact_action(val1, NULL, NULL, 1, 1, num_type, cb_input, cb_out, cb_out_len);
@@ -408,7 +408,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
         int endInclusive = num_val_query[1] == '|';
         // find all numbers that are smaller than the given number
         int    beginPos = endInclusive ? 2 : 1;
-        char  *numstr   = substring(num_val_query, beginPos, strlen(num_val_query));
+        char * numstr   = substring(num_val_query, beginPos, strlen(num_val_query));
         size_t klen1    = get_number_from_string(numstr, num_type, &val1);
         action_collection->lt_action(NULL, NULL, val1, 0, endInclusive, num_type, cb_input, cb_out,
                                      cb_out_len);
@@ -419,7 +419,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
         int beginInclusive = num_val_query[strlen(num_val_query) - 2] == '|';
         int endPos         = beginInclusive ? strlen(num_val_query) - 2 : strlen(num_val_query) - 1;
         // find all numbers that are greater than the given number
-        char  *numstr = substring(num_val_query, 0, endPos);
+        char * numstr = substring(num_val_query, 0, endPos);
         size_t klen1  = get_number_from_string(numstr, num_type, &val1);
 
         action_collection->gt_action(NULL, val1, NULL, beginInclusive, 0, num_type, cb_input, cb_out,
@@ -440,8 +440,8 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
         // lo_tok might be ended with '|', and hi_tok might be started with '|', to indicate inclusivity.
         int    beginInclusive = endsWith(lo_tok, "|");
         int    endInclusive   = startsWith(hi_tok, "|");
-        char  *lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
-        char  *hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
+        char * lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
+        char * hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
         size_t klen1          = get_number_from_string(lo_num_str, num_type, &val1);
         size_t klen2          = get_number_from_string(hi_num_str, num_type, &val2);
 
@@ -455,7 +455,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
     else {
         // exact query by default
         // exact number search
-        char  *num_str = strdup(num_val_query);
+        char * num_str = strdup(num_val_query);
         size_t klen1   = get_number_from_string(num_str, num_type, &val1);
 
         action_collection->exact_action(val1, NULL, NULL, 1, 1, num_type, cb_input, cb_out, cb_out_len);

--- a/src/commons/utils/query_utils.c
+++ b/src/commons/utils/query_utils.c
@@ -5,6 +5,7 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 int
 _gen_affix_for_token(char *token_str, int affix_type, size_t affix_len, char **out_str)
@@ -19,8 +20,8 @@ _gen_affix_for_token(char *token_str, int affix_type, size_t affix_len, char **o
 
     affix_len        = affix_len < token_len ? affix_len : token_len;
     size_t copy_len  = affix_type == 0 ? token_len : affix_len;
-    char * source    = affix_type <= 1 ? token_str : &(token_str[token_len - affix_len]);
-    char * affix_str = (char *)calloc(copy_len + 3, sizeof(char));
+    char  *source    = affix_type <= 1 ? token_str : &(token_str[token_len - affix_len]);
+    char  *affix_str = (char *)calloc(copy_len + 3, sizeof(char));
 
     strncpy(affix_str, source, copy_len + 1);
 
@@ -59,9 +60,9 @@ _gen_affix_for_token(char *token_str, int affix_type, size_t affix_len, char **o
 void
 gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
 {
-    char * key_ptr       = NULL;
+    char  *key_ptr       = NULL;
     size_t key_ptr_len   = 0;
-    char * value_ptr     = NULL;
+    char  *value_ptr     = NULL;
     size_t value_ptr_len = 0;
     // check base_tag->name length
     if (strlen(input->base_tag->name) < 3) {
@@ -90,7 +91,7 @@ gen_query_key_value(query_gen_input_t *input, query_gen_output_t *output)
     if (is_PDC_STRING(input->base_tag->type)) {
         char *temp_value = NULL;
         value_ptr_len    = _gen_affix_for_token((char *)input->base_tag->value, input->value_query_type,
-                                             affix_len, &temp_value);
+                                                affix_len, &temp_value);
         value_ptr        = (char *)calloc(value_ptr_len + 3, sizeof(char));
         value_ptr[0]     = '"';
         strcat(value_ptr, temp_value);
@@ -231,7 +232,7 @@ gen_tags(int obj_id)
         char *fspace = ret;
         ret          = dsprintf("%stag%d=%d%d,", ret, j, obj_id, j);
         if (strlen(fspace) > 0) {
-            free(fspace);
+            fspace = (char *)PDC_free(fspace);
         }
     }
     ret[strlen(ret) - 1] = '\0';
@@ -254,7 +255,7 @@ gen_tags_in_loop()
         char *ret     = gen_tags(tag_num);
         println("helloworld, %s", ret);
         if (ret != NULL) {
-            free(ret);
+            ret = (char *)PDC_free(ret);
         }
     }
 }
@@ -326,10 +327,10 @@ k_v_matches_p(const char *tagslist, const char *key_pattern, const char *value_p
                 (value_pattern == NULL ? is_key_matched : (is_key_matched && is_value_matched));
 
             if (key != NULL) {
-                free(key);
+                key = (char *)PDC_free(key);
             }
             if (value != NULL) {
-                free(value);
+                value = (char *)PDC_free(value);
             }
 
             if (pattern_matches) {
@@ -339,25 +340,12 @@ k_v_matches_p(const char *tagslist, const char *key_pattern, const char *value_p
         }
         tag_kv = strtok(NULL, TAG_DELIMITER);
     }
-
-    if (_tags_list != NULL) {
-        // free(_tags_list);
-    }
     return rst_kv;
 }
 
 int
 is_value_match(const char *tagslist, const char *tagname, const char *val)
 {
-    /*
-    char *pattern = strdup(val);
-    if (startsWith("*", pattern)) {
-        pattern = &pattern[1];
-    }
-    if (endsWith("*", pattern)) {
-        pattern[strlen(pattern)]='\0';
-    }
-     */
     return is_value_match_p(tagslist, tagname, val);
 }
 int
@@ -369,7 +357,7 @@ int
 is_value_in_range(const char *tagslist, const char *tagname, int from, int to)
 {
     const char *matched_kv = k_v_matches_p(tagslist, tagname, NULL);
-    char *      value      = get_value(matched_kv, '=');
+    char       *value      = get_value(matched_kv, '=');
     int         v          = atoi(value);
     return (v >= from && v <= to);
 }
@@ -405,7 +393,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
     void *val2;
     if (startsWith(num_val_query, "|") && startsWith(num_val_query, "|")) { // EXACT
         // exact number search
-        char * num_str = substring(num_val_query, 1, strlen(num_val_query) - 1);
+        char  *num_str = substring(num_val_query, 1, strlen(num_val_query) - 1);
         size_t klen1   = get_number_from_string(num_str, num_type, &val1);
 
         action_collection->exact_action(val1, NULL, NULL, 1, 1, num_type, cb_input, cb_out, cb_out_len);
@@ -420,7 +408,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
         int endInclusive = num_val_query[1] == '|';
         // find all numbers that are smaller than the given number
         int    beginPos = endInclusive ? 2 : 1;
-        char * numstr   = substring(num_val_query, beginPos, strlen(num_val_query));
+        char  *numstr   = substring(num_val_query, beginPos, strlen(num_val_query));
         size_t klen1    = get_number_from_string(numstr, num_type, &val1);
         action_collection->lt_action(NULL, NULL, val1, 0, endInclusive, num_type, cb_input, cb_out,
                                      cb_out_len);
@@ -431,7 +419,7 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
         int beginInclusive = num_val_query[strlen(num_val_query) - 2] == '|';
         int endPos         = beginInclusive ? strlen(num_val_query) - 2 : strlen(num_val_query) - 1;
         // find all numbers that are greater than the given number
-        char * numstr = substring(num_val_query, 0, endPos);
+        char  *numstr = substring(num_val_query, 0, endPos);
         size_t klen1  = get_number_from_string(numstr, num_type, &val1);
 
         action_collection->gt_action(NULL, val1, NULL, beginInclusive, 0, num_type, cb_input, cb_out,
@@ -452,8 +440,8 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
         // lo_tok might be ended with '|', and hi_tok might be started with '|', to indicate inclusivity.
         int    beginInclusive = endsWith(lo_tok, "|");
         int    endInclusive   = startsWith(hi_tok, "|");
-        char * lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
-        char * hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
+        char  *lo_num_str     = beginInclusive ? substring(lo_tok, 0, strlen(lo_tok) - 1) : lo_tok;
+        char  *hi_num_str     = endInclusive ? substring(hi_tok, 1, strlen(hi_tok)) : hi_tok;
         size_t klen1          = get_number_from_string(lo_num_str, num_type, &val1);
         size_t klen2          = get_number_from_string(hi_num_str, num_type, &val2);
 
@@ -467,16 +455,10 @@ parse_and_run_number_value_query(char *num_val_query, pdc_c_var_type_t num_type,
     else {
         // exact query by default
         // exact number search
-        char * num_str = strdup(num_val_query);
+        char  *num_str = strdup(num_val_query);
         size_t klen1   = get_number_from_string(num_str, num_type, &val1);
 
         action_collection->exact_action(val1, NULL, NULL, 1, 1, num_type, cb_input, cb_out, cb_out_len);
-        // value_index_leaf_content_t *value_index_leaf = NULL;
-        // rbt_find(leafcnt->primary_rbt, val1, klen1, (void **)&value_index_leaf);
-        // if (value_index_leaf != NULL) {
-        //     collect_obj_ids(value_index_leaf, idx_record);
-        // }
-        // free(num_str);
     }
     return 0;
 }

--- a/src/commons/utils/query_utils_test.c
+++ b/src/commons/utils/query_utils_test.c
@@ -16,7 +16,7 @@ main(int argc, char *argv[])
 {
     int          affix_length = atoi(argv[1]);
     pdc_kvtag_t *base_string_tag;
-    base_string_tag        = (pdc_kvtag_t *)calloc(1, sizeof(pdc_kvtag_t));
+    base_string_tag        = (pdc_kvtag_t *)PDC_calloc(1, sizeof(pdc_kvtag_t));
     base_string_tag->name  = "testname";
     base_string_tag->type  = PDC_STRING;
     base_string_tag->value = "testvalue";
@@ -37,10 +37,10 @@ main(int argc, char *argv[])
 
     pdc_kvtag_t *base_int_tag;
     int          int_value          = 234;
-    base_int_tag                    = (pdc_kvtag_t *)calloc(1, sizeof(pdc_kvtag_t));
+    base_int_tag                    = (pdc_kvtag_t *)PDC_calloc(1, sizeof(pdc_kvtag_t));
     base_int_tag->name              = "testname";
     base_int_tag->type              = PDC_INT;
-    base_int_tag->value             = (void *)calloc(1, sizeof(int));
+    base_int_tag->value             = (void *)PDC_calloc(1, sizeof(int));
     ((int *)base_int_tag->value)[0] = int_value;
 
     for (int i = 4; i < 6; i++) {

--- a/src/commons/utils/query_utils_test.c
+++ b/src/commons/utils/query_utils_test.c
@@ -7,7 +7,7 @@ print_query_output(query_gen_output_t *output)
     println("value query: %s, len: %lu", output->value_query, output->value_query_len);
     char *final_query_str = gen_query_str(output);
     println("final query: %s, len: %lu", final_query_str, strlen(final_query_str));
-    free(final_query_str);
+    final_query_str = (char *)PDC_free(final_query_str);
 }
 
 int

--- a/src/commons/utils/query_utils_test.c
+++ b/src/commons/utils/query_utils_test.c
@@ -1,4 +1,5 @@
 #include "query_utils.h"
+#include "pdc_malloc.h"
 
 void
 print_query_output(query_gen_output_t *output)

--- a/src/commons/utils/string_utils.c
+++ b/src/commons/utils/string_utils.c
@@ -170,7 +170,7 @@ dsprintf(const char *format, ...)
     va_start(args, format);
     // 3. get arguments value
     int numbytes = vsnprintf((char *)NULL, 0, format, args);
-    ret          = (char *)calloc((numbytes + 1), sizeof(char));
+    ret          = (char *)PDC_calloc((numbytes + 1), sizeof(char));
 
     va_start(args, format);
     vsprintf(ret, format, args);
@@ -311,13 +311,13 @@ gen_random_strings(int count, int minlen, int maxlen, int alphabet_size)
 {
     int    c        = 0;
     int    i        = 0;
-    char **result   = (char **)calloc(count, sizeof(char *));
+    char **result   = (char **)PDC_calloc(count, sizeof(char *));
     int    abc_size = alphabet_size > strlen(VISIBLE_ALPHABET) ? strlen(VISIBLE_ALPHABET) : alphabet_size;
     abc_size        = abc_size < 1 ? 26 : abc_size; // the minimum alphabet size is 26
     for (c = 0; c < count; c++) {
         int len   = (rand() % maxlen) + 1;
         len       = len < minlen ? minlen : len; // Ensure at least minlen character
-        char *str = (char *)calloc(len + 1, sizeof(char));
+        char *str = (char *)PDC_calloc(len + 1, sizeof(char));
         for (i = 0; i < len; i++) {
             int randnum = rand();
             if (randnum < 0)

--- a/src/commons/utils/string_utils.c
+++ b/src/commons/utils/string_utils.c
@@ -4,6 +4,7 @@
 
 #include "string_utils.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 #include <regex.h>
 
 const char *VISIBLE_ALPHABET =
@@ -69,7 +70,7 @@ simple_matches(const char *str, const char *pattern)
             break;
     }
     if (tok != NULL) {
-        free(tok);
+        tok = (char *)PDC_free(tok);
     }
     return result;
 }
@@ -126,7 +127,7 @@ substring(const char *str, int start, int end)
     int substr_len = end - start;
 
     // Allocate memory for the new string (including null-terminator)
-    char *substr = (char *)malloc((substr_len + 1) * sizeof(char));
+    char *substr = (char *)PDC_malloc((substr_len + 1) * sizeof(char));
     if (substr == NULL) { // Check if malloc succeeded
         return NULL;
     }
@@ -216,7 +217,7 @@ reverse_str(char *str)
     }
 
     int   length   = strlen(str);
-    char *reversed = (char *)malloc(length + 1); // +1 for the null-terminator
+    char *reversed = (char *)PDC_malloc(length + 1); // +1 for the null-terminator
 
     if (reversed == NULL) {
         return NULL; // Return NULL if memory allocation fails
@@ -259,7 +260,7 @@ split_string(const char *str, const char *delim, char ***result, int *result_len
     }
 
     *result_len = count + 1;
-    *result     = (char **)malloc((*result_len) * sizeof(char *));
+    *result     = (char **)PDC_malloc((*result_len) * sizeof(char *));
     if (!*result) {
         return -1; // Memory allocation failed
     }
@@ -271,12 +272,12 @@ split_string(const char *str, const char *delim, char ***result, int *result_len
     while (i < count && regexec(&regex, tmp, 1, pmatch, 0) != REG_NOMATCH) {
         int len = pmatch[0].rm_so;
 
-        (*result)[i] = (char *)malloc((len + 1) * sizeof(char));
+        (*result)[i] = (char *)PDC_malloc((len + 1) * sizeof(char));
         if (!(*result)[i]) {
             for (int j = 0; j < i; j++) {
-                free((*result)[j]);
+                (*result)[j] = (char *)PDC_free((*result)[j]);
             }
-            free(*result);
+            *result = (char **)PDC_free(*result);
             *result = NULL;
             regfree(&regex);
             return -1;
@@ -293,9 +294,9 @@ split_string(const char *str, const char *delim, char ***result, int *result_len
     (*result)[i] = strdup(start);
     if (!(*result)[i]) {
         for (int j = 0; j < i; j++) {
-            free((*result)[j]);
+            (*result)[j] = (char *)PDC_free((*result)[j]);
         }
-        free(*result);
+        *result = (char **)PDC_free(*result);
         *result = NULL;
         regfree(&regex);
         return -1;

--- a/src/commons/utils/thpool.c
+++ b/src/commons/utils/thpool.c
@@ -417,7 +417,8 @@ jobqueue_clear(jobqueue *jobqueue_p)
 {
 
     while (jobqueue_p->len) {
-        free(jobqueue_pull(jobqueue_p));
+        struct job *j = jobqueue_pull(jobqueue_p);
+        j             = (struct job *)PDC_free(j);
     }
 
     jobqueue_p->front = NULL;
@@ -486,7 +487,7 @@ static void
 jobqueue_destroy(jobqueue *jobqueue_p)
 {
     jobqueue_clear(jobqueue_p);
-    free(jobqueue_p->has_jobs);
+    jobqueue_p->has_jobs = (bsem *)PDC_free(jobqueue_p->has_jobs);
 }
 
 /* ======================== SYNCHRONISATION ========================= */

--- a/src/commons/utils/thpool.c
+++ b/src/commons/utils/thpool.c
@@ -65,9 +65,9 @@ typedef struct job {
 /* Job queue */
 typedef struct jobqueue {
     pthread_mutex_t rwmutex;  /* used for queue r/w access */
-    job            *front;    /* pointer to front of queue */
-    job            *rear;     /* pointer to rear  of queue */
-    bsem           *has_jobs; /* flag as binary semaphore  */
+    job *           front;    /* pointer to front of queue */
+    job *           rear;     /* pointer to rear  of queue */
+    bsem *          has_jobs; /* flag as binary semaphore  */
     int             len;      /* number of jobs in queue   */
 } jobqueue;
 
@@ -80,7 +80,7 @@ typedef struct thread {
 
 /* Threadpool */
 typedef struct thpool_ {
-    thread        **threads;             /* pointer to threads        */
+    thread **       threads;             /* pointer to threads        */
     volatile int    num_threads_alive;   /* threads currently alive   */
     volatile int    num_threads_working; /* threads currently working */
     pthread_mutex_t thcount_lock;        /* used for thread count etc */
@@ -360,7 +360,7 @@ thread_do(struct thread *thread_p)
             /* Read job from queue and execute it */
             void (*func_buff)(void *);
             void *arg_buff;
-            job  *job_p = jobqueue_pull(&thpool_p->jobqueue);
+            job * job_p = jobqueue_pull(&thpool_p->jobqueue);
             if (job_p) {
                 func_buff = job_p->function;
                 arg_buff  = job_p->arg;

--- a/src/commons/utils/thpool.c
+++ b/src/commons/utils/thpool.c
@@ -29,6 +29,7 @@
 
 #include "thpool.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 #ifdef THPOOL_DEBUG
 #define THPOOL_DEBUG 1
@@ -64,9 +65,9 @@ typedef struct job {
 /* Job queue */
 typedef struct jobqueue {
     pthread_mutex_t rwmutex;  /* used for queue r/w access */
-    job *           front;    /* pointer to front of queue */
-    job *           rear;     /* pointer to rear  of queue */
-    bsem *          has_jobs; /* flag as binary semaphore  */
+    job            *front;    /* pointer to front of queue */
+    job            *rear;     /* pointer to rear  of queue */
+    bsem           *has_jobs; /* flag as binary semaphore  */
     int             len;      /* number of jobs in queue   */
 } jobqueue;
 
@@ -79,7 +80,7 @@ typedef struct thread {
 
 /* Threadpool */
 typedef struct thpool_ {
-    thread **       threads;             /* pointer to threads        */
+    thread        **threads;             /* pointer to threads        */
     volatile int    num_threads_alive;   /* threads currently alive   */
     volatile int    num_threads_working; /* threads currently working */
     pthread_mutex_t thcount_lock;        /* used for thread count etc */
@@ -122,7 +123,7 @@ thpool_init(int num_threads)
 
     /* Make new thread pool */
     thpool_ *thpool_p;
-    thpool_p = (struct thpool_ *)malloc(sizeof(struct thpool_));
+    thpool_p = (struct thpool_ *)PDC_malloc(sizeof(struct thpool_));
     if (thpool_p == NULL) {
         err("thpool_init(): Could not allocate memory for thread pool\n");
         return NULL;
@@ -133,16 +134,16 @@ thpool_init(int num_threads)
     /* Initialise the job queue */
     if (jobqueue_init(&thpool_p->jobqueue) == -1) {
         err("thpool_init(): Could not allocate memory for job queue\n");
-        free(thpool_p);
+        thpool_p = (thpool_ *)PDC_free(thpool_p);
         return NULL;
     }
 
     /* Make threads in pool */
-    thpool_p->threads = (struct thread **)malloc(num_threads * sizeof(struct thread *));
+    thpool_p->threads = (struct thread **)PDC_malloc(num_threads * sizeof(struct thread *));
     if (thpool_p->threads == NULL) {
         err("thpool_init(): Could not allocate memory for threads\n");
         jobqueue_destroy(&thpool_p->jobqueue);
-        free(thpool_p);
+        thpool_p = (thpool_ *)PDC_free(thpool_p);
         return NULL;
     }
 
@@ -171,7 +172,7 @@ thpool_add_work(thpool_ *thpool_p, void (*function_p)(void *), void *arg_p)
 {
     job *newjob;
 
-    newjob = (struct job *)malloc(sizeof(struct job));
+    newjob = (struct job *)PDC_malloc(sizeof(struct job));
     if (newjob == NULL) {
         err("thpool_add_work(): Could not allocate memory for new job\n");
         return -1;
@@ -235,8 +236,8 @@ thpool_destroy(thpool_ *thpool_p)
     for (n = 0; n < threads_total; n++) {
         thread_destroy(thpool_p->threads[n]);
     }
-    free(thpool_p->threads);
-    free(thpool_p);
+    thpool_p->threads = (thread **)PDC_free(thpool_p->threads);
+    thpool_p          = (thpool_ *)PDC_free(thpool_p);
 }
 
 /* Pause all threads in threadpool */
@@ -279,7 +280,7 @@ static int
 thread_init(thpool_ *thpool_p, struct thread **thread_p, int id)
 {
 
-    *thread_p = (struct thread *)malloc(sizeof(struct thread));
+    *thread_p = (struct thread *)PDC_malloc(sizeof(struct thread));
     if (thread_p == NULL) {
         err("thread_init(): Could not allocate memory for thread\n");
         return -1;
@@ -359,12 +360,12 @@ thread_do(struct thread *thread_p)
             /* Read job from queue and execute it */
             void (*func_buff)(void *);
             void *arg_buff;
-            job * job_p = jobqueue_pull(&thpool_p->jobqueue);
+            job  *job_p = jobqueue_pull(&thpool_p->jobqueue);
             if (job_p) {
                 func_buff = job_p->function;
                 arg_buff  = job_p->arg;
                 func_buff(arg_buff);
-                free(job_p);
+                job_p = (job *)PDC_free(job_p);
             }
 
             pthread_mutex_lock(&thpool_p->thcount_lock);
@@ -386,7 +387,7 @@ thread_do(struct thread *thread_p)
 static void
 thread_destroy(thread *thread_p)
 {
-    free(thread_p);
+    thread_p = (thread *)PDC_free(thread_p);
 }
 
 /* ============================ JOB QUEUE =========================== */
@@ -399,7 +400,7 @@ jobqueue_init(jobqueue *jobqueue_p)
     jobqueue_p->front = NULL;
     jobqueue_p->rear  = NULL;
 
-    jobqueue_p->has_jobs = (struct bsem *)malloc(sizeof(struct bsem));
+    jobqueue_p->has_jobs = (struct bsem *)PDC_malloc(sizeof(struct bsem));
     if (jobqueue_p->has_jobs == NULL) {
         return -1;
     }

--- a/src/server/dablooms/pdc_dablooms.c
+++ b/src/server/dablooms/pdc_dablooms.c
@@ -381,7 +381,7 @@ scaling_bloom_init(unsigned int capacity, double error_rate)
 {
     scaling_bloom_t *bloom;
 
-    if ((bloom = malloc(sizeof(scaling_bloom_t))) == NULL) {
+    if ((bloom = PDC_malloc(sizeof(scaling_bloom_t))) == NULL) {
         return NULL;
     }
     if ((bloom->bitmap = new_bitmap(sizeof(scaling_bloom_header_t))) == NULL) {
@@ -404,7 +404,7 @@ scaling_bloom_t *
 new_scaling_bloom(unsigned int capacity, double error_rate)
 {
 
-    scaling_bloom_t * bloom;
+    scaling_bloom_t  *bloom;
     counting_bloom_t *cur_bloom;
 
     bloom = scaling_bloom_init(capacity, error_rate);

--- a/src/server/dablooms/pdc_dablooms.c
+++ b/src/server/dablooms/pdc_dablooms.c
@@ -293,7 +293,7 @@ new_counting_bloom_from_scale(scaling_bloom_t *bloom)
 
     error_rate = bloom->error_rate * (pow(ERROR_TIGHTENING_RATIO, bloom->num_blooms + 1));
 
-    if ((bloom->blooms = realloc(bloom->blooms, (bloom->num_blooms + 1) * sizeof(counting_bloom_t *))) ==
+    if ((bloom->blooms = PDC_realloc(bloom->blooms, (bloom->num_blooms + 1) * sizeof(counting_bloom_t *))) ==
         NULL) {
         LOG_ERROR("Error, could not realloc a new bloom filter\n");
         return NULL;

--- a/src/server/dablooms/pdc_dablooms.c
+++ b/src/server/dablooms/pdc_dablooms.c
@@ -13,8 +13,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <errno.h>
-#include "pdc_malloc.h"
 
+#include "pdc_malloc.h"
 #include "pdc_murmur.h"
 #include "pdc_dablooms.h"
 #include "pdc_logger.h"
@@ -33,7 +33,7 @@ dablooms_version(void)
 void
 free_bitmap(bitmap_t *bitmap)
 {
-    free(bitmap);
+    bitmap = (bitmap_t *)PDC_free(bitmap);
 }
 
 bitmap_t *
@@ -169,10 +169,10 @@ int
 free_counting_bloom(counting_bloom_t *bloom)
 {
     if (bloom != NULL) {
-        free(bloom->hashes);
+        bloom->hashes = (uint32_t *)PDC_free(bloom->hashes);
         bloom->hashes = NULL;
-        free(bloom->bitmap);
-        free(bloom);
+        bloom->bitmap = (bitmap_t *)PDC_free(bloom->bitmap);
+        bloom = (counting_bloom_t *)PDC_free(bloom);
         bloom = NULL;
     }
     return 0;
@@ -276,9 +276,9 @@ free_scaling_bloom(scaling_bloom_t *bloom)
         free(bloom->blooms[i]);
         bloom->blooms[i] = NULL;
     }
-    free(bloom->blooms);
+    bloom->blooms = (counting_bloom_t **)PDC_free(bloom->blooms);
     free_bitmap(bloom->bitmap);
-    free(bloom);
+    bloom = (scaling_bloom_t *)PDC_free(bloom);
     return 0;
 }
 
@@ -404,7 +404,7 @@ scaling_bloom_t *
 new_scaling_bloom(unsigned int capacity, double error_rate)
 {
 
-    scaling_bloom_t * bloom;
+    scaling_bloom_t  *bloom;
     counting_bloom_t *cur_bloom;
 
     bloom = scaling_bloom_init(capacity, error_rate);

--- a/src/server/dablooms/pdc_dablooms.c
+++ b/src/server/dablooms/pdc_dablooms.c
@@ -172,8 +172,8 @@ free_counting_bloom(counting_bloom_t *bloom)
         bloom->hashes = (uint32_t *)PDC_free(bloom->hashes);
         bloom->hashes = NULL;
         bloom->bitmap = (bitmap_t *)PDC_free(bloom->bitmap);
-        bloom = (counting_bloom_t *)PDC_free(bloom);
-        bloom = NULL;
+        bloom         = (counting_bloom_t *)PDC_free(bloom);
+        bloom         = NULL;
     }
     return 0;
 }
@@ -271,10 +271,10 @@ free_scaling_bloom(scaling_bloom_t *bloom)
 {
     int i;
     for (i = bloom->num_blooms - 1; i >= 0; i--) {
-        free(bloom->blooms[i]->hashes);
+        bloom->blooms[i]->hashes = (uint32_t *)PDC_free(bloom->blooms[i]->hashes);
         bloom->blooms[i]->hashes = NULL;
-        free(bloom->blooms[i]);
-        bloom->blooms[i] = NULL;
+        bloom->blooms[i]         = (counting_bloom_t *)PDC_free(bloom->blooms[i]);
+        bloom->blooms[i]         = NULL;
     }
     bloom->blooms = (counting_bloom_t **)PDC_free(bloom->blooms);
     free_bitmap(bloom->bitmap);

--- a/src/server/dablooms/pdc_dablooms.c
+++ b/src/server/dablooms/pdc_dablooms.c
@@ -404,7 +404,7 @@ scaling_bloom_t *
 new_scaling_bloom(unsigned int capacity, double error_rate)
 {
 
-    scaling_bloom_t  *bloom;
+    scaling_bloom_t * bloom;
     counting_bloom_t *cur_bloom;
 
     bloom = scaling_bloom_init(capacity, error_rate);

--- a/src/server/include/pdc_client_server_common.h
+++ b/src/server/include/pdc_client_server_common.h
@@ -132,17 +132,17 @@ typedef struct pdc_kvtag_list_t {
 
 typedef struct get_storage_loc_args_t {
     perr_t (*cb)();
-    void           *cb_args;
+    void *          cb_args;
     region_list_t **region_lists;
     hg_handle_t     rpc_handle;
-    uint32_t       *n_loc;
-    void           *void_buf;
+    uint32_t *      n_loc;
+    void *          void_buf;
 } get_storage_loc_args_t;
 
 typedef struct update_region_storage_meta_bulk_args_t {
     perr_t (*cb)();
-    void       *meta_list_target;
-    int        *n_updated;
+    void *      meta_list_target;
+    int *       n_updated;
     int         server_id;
     hg_bulk_t   bulk_handle;
     hg_handle_t rpc_handle;
@@ -165,8 +165,8 @@ typedef struct region_list_t {
     int                   is_data_ready;
     char                  shm_addr[ADDR_MAX];
     int                   shm_fd;
-    pdc_histogram_t      *region_hist;
-    char                 *buf;
+    pdc_histogram_t *     region_hist;
+    char *                buf;
     _pdc_data_loc_t       data_loc_type;
     char                  storage_location[ADDR_MAX];
     uint64_t              offset;
@@ -259,7 +259,7 @@ typedef struct region_map_t {
     pdcid_t                local_reg_id;  /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t              *local_reg_size;
+    uint64_t *             local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -270,7 +270,7 @@ typedef struct region_map_t {
 } region_map_t;
 
 typedef struct region_buf_map_t {
-    void                             *remote_data_ptr;
+    void *                            remote_data_ptr;
     pdcid_t                           remote_obj_id; /* target of object id */
     pdcid_t                           remote_reg_id; /* target of region id */
     int32_t                           remote_client_id;
@@ -284,7 +284,7 @@ typedef struct region_buf_map_t {
     pdcid_t                local_reg_id; /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t              *local_reg_size;
+    uint64_t *             local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -326,8 +326,8 @@ typedef struct data_server_region_t {
     region_list_t *region_storage_head;
     // For non-mapped object analysis
     // Used primarily as a local_temp
-    void                        *obj_data_ptr;
-    char                        *storage_location; // save the file location to enable reopening
+    void *                       obj_data_ptr;
+    char *                       storage_location; // save the file location to enable reopening
     struct data_server_region_t *prev;
     struct data_server_region_t *next;
 } data_server_region_t;
@@ -336,7 +336,7 @@ typedef struct data_server_region_unmap_t {
     uint64_t obj_id;
 
     region_info_transfer_t unmap_region;
-    const struct hg_info  *info;
+    const struct hg_info * info;
 
     struct data_server_region_unmap_t *prev;
     struct data_server_region_unmap_t *next;
@@ -388,7 +388,7 @@ typedef struct pdc_metadata_t {
     // For hash table list
     struct pdc_metadata_t *prev;
     struct pdc_metadata_t *next;
-    void                  *bloom;
+    void *                 bloom;
 
 } pdc_metadata_t;
 
@@ -409,7 +409,7 @@ typedef struct query_read_names_args_t {
     int    cnt;
     int    is_select_all;
     char **obj_names;
-    char  *obj_names_1d;
+    char * obj_names_1d;
 } query_read_names_args_t;
 
 /********************************************************/
@@ -1101,7 +1101,7 @@ typedef struct pdc_query_xfer_t {
     int                     n_unique_obj;
     int                     query_op;
     int                     n_combine_ops;
-    int                    *combine_ops;
+    int *                   combine_ops;
     int                     n_constraints;
     int                     get_op;
     int                     next_server_id;
@@ -1132,7 +1132,7 @@ typedef struct query_storage_region_transfer_t {
     int                    manager;
     uint64_t               obj_id;
     region_info_transfer_t region_transfer;
-    char                  *storage_location;
+    char *                 storage_location;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
@@ -1156,10 +1156,10 @@ typedef struct {
 typedef struct {
     int8_t   op_type;
     int8_t   hash_algo;
-    char    *attr_key;
+    char *   attr_key;
     uint32_t attr_vsize;
     uint8_t  attr_vtype;
-    void    *attr_val;
+    void *   attr_val;
     uint64_t vnode_id;
     int8_t   obj_ref_type;
     uint64_t obj_primary_ref;
@@ -3959,10 +3959,10 @@ struct bulk_args_t {
     size_t            nbytes;
     int               origin;
     size_t            ret;
-    pdc_metadata_t  **meta_arr;
+    pdc_metadata_t ** meta_arr;
     uint32_t          n_meta;
     uint64_t          obj_id;
-    uint64_t         *obj_ids;
+    uint64_t *        obj_ids;
     int               client_seq_id;
     int               is_id; // if is_id == true, then use uint64_t; otherwise, pdc_metadata_t
     int8_t            op_type;
@@ -3986,7 +3986,7 @@ struct buf_map_release_bulk_args {
     double start_time;
 #endif
     hg_handle_t             handle;
-    void                   *data_buf;
+    void *                  data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4014,11 +4014,11 @@ struct buf_map_release_bulk_args {
 
 struct buf_map_transform_and_release_bulk_args {
     hg_handle_t                    handle;
-    void                          *data_buf;
+    void *                         data_buf;
     pdcid_t                        remote_obj_id; /* target of object id */
     pdcid_t                        remote_reg_id; /* target of region id */
     int32_t                        remote_client_id;
-    struct pdc_region_info        *remote_reg_info;
+    struct pdc_region_info *       remote_reg_info;
     region_info_transfer_t         remote_region;
     hg_bulk_t                      remote_bulk_handle;
     hg_bulk_t                      local_bulk_handle;
@@ -4032,7 +4032,7 @@ struct buf_map_transform_and_release_bulk_args {
 
 struct buf_map_analysis_and_release_bulk_args {
     hg_handle_t             handle;
-    void                   *data_buf;
+    void *                  data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4053,8 +4053,8 @@ struct lock_bulk_args {
     hg_handle_t             handle;
     region_lock_in_t        in;
     struct pdc_region_info *server_region;
-    void                   *data_buf;
-    region_map_t           *mapping_list;
+    void *                  data_buf;
+    region_map_t *          mapping_list;
     hg_addr_t               addr;
 };
 
@@ -4064,14 +4064,14 @@ struct region_lock_update_bulk_args {
     pdcid_t                 remote_obj_id;
     pdcid_t                 remote_reg_id;
     int32_t                 remote_client_id;
-    void                   *data_buf;
+    void *                  data_buf;
     struct pdc_region_info *server_region;
 };
 
 struct transfer_request_wait_all_local_bulk_args {
     hg_handle_t                    handle;
     hg_bulk_t                      bulk_handle;
-    void                          *data_buf;
+    void *                         data_buf;
     transfer_request_wait_all_in_t in;
 #ifdef PDC_TIMING
     double start_time;
@@ -4082,8 +4082,8 @@ struct transfer_request_all_local_bulk_args {
     hg_handle_t               handle;
     hg_bulk_t                 bulk_handle;
     transfer_request_all_in_t in;
-    uint64_t                 *transfer_request_id;
-    void                     *data_buf;
+    uint64_t *                transfer_request_id;
+    void *                    data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4093,8 +4093,8 @@ struct transfer_request_all_local_bulk_args2 {
     hg_handle_t               handle;
     transfer_request_all_data request_data;
     hg_bulk_t                 bulk_handle;
-    uint64_t                 *transfer_request_id;
-    void                     *data_buf;
+    uint64_t *                transfer_request_id;
+    void *                    data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4104,7 +4104,7 @@ struct transfer_request_metadata_query_local_bulk_args {
     hg_handle_t                          handle;
     hg_bulk_t                            bulk_handle;
     transfer_request_metadata_query_in_t in;
-    void                                *data_buf;
+    void *                               data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4113,7 +4113,7 @@ struct transfer_request_metadata_query_local_bulk_args {
 struct transfer_request_metadata_query2_local_bulk_args {
     hg_handle_t handle;
     hg_bulk_t   bulk_handle;
-    void       *data_buf;
+    void *      data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4124,7 +4124,7 @@ struct transfer_request_local_bulk_args {
     hg_bulk_t             bulk_handle;
     transfer_request_in_t in;
     uint64_t              transfer_request_id;
-    void                 *data_buf;
+    void *                data_buf;
     size_t                total_mem_size;
 
 #ifdef PDC_TIMING
@@ -4173,12 +4173,12 @@ typedef struct process_bulk_storage_meta_args_t {
 
 typedef struct region_meta_transfer_t {
     int                    loc_len;
-    char                  *storage_location;
+    char *                 storage_location;
     region_info_transfer_t region_info;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
-    pdc_histogram_t       *histogram;
+    pdc_histogram_t *      histogram;
 } region_meta_transfer_t;
 
 typedef struct storage_region_bulk_header_t {

--- a/src/server/include/pdc_client_server_common.h
+++ b/src/server/include/pdc_client_server_common.h
@@ -132,17 +132,17 @@ typedef struct pdc_kvtag_list_t {
 
 typedef struct get_storage_loc_args_t {
     perr_t (*cb)();
-    void *          cb_args;
+    void           *cb_args;
     region_list_t **region_lists;
     hg_handle_t     rpc_handle;
-    uint32_t *      n_loc;
-    void *          void_buf;
+    uint32_t       *n_loc;
+    void           *void_buf;
 } get_storage_loc_args_t;
 
 typedef struct update_region_storage_meta_bulk_args_t {
     perr_t (*cb)();
-    void *      meta_list_target;
-    int *       n_updated;
+    void       *meta_list_target;
+    int        *n_updated;
     int         server_id;
     hg_bulk_t   bulk_handle;
     hg_handle_t rpc_handle;
@@ -165,8 +165,8 @@ typedef struct region_list_t {
     int                   is_data_ready;
     char                  shm_addr[ADDR_MAX];
     int                   shm_fd;
-    pdc_histogram_t *     region_hist;
-    char *                buf;
+    pdc_histogram_t      *region_hist;
+    char                 *buf;
     _pdc_data_loc_t       data_loc_type;
     char                  storage_location[ADDR_MAX];
     uint64_t              offset;
@@ -259,7 +259,7 @@ typedef struct region_map_t {
     pdcid_t                local_reg_id;  /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t *             local_reg_size;
+    uint64_t              *local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -270,7 +270,7 @@ typedef struct region_map_t {
 } region_map_t;
 
 typedef struct region_buf_map_t {
-    void *                            remote_data_ptr;
+    void                             *remote_data_ptr;
     pdcid_t                           remote_obj_id; /* target of object id */
     pdcid_t                           remote_reg_id; /* target of region id */
     int32_t                           remote_client_id;
@@ -284,7 +284,7 @@ typedef struct region_buf_map_t {
     pdcid_t                local_reg_id; /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t *             local_reg_size;
+    uint64_t              *local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -326,8 +326,8 @@ typedef struct data_server_region_t {
     region_list_t *region_storage_head;
     // For non-mapped object analysis
     // Used primarily as a local_temp
-    void *                       obj_data_ptr;
-    char *                       storage_location; // save the file location to enable reopening
+    void                        *obj_data_ptr;
+    char                        *storage_location; // save the file location to enable reopening
     struct data_server_region_t *prev;
     struct data_server_region_t *next;
 } data_server_region_t;
@@ -336,7 +336,7 @@ typedef struct data_server_region_unmap_t {
     uint64_t obj_id;
 
     region_info_transfer_t unmap_region;
-    const struct hg_info * info;
+    const struct hg_info  *info;
 
     struct data_server_region_unmap_t *prev;
     struct data_server_region_unmap_t *next;
@@ -388,7 +388,7 @@ typedef struct pdc_metadata_t {
     // For hash table list
     struct pdc_metadata_t *prev;
     struct pdc_metadata_t *next;
-    void *                 bloom;
+    void                  *bloom;
 
 } pdc_metadata_t;
 
@@ -409,7 +409,7 @@ typedef struct query_read_names_args_t {
     int    cnt;
     int    is_select_all;
     char **obj_names;
-    char * obj_names_1d;
+    char  *obj_names_1d;
 } query_read_names_args_t;
 
 /********************************************************/
@@ -1101,7 +1101,7 @@ typedef struct pdc_query_xfer_t {
     int                     n_unique_obj;
     int                     query_op;
     int                     n_combine_ops;
-    int *                   combine_ops;
+    int                    *combine_ops;
     int                     n_constraints;
     int                     get_op;
     int                     next_server_id;
@@ -1132,7 +1132,7 @@ typedef struct query_storage_region_transfer_t {
     int                    manager;
     uint64_t               obj_id;
     region_info_transfer_t region_transfer;
-    char *                 storage_location;
+    char                  *storage_location;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
@@ -1156,10 +1156,10 @@ typedef struct {
 typedef struct {
     int8_t   op_type;
     int8_t   hash_algo;
-    char *   attr_key;
+    char    *attr_key;
     uint32_t attr_vsize;
     uint8_t  attr_vtype;
-    void *   attr_val;
+    void    *attr_val;
     uint64_t vnode_id;
     int8_t   obj_ref_type;
     uint64_t obj_primary_ref;
@@ -1212,7 +1212,7 @@ hg_proc_pdc_kvtag_t(hg_proc_t proc, void *data)
     if (struct_data->size) {
         switch (hg_proc_get_op(proc)) {
             case HG_DECODE:
-                struct_data->value = malloc(struct_data->size);
+                struct_data->value = PDC_malloc(struct_data->size);
                 /* HG_FALLTHROUGH(); */
                 /* FALLTHRU */
             case HG_ENCODE:
@@ -3241,8 +3241,8 @@ hg_proc_pdc_histogram_t(hg_proc_t proc, void *data)
     if (struct_data->nbin > 0) {
         switch (hg_proc_get_op(proc)) {
             case HG_DECODE:
-                struct_data->range = malloc(struct_data->nbin * sizeof(double) * 2);
-                struct_data->bin   = malloc(struct_data->nbin * sizeof(uint64_t));
+                struct_data->range = PDC_malloc(struct_data->nbin * sizeof(double) * 2);
+                struct_data->bin   = PDC_malloc(struct_data->nbin * sizeof(uint64_t));
                 /* HG_FALLTHROUGH(); */
                 /* FALLTHRU */
             case HG_ENCODE:
@@ -3873,7 +3873,7 @@ hg_proc_dart_perform_one_server_in_t(hg_proc_t proc, void *data)
     if (struct_data->attr_vsize) {
         switch (hg_proc_get_op(proc)) {
             case HG_DECODE:
-                struct_data->attr_val = malloc(struct_data->attr_vsize);
+                struct_data->attr_val = PDC_malloc(struct_data->attr_vsize);
                 break;
             case HG_ENCODE:
                 ret = hg_proc_raw(proc, struct_data->attr_val, struct_data->attr_vsize);
@@ -3958,10 +3958,10 @@ struct bulk_args_t {
     size_t            nbytes;
     int               origin;
     size_t            ret;
-    pdc_metadata_t ** meta_arr;
+    pdc_metadata_t  **meta_arr;
     uint32_t          n_meta;
     uint64_t          obj_id;
-    uint64_t *        obj_ids;
+    uint64_t         *obj_ids;
     int               client_seq_id;
     int               is_id; // if is_id == true, then use uint64_t; otherwise, pdc_metadata_t
     int8_t            op_type;
@@ -3985,7 +3985,7 @@ struct buf_map_release_bulk_args {
     double start_time;
 #endif
     hg_handle_t             handle;
-    void *                  data_buf;
+    void                   *data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4013,11 +4013,11 @@ struct buf_map_release_bulk_args {
 
 struct buf_map_transform_and_release_bulk_args {
     hg_handle_t                    handle;
-    void *                         data_buf;
+    void                          *data_buf;
     pdcid_t                        remote_obj_id; /* target of object id */
     pdcid_t                        remote_reg_id; /* target of region id */
     int32_t                        remote_client_id;
-    struct pdc_region_info *       remote_reg_info;
+    struct pdc_region_info        *remote_reg_info;
     region_info_transfer_t         remote_region;
     hg_bulk_t                      remote_bulk_handle;
     hg_bulk_t                      local_bulk_handle;
@@ -4031,7 +4031,7 @@ struct buf_map_transform_and_release_bulk_args {
 
 struct buf_map_analysis_and_release_bulk_args {
     hg_handle_t             handle;
-    void *                  data_buf;
+    void                   *data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4052,8 +4052,8 @@ struct lock_bulk_args {
     hg_handle_t             handle;
     region_lock_in_t        in;
     struct pdc_region_info *server_region;
-    void *                  data_buf;
-    region_map_t *          mapping_list;
+    void                   *data_buf;
+    region_map_t           *mapping_list;
     hg_addr_t               addr;
 };
 
@@ -4063,14 +4063,14 @@ struct region_lock_update_bulk_args {
     pdcid_t                 remote_obj_id;
     pdcid_t                 remote_reg_id;
     int32_t                 remote_client_id;
-    void *                  data_buf;
+    void                   *data_buf;
     struct pdc_region_info *server_region;
 };
 
 struct transfer_request_wait_all_local_bulk_args {
     hg_handle_t                    handle;
     hg_bulk_t                      bulk_handle;
-    void *                         data_buf;
+    void                          *data_buf;
     transfer_request_wait_all_in_t in;
 #ifdef PDC_TIMING
     double start_time;
@@ -4081,8 +4081,8 @@ struct transfer_request_all_local_bulk_args {
     hg_handle_t               handle;
     hg_bulk_t                 bulk_handle;
     transfer_request_all_in_t in;
-    uint64_t *                transfer_request_id;
-    void *                    data_buf;
+    uint64_t                 *transfer_request_id;
+    void                     *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4092,8 +4092,8 @@ struct transfer_request_all_local_bulk_args2 {
     hg_handle_t               handle;
     transfer_request_all_data request_data;
     hg_bulk_t                 bulk_handle;
-    uint64_t *                transfer_request_id;
-    void *                    data_buf;
+    uint64_t                 *transfer_request_id;
+    void                     *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4103,7 +4103,7 @@ struct transfer_request_metadata_query_local_bulk_args {
     hg_handle_t                          handle;
     hg_bulk_t                            bulk_handle;
     transfer_request_metadata_query_in_t in;
-    void *                               data_buf;
+    void                                *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4112,7 +4112,7 @@ struct transfer_request_metadata_query_local_bulk_args {
 struct transfer_request_metadata_query2_local_bulk_args {
     hg_handle_t handle;
     hg_bulk_t   bulk_handle;
-    void *      data_buf;
+    void       *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4123,7 +4123,7 @@ struct transfer_request_local_bulk_args {
     hg_bulk_t             bulk_handle;
     transfer_request_in_t in;
     uint64_t              transfer_request_id;
-    void *                data_buf;
+    void                 *data_buf;
     size_t                total_mem_size;
 
 #ifdef PDC_TIMING
@@ -4172,12 +4172,12 @@ typedef struct process_bulk_storage_meta_args_t {
 
 typedef struct region_meta_transfer_t {
     int                    loc_len;
-    char *                 storage_location;
+    char                  *storage_location;
     region_info_transfer_t region_info;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
-    pdc_histogram_t *      histogram;
+    pdc_histogram_t       *histogram;
 } region_meta_transfer_t;
 
 typedef struct storage_region_bulk_header_t {

--- a/src/server/include/pdc_client_server_common.h
+++ b/src/server/include/pdc_client_server_common.h
@@ -132,17 +132,17 @@ typedef struct pdc_kvtag_list_t {
 
 typedef struct get_storage_loc_args_t {
     perr_t (*cb)();
-    void           *cb_args;
+    void *          cb_args;
     region_list_t **region_lists;
     hg_handle_t     rpc_handle;
-    uint32_t       *n_loc;
-    void           *void_buf;
+    uint32_t *      n_loc;
+    void *          void_buf;
 } get_storage_loc_args_t;
 
 typedef struct update_region_storage_meta_bulk_args_t {
     perr_t (*cb)();
-    void       *meta_list_target;
-    int        *n_updated;
+    void *      meta_list_target;
+    int *       n_updated;
     int         server_id;
     hg_bulk_t   bulk_handle;
     hg_handle_t rpc_handle;
@@ -165,8 +165,8 @@ typedef struct region_list_t {
     int                   is_data_ready;
     char                  shm_addr[ADDR_MAX];
     int                   shm_fd;
-    pdc_histogram_t      *region_hist;
-    char                 *buf;
+    pdc_histogram_t *     region_hist;
+    char *                buf;
     _pdc_data_loc_t       data_loc_type;
     char                  storage_location[ADDR_MAX];
     uint64_t              offset;
@@ -259,7 +259,7 @@ typedef struct region_map_t {
     pdcid_t                local_reg_id;  /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t              *local_reg_size;
+    uint64_t *             local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -270,7 +270,7 @@ typedef struct region_map_t {
 } region_map_t;
 
 typedef struct region_buf_map_t {
-    void                             *remote_data_ptr;
+    void *                            remote_data_ptr;
     pdcid_t                           remote_obj_id; /* target of object id */
     pdcid_t                           remote_reg_id; /* target of region id */
     int32_t                           remote_client_id;
@@ -284,7 +284,7 @@ typedef struct region_buf_map_t {
     pdcid_t                local_reg_id; /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t              *local_reg_size;
+    uint64_t *             local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -326,8 +326,8 @@ typedef struct data_server_region_t {
     region_list_t *region_storage_head;
     // For non-mapped object analysis
     // Used primarily as a local_temp
-    void                        *obj_data_ptr;
-    char                        *storage_location; // save the file location to enable reopening
+    void *                       obj_data_ptr;
+    char *                       storage_location; // save the file location to enable reopening
     struct data_server_region_t *prev;
     struct data_server_region_t *next;
 } data_server_region_t;
@@ -336,7 +336,7 @@ typedef struct data_server_region_unmap_t {
     uint64_t obj_id;
 
     region_info_transfer_t unmap_region;
-    const struct hg_info  *info;
+    const struct hg_info * info;
 
     struct data_server_region_unmap_t *prev;
     struct data_server_region_unmap_t *next;
@@ -388,7 +388,7 @@ typedef struct pdc_metadata_t {
     // For hash table list
     struct pdc_metadata_t *prev;
     struct pdc_metadata_t *next;
-    void                  *bloom;
+    void *                 bloom;
 
 } pdc_metadata_t;
 
@@ -409,7 +409,7 @@ typedef struct query_read_names_args_t {
     int    cnt;
     int    is_select_all;
     char **obj_names;
-    char  *obj_names_1d;
+    char * obj_names_1d;
 } query_read_names_args_t;
 
 /********************************************************/
@@ -1101,7 +1101,7 @@ typedef struct pdc_query_xfer_t {
     int                     n_unique_obj;
     int                     query_op;
     int                     n_combine_ops;
-    int                    *combine_ops;
+    int *                   combine_ops;
     int                     n_constraints;
     int                     get_op;
     int                     next_server_id;
@@ -1132,7 +1132,7 @@ typedef struct query_storage_region_transfer_t {
     int                    manager;
     uint64_t               obj_id;
     region_info_transfer_t region_transfer;
-    char                  *storage_location;
+    char *                 storage_location;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
@@ -1156,10 +1156,10 @@ typedef struct {
 typedef struct {
     int8_t   op_type;
     int8_t   hash_algo;
-    char    *attr_key;
+    char *   attr_key;
     uint32_t attr_vsize;
     uint8_t  attr_vtype;
-    void    *attr_val;
+    void *   attr_val;
     uint64_t vnode_id;
     int8_t   obj_ref_type;
     uint64_t obj_primary_ref;
@@ -3958,10 +3958,10 @@ struct bulk_args_t {
     size_t            nbytes;
     int               origin;
     size_t            ret;
-    pdc_metadata_t  **meta_arr;
+    pdc_metadata_t ** meta_arr;
     uint32_t          n_meta;
     uint64_t          obj_id;
-    uint64_t         *obj_ids;
+    uint64_t *        obj_ids;
     int               client_seq_id;
     int               is_id; // if is_id == true, then use uint64_t; otherwise, pdc_metadata_t
     int8_t            op_type;
@@ -3985,7 +3985,7 @@ struct buf_map_release_bulk_args {
     double start_time;
 #endif
     hg_handle_t             handle;
-    void                   *data_buf;
+    void *                  data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4013,11 +4013,11 @@ struct buf_map_release_bulk_args {
 
 struct buf_map_transform_and_release_bulk_args {
     hg_handle_t                    handle;
-    void                          *data_buf;
+    void *                         data_buf;
     pdcid_t                        remote_obj_id; /* target of object id */
     pdcid_t                        remote_reg_id; /* target of region id */
     int32_t                        remote_client_id;
-    struct pdc_region_info        *remote_reg_info;
+    struct pdc_region_info *       remote_reg_info;
     region_info_transfer_t         remote_region;
     hg_bulk_t                      remote_bulk_handle;
     hg_bulk_t                      local_bulk_handle;
@@ -4031,7 +4031,7 @@ struct buf_map_transform_and_release_bulk_args {
 
 struct buf_map_analysis_and_release_bulk_args {
     hg_handle_t             handle;
-    void                   *data_buf;
+    void *                  data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4052,8 +4052,8 @@ struct lock_bulk_args {
     hg_handle_t             handle;
     region_lock_in_t        in;
     struct pdc_region_info *server_region;
-    void                   *data_buf;
-    region_map_t           *mapping_list;
+    void *                  data_buf;
+    region_map_t *          mapping_list;
     hg_addr_t               addr;
 };
 
@@ -4063,14 +4063,14 @@ struct region_lock_update_bulk_args {
     pdcid_t                 remote_obj_id;
     pdcid_t                 remote_reg_id;
     int32_t                 remote_client_id;
-    void                   *data_buf;
+    void *                  data_buf;
     struct pdc_region_info *server_region;
 };
 
 struct transfer_request_wait_all_local_bulk_args {
     hg_handle_t                    handle;
     hg_bulk_t                      bulk_handle;
-    void                          *data_buf;
+    void *                         data_buf;
     transfer_request_wait_all_in_t in;
 #ifdef PDC_TIMING
     double start_time;
@@ -4081,8 +4081,8 @@ struct transfer_request_all_local_bulk_args {
     hg_handle_t               handle;
     hg_bulk_t                 bulk_handle;
     transfer_request_all_in_t in;
-    uint64_t                 *transfer_request_id;
-    void                     *data_buf;
+    uint64_t *                transfer_request_id;
+    void *                    data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4092,8 +4092,8 @@ struct transfer_request_all_local_bulk_args2 {
     hg_handle_t               handle;
     transfer_request_all_data request_data;
     hg_bulk_t                 bulk_handle;
-    uint64_t                 *transfer_request_id;
-    void                     *data_buf;
+    uint64_t *                transfer_request_id;
+    void *                    data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4103,7 +4103,7 @@ struct transfer_request_metadata_query_local_bulk_args {
     hg_handle_t                          handle;
     hg_bulk_t                            bulk_handle;
     transfer_request_metadata_query_in_t in;
-    void                                *data_buf;
+    void *                               data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4112,7 +4112,7 @@ struct transfer_request_metadata_query_local_bulk_args {
 struct transfer_request_metadata_query2_local_bulk_args {
     hg_handle_t handle;
     hg_bulk_t   bulk_handle;
-    void       *data_buf;
+    void *      data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4123,7 +4123,7 @@ struct transfer_request_local_bulk_args {
     hg_bulk_t             bulk_handle;
     transfer_request_in_t in;
     uint64_t              transfer_request_id;
-    void                 *data_buf;
+    void *                data_buf;
     size_t                total_mem_size;
 
 #ifdef PDC_TIMING
@@ -4172,12 +4172,12 @@ typedef struct process_bulk_storage_meta_args_t {
 
 typedef struct region_meta_transfer_t {
     int                    loc_len;
-    char                  *storage_location;
+    char *                 storage_location;
     region_info_transfer_t region_info;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
-    pdc_histogram_t       *histogram;
+    pdc_histogram_t *      histogram;
 } region_meta_transfer_t;
 
 typedef struct storage_region_bulk_header_t {

--- a/src/server/include/pdc_client_server_common.h
+++ b/src/server/include/pdc_client_server_common.h
@@ -132,17 +132,17 @@ typedef struct pdc_kvtag_list_t {
 
 typedef struct get_storage_loc_args_t {
     perr_t (*cb)();
-    void *          cb_args;
+    void           *cb_args;
     region_list_t **region_lists;
     hg_handle_t     rpc_handle;
-    uint32_t *      n_loc;
-    void *          void_buf;
+    uint32_t       *n_loc;
+    void           *void_buf;
 } get_storage_loc_args_t;
 
 typedef struct update_region_storage_meta_bulk_args_t {
     perr_t (*cb)();
-    void *      meta_list_target;
-    int *       n_updated;
+    void       *meta_list_target;
+    int        *n_updated;
     int         server_id;
     hg_bulk_t   bulk_handle;
     hg_handle_t rpc_handle;
@@ -165,8 +165,8 @@ typedef struct region_list_t {
     int                   is_data_ready;
     char                  shm_addr[ADDR_MAX];
     int                   shm_fd;
-    pdc_histogram_t *     region_hist;
-    char *                buf;
+    pdc_histogram_t      *region_hist;
+    char                 *buf;
     _pdc_data_loc_t       data_loc_type;
     char                  storage_location[ADDR_MAX];
     uint64_t              offset;
@@ -259,7 +259,7 @@ typedef struct region_map_t {
     pdcid_t                local_reg_id;  /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t *             local_reg_size;
+    uint64_t              *local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -270,7 +270,7 @@ typedef struct region_map_t {
 } region_map_t;
 
 typedef struct region_buf_map_t {
-    void *                            remote_data_ptr;
+    void                             *remote_data_ptr;
     pdcid_t                           remote_obj_id; /* target of object id */
     pdcid_t                           remote_reg_id; /* target of region id */
     int32_t                           remote_client_id;
@@ -284,7 +284,7 @@ typedef struct region_buf_map_t {
     pdcid_t                local_reg_id; /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t *             local_reg_size;
+    uint64_t              *local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -326,8 +326,8 @@ typedef struct data_server_region_t {
     region_list_t *region_storage_head;
     // For non-mapped object analysis
     // Used primarily as a local_temp
-    void *                       obj_data_ptr;
-    char *                       storage_location; // save the file location to enable reopening
+    void                        *obj_data_ptr;
+    char                        *storage_location; // save the file location to enable reopening
     struct data_server_region_t *prev;
     struct data_server_region_t *next;
 } data_server_region_t;
@@ -336,7 +336,7 @@ typedef struct data_server_region_unmap_t {
     uint64_t obj_id;
 
     region_info_transfer_t unmap_region;
-    const struct hg_info * info;
+    const struct hg_info  *info;
 
     struct data_server_region_unmap_t *prev;
     struct data_server_region_unmap_t *next;
@@ -388,7 +388,7 @@ typedef struct pdc_metadata_t {
     // For hash table list
     struct pdc_metadata_t *prev;
     struct pdc_metadata_t *next;
-    void *                 bloom;
+    void                  *bloom;
 
 } pdc_metadata_t;
 
@@ -409,7 +409,7 @@ typedef struct query_read_names_args_t {
     int    cnt;
     int    is_select_all;
     char **obj_names;
-    char * obj_names_1d;
+    char  *obj_names_1d;
 } query_read_names_args_t;
 
 /********************************************************/
@@ -1101,7 +1101,7 @@ typedef struct pdc_query_xfer_t {
     int                     n_unique_obj;
     int                     query_op;
     int                     n_combine_ops;
-    int *                   combine_ops;
+    int                    *combine_ops;
     int                     n_constraints;
     int                     get_op;
     int                     next_server_id;
@@ -1132,7 +1132,7 @@ typedef struct query_storage_region_transfer_t {
     int                    manager;
     uint64_t               obj_id;
     region_info_transfer_t region_transfer;
-    char *                 storage_location;
+    char                  *storage_location;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
@@ -1156,10 +1156,10 @@ typedef struct {
 typedef struct {
     int8_t   op_type;
     int8_t   hash_algo;
-    char *   attr_key;
+    char    *attr_key;
     uint32_t attr_vsize;
     uint8_t  attr_vtype;
-    void *   attr_val;
+    void    *attr_val;
     uint64_t vnode_id;
     int8_t   obj_ref_type;
     uint64_t obj_primary_ref;
@@ -3874,7 +3874,8 @@ hg_proc_dart_perform_one_server_in_t(hg_proc_t proc, void *data)
         switch (hg_proc_get_op(proc)) {
             case HG_DECODE:
                 struct_data->attr_val = PDC_malloc(struct_data->attr_vsize);
-                break;
+                /* HG_FALLTHROUGH(); */
+                /* FALLTHRU */
             case HG_ENCODE:
                 ret = hg_proc_raw(proc, struct_data->attr_val, struct_data->attr_vsize);
                 break;
@@ -3958,10 +3959,10 @@ struct bulk_args_t {
     size_t            nbytes;
     int               origin;
     size_t            ret;
-    pdc_metadata_t ** meta_arr;
+    pdc_metadata_t  **meta_arr;
     uint32_t          n_meta;
     uint64_t          obj_id;
-    uint64_t *        obj_ids;
+    uint64_t         *obj_ids;
     int               client_seq_id;
     int               is_id; // if is_id == true, then use uint64_t; otherwise, pdc_metadata_t
     int8_t            op_type;
@@ -3985,7 +3986,7 @@ struct buf_map_release_bulk_args {
     double start_time;
 #endif
     hg_handle_t             handle;
-    void *                  data_buf;
+    void                   *data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4013,11 +4014,11 @@ struct buf_map_release_bulk_args {
 
 struct buf_map_transform_and_release_bulk_args {
     hg_handle_t                    handle;
-    void *                         data_buf;
+    void                          *data_buf;
     pdcid_t                        remote_obj_id; /* target of object id */
     pdcid_t                        remote_reg_id; /* target of region id */
     int32_t                        remote_client_id;
-    struct pdc_region_info *       remote_reg_info;
+    struct pdc_region_info        *remote_reg_info;
     region_info_transfer_t         remote_region;
     hg_bulk_t                      remote_bulk_handle;
     hg_bulk_t                      local_bulk_handle;
@@ -4031,7 +4032,7 @@ struct buf_map_transform_and_release_bulk_args {
 
 struct buf_map_analysis_and_release_bulk_args {
     hg_handle_t             handle;
-    void *                  data_buf;
+    void                   *data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4052,8 +4053,8 @@ struct lock_bulk_args {
     hg_handle_t             handle;
     region_lock_in_t        in;
     struct pdc_region_info *server_region;
-    void *                  data_buf;
-    region_map_t *          mapping_list;
+    void                   *data_buf;
+    region_map_t           *mapping_list;
     hg_addr_t               addr;
 };
 
@@ -4063,14 +4064,14 @@ struct region_lock_update_bulk_args {
     pdcid_t                 remote_obj_id;
     pdcid_t                 remote_reg_id;
     int32_t                 remote_client_id;
-    void *                  data_buf;
+    void                   *data_buf;
     struct pdc_region_info *server_region;
 };
 
 struct transfer_request_wait_all_local_bulk_args {
     hg_handle_t                    handle;
     hg_bulk_t                      bulk_handle;
-    void *                         data_buf;
+    void                          *data_buf;
     transfer_request_wait_all_in_t in;
 #ifdef PDC_TIMING
     double start_time;
@@ -4081,8 +4082,8 @@ struct transfer_request_all_local_bulk_args {
     hg_handle_t               handle;
     hg_bulk_t                 bulk_handle;
     transfer_request_all_in_t in;
-    uint64_t *                transfer_request_id;
-    void *                    data_buf;
+    uint64_t                 *transfer_request_id;
+    void                     *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4092,8 +4093,8 @@ struct transfer_request_all_local_bulk_args2 {
     hg_handle_t               handle;
     transfer_request_all_data request_data;
     hg_bulk_t                 bulk_handle;
-    uint64_t *                transfer_request_id;
-    void *                    data_buf;
+    uint64_t                 *transfer_request_id;
+    void                     *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4103,7 +4104,7 @@ struct transfer_request_metadata_query_local_bulk_args {
     hg_handle_t                          handle;
     hg_bulk_t                            bulk_handle;
     transfer_request_metadata_query_in_t in;
-    void *                               data_buf;
+    void                                *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4112,7 +4113,7 @@ struct transfer_request_metadata_query_local_bulk_args {
 struct transfer_request_metadata_query2_local_bulk_args {
     hg_handle_t handle;
     hg_bulk_t   bulk_handle;
-    void *      data_buf;
+    void       *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4123,7 +4124,7 @@ struct transfer_request_local_bulk_args {
     hg_bulk_t             bulk_handle;
     transfer_request_in_t in;
     uint64_t              transfer_request_id;
-    void *                data_buf;
+    void                 *data_buf;
     size_t                total_mem_size;
 
 #ifdef PDC_TIMING
@@ -4172,12 +4173,12 @@ typedef struct process_bulk_storage_meta_args_t {
 
 typedef struct region_meta_transfer_t {
     int                    loc_len;
-    char *                 storage_location;
+    char                  *storage_location;
     region_info_transfer_t region_info;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
-    pdc_histogram_t *      histogram;
+    pdc_histogram_t       *histogram;
 } region_meta_transfer_t;
 
 typedef struct storage_region_bulk_header_t {

--- a/src/server/include/pdc_client_server_common.h
+++ b/src/server/include/pdc_client_server_common.h
@@ -31,6 +31,7 @@
 #include "pdc_prop_pkg.h"
 #include "pdc_analysis_and_transforms_common.h"
 #include "pdc_query.h"
+#include "pdc_malloc.h"
 
 #include "pdc_timing.h"
 #include "pdc_server_region_transfer_metadata_query.h"
@@ -131,17 +132,17 @@ typedef struct pdc_kvtag_list_t {
 
 typedef struct get_storage_loc_args_t {
     perr_t (*cb)();
-    void *          cb_args;
+    void           *cb_args;
     region_list_t **region_lists;
     hg_handle_t     rpc_handle;
-    uint32_t *      n_loc;
-    void *          void_buf;
+    uint32_t       *n_loc;
+    void           *void_buf;
 } get_storage_loc_args_t;
 
 typedef struct update_region_storage_meta_bulk_args_t {
     perr_t (*cb)();
-    void *      meta_list_target;
-    int *       n_updated;
+    void       *meta_list_target;
+    int        *n_updated;
     int         server_id;
     hg_bulk_t   bulk_handle;
     hg_handle_t rpc_handle;
@@ -164,8 +165,8 @@ typedef struct region_list_t {
     int                   is_data_ready;
     char                  shm_addr[ADDR_MAX];
     int                   shm_fd;
-    pdc_histogram_t *     region_hist;
-    char *                buf;
+    pdc_histogram_t      *region_hist;
+    char                 *buf;
     _pdc_data_loc_t       data_loc_type;
     char                  storage_location[ADDR_MAX];
     uint64_t              offset;
@@ -258,7 +259,7 @@ typedef struct region_map_t {
     pdcid_t                local_reg_id;  /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t *             local_reg_size;
+    uint64_t              *local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -269,7 +270,7 @@ typedef struct region_map_t {
 } region_map_t;
 
 typedef struct region_buf_map_t {
-    void *                            remote_data_ptr;
+    void                             *remote_data_ptr;
     pdcid_t                           remote_obj_id; /* target of object id */
     pdcid_t                           remote_reg_id; /* target of region id */
     int32_t                           remote_client_id;
@@ -283,7 +284,7 @@ typedef struct region_buf_map_t {
     pdcid_t                local_reg_id; /* origin of region id */
     region_info_transfer_t local_region;
     size_t                 local_ndim;
-    uint64_t *             local_reg_size;
+    uint64_t              *local_reg_size;
     hg_addr_t              local_addr;
     hg_bulk_t              local_bulk_handle;
     pdc_var_type_t         local_data_type;
@@ -325,8 +326,8 @@ typedef struct data_server_region_t {
     region_list_t *region_storage_head;
     // For non-mapped object analysis
     // Used primarily as a local_temp
-    void *                       obj_data_ptr;
-    char *                       storage_location; // save the file location to enable reopening
+    void                        *obj_data_ptr;
+    char                        *storage_location; // save the file location to enable reopening
     struct data_server_region_t *prev;
     struct data_server_region_t *next;
 } data_server_region_t;
@@ -335,7 +336,7 @@ typedef struct data_server_region_unmap_t {
     uint64_t obj_id;
 
     region_info_transfer_t unmap_region;
-    const struct hg_info * info;
+    const struct hg_info  *info;
 
     struct data_server_region_unmap_t *prev;
     struct data_server_region_unmap_t *next;
@@ -387,7 +388,7 @@ typedef struct pdc_metadata_t {
     // For hash table list
     struct pdc_metadata_t *prev;
     struct pdc_metadata_t *next;
-    void *                 bloom;
+    void                  *bloom;
 
 } pdc_metadata_t;
 
@@ -408,7 +409,7 @@ typedef struct query_read_names_args_t {
     int    cnt;
     int    is_select_all;
     char **obj_names;
-    char * obj_names_1d;
+    char  *obj_names_1d;
 } query_read_names_args_t;
 
 /********************************************************/
@@ -1100,7 +1101,7 @@ typedef struct pdc_query_xfer_t {
     int                     n_unique_obj;
     int                     query_op;
     int                     n_combine_ops;
-    int *                   combine_ops;
+    int                    *combine_ops;
     int                     n_constraints;
     int                     get_op;
     int                     next_server_id;
@@ -1131,7 +1132,7 @@ typedef struct query_storage_region_transfer_t {
     int                    manager;
     uint64_t               obj_id;
     region_info_transfer_t region_transfer;
-    char *                 storage_location;
+    char                  *storage_location;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
@@ -1155,10 +1156,10 @@ typedef struct {
 typedef struct {
     int8_t   op_type;
     int8_t   hash_algo;
-    char *   attr_key;
+    char    *attr_key;
     uint32_t attr_vsize;
     uint8_t  attr_vtype;
-    void *   attr_val;
+    void    *attr_val;
     uint64_t vnode_id;
     int8_t   obj_ref_type;
     uint64_t obj_primary_ref;
@@ -1218,7 +1219,7 @@ hg_proc_pdc_kvtag_t(hg_proc_t proc, void *data)
                 ret = hg_proc_raw(proc, struct_data->value, struct_data->size);
                 break;
             case HG_FREE:
-                free(struct_data->value);
+                struct_data->value = (void *)PDC_free(struct_data->value);
             default:
                 break;
         }
@@ -3250,9 +3251,9 @@ hg_proc_pdc_histogram_t(hg_proc_t proc, void *data)
                 break;
             case HG_FREE:
                 if (struct_data->range)
-                    free(struct_data->range);
+                    struct_data->range = (double *)PDC_free(struct_data->range);
                 if (struct_data->bin)
-                    free(struct_data->bin);
+                    struct_data->bin = (uint64_t *)PDC_free(struct_data->bin);
                 /* FALLTHRU */
             default:
                 break;
@@ -3819,80 +3820,67 @@ hg_proc_dart_perform_one_server_in_t(hg_proc_t proc, void *data)
     dart_perform_one_server_in_t *struct_data = (dart_perform_one_server_in_t *)data;
     ret                                       = hg_proc_int8_t(proc, &struct_data->op_type);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_int8_t(proc, &struct_data->hash_algo);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_hg_string_t(proc, &struct_data->attr_key);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint32_t(proc, &struct_data->attr_vsize);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint8_t(proc, &struct_data->attr_vtype);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint64_t(proc, &struct_data->vnode_id);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_int8_t(proc, &struct_data->obj_ref_type);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint64_t(proc, &struct_data->obj_primary_ref);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint64_t(proc, &struct_data->obj_secondary_ref);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint64_t(proc, &struct_data->obj_server_ref);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_int8_t(proc, &struct_data->inserting_suffix);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_int64_t(proc, &struct_data->timestamp);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     ret = hg_proc_uint32_t(proc, &struct_data->src_client_id);
     if (ret != HG_SUCCESS) {
-
         return ret;
     }
     if (struct_data->attr_vsize) {
         switch (hg_proc_get_op(proc)) {
             case HG_DECODE:
                 struct_data->attr_val = malloc(struct_data->attr_vsize);
-                /* HG_FALLTHROUGH(); */
-                /* FALLTHRU */
+                break;
             case HG_ENCODE:
                 ret = hg_proc_raw(proc, struct_data->attr_val, struct_data->attr_vsize);
                 break;
             case HG_FREE:
-                free(struct_data->attr_val);
+                struct_data->attr_val = (void *)PDC_free(struct_data->attr_val);
+                break;
             default:
                 break;
         }
@@ -3970,10 +3958,10 @@ struct bulk_args_t {
     size_t            nbytes;
     int               origin;
     size_t            ret;
-    pdc_metadata_t ** meta_arr;
+    pdc_metadata_t  **meta_arr;
     uint32_t          n_meta;
     uint64_t          obj_id;
-    uint64_t *        obj_ids;
+    uint64_t         *obj_ids;
     int               client_seq_id;
     int               is_id; // if is_id == true, then use uint64_t; otherwise, pdc_metadata_t
     int8_t            op_type;
@@ -3997,7 +3985,7 @@ struct buf_map_release_bulk_args {
     double start_time;
 #endif
     hg_handle_t             handle;
-    void *                  data_buf;
+    void                   *data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4025,11 +4013,11 @@ struct buf_map_release_bulk_args {
 
 struct buf_map_transform_and_release_bulk_args {
     hg_handle_t                    handle;
-    void *                         data_buf;
+    void                          *data_buf;
     pdcid_t                        remote_obj_id; /* target of object id */
     pdcid_t                        remote_reg_id; /* target of region id */
     int32_t                        remote_client_id;
-    struct pdc_region_info *       remote_reg_info;
+    struct pdc_region_info        *remote_reg_info;
     region_info_transfer_t         remote_region;
     hg_bulk_t                      remote_bulk_handle;
     hg_bulk_t                      local_bulk_handle;
@@ -4043,7 +4031,7 @@ struct buf_map_transform_and_release_bulk_args {
 
 struct buf_map_analysis_and_release_bulk_args {
     hg_handle_t             handle;
-    void *                  data_buf;
+    void                   *data_buf;
     pdcid_t                 remote_obj_id; /* target of object id */
     pdcid_t                 remote_reg_id; /* target of region id */
     int32_t                 remote_client_id;
@@ -4064,8 +4052,8 @@ struct lock_bulk_args {
     hg_handle_t             handle;
     region_lock_in_t        in;
     struct pdc_region_info *server_region;
-    void *                  data_buf;
-    region_map_t *          mapping_list;
+    void                   *data_buf;
+    region_map_t           *mapping_list;
     hg_addr_t               addr;
 };
 
@@ -4075,14 +4063,14 @@ struct region_lock_update_bulk_args {
     pdcid_t                 remote_obj_id;
     pdcid_t                 remote_reg_id;
     int32_t                 remote_client_id;
-    void *                  data_buf;
+    void                   *data_buf;
     struct pdc_region_info *server_region;
 };
 
 struct transfer_request_wait_all_local_bulk_args {
     hg_handle_t                    handle;
     hg_bulk_t                      bulk_handle;
-    void *                         data_buf;
+    void                          *data_buf;
     transfer_request_wait_all_in_t in;
 #ifdef PDC_TIMING
     double start_time;
@@ -4093,8 +4081,8 @@ struct transfer_request_all_local_bulk_args {
     hg_handle_t               handle;
     hg_bulk_t                 bulk_handle;
     transfer_request_all_in_t in;
-    uint64_t *                transfer_request_id;
-    void *                    data_buf;
+    uint64_t                 *transfer_request_id;
+    void                     *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4104,8 +4092,8 @@ struct transfer_request_all_local_bulk_args2 {
     hg_handle_t               handle;
     transfer_request_all_data request_data;
     hg_bulk_t                 bulk_handle;
-    uint64_t *                transfer_request_id;
-    void *                    data_buf;
+    uint64_t                 *transfer_request_id;
+    void                     *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4115,7 +4103,7 @@ struct transfer_request_metadata_query_local_bulk_args {
     hg_handle_t                          handle;
     hg_bulk_t                            bulk_handle;
     transfer_request_metadata_query_in_t in;
-    void *                               data_buf;
+    void                                *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4124,7 +4112,7 @@ struct transfer_request_metadata_query_local_bulk_args {
 struct transfer_request_metadata_query2_local_bulk_args {
     hg_handle_t handle;
     hg_bulk_t   bulk_handle;
-    void *      data_buf;
+    void       *data_buf;
 #ifdef PDC_TIMING
     double start_time;
 #endif
@@ -4135,7 +4123,7 @@ struct transfer_request_local_bulk_args {
     hg_bulk_t             bulk_handle;
     transfer_request_in_t in;
     uint64_t              transfer_request_id;
-    void *                data_buf;
+    void                 *data_buf;
     size_t                total_mem_size;
 
 #ifdef PDC_TIMING
@@ -4184,12 +4172,12 @@ typedef struct process_bulk_storage_meta_args_t {
 
 typedef struct region_meta_transfer_t {
     int                    loc_len;
-    char *                 storage_location;
+    char                  *storage_location;
     region_info_transfer_t region_info;
     uint64_t               offset;
     uint64_t               size;
     int                    has_hist;
-    pdc_histogram_t *      histogram;
+    pdc_histogram_t       *histogram;
 } region_meta_transfer_t;
 
 typedef struct storage_region_bulk_header_t {

--- a/src/server/pdc_client_server_common.c
+++ b/src/server/pdc_client_server_common.c
@@ -807,10 +807,10 @@ PDC_region_transfer_t_to_region_info(region_info_transfer_t *transfer)
     if (NULL == transfer)
         PGOTO_ERROR(NULL, "PDC_region_transfer_t_to_region_info(): NULL input!");
 
-    region = (struct pdc_region_info *)calloc(1, sizeof(struct pdc_region_info));
+    region = (struct pdc_region_info *)PDC_calloc(1, sizeof(struct pdc_region_info));
     ndim = region->ndim = transfer->ndim;
-    region->offset      = (uint64_t *)calloc(sizeof(uint64_t), ndim);
-    region->size        = (uint64_t *)calloc(sizeof(uint64_t), ndim);
+    region->offset      = (uint64_t *)PDC_calloc(sizeof(uint64_t), ndim);
+    region->size        = (uint64_t *)PDC_calloc(sizeof(uint64_t), ndim);
 
     PDC_copy_region_desc(transfer->start, region->offset, ndim, ndim);
     PDC_copy_region_desc(transfer->count, region->size, ndim, ndim);
@@ -1508,7 +1508,8 @@ HG_TEST_RPC_CB(client_test_connect, handle)
     hg_return_t               ret_value = HG_SUCCESS;
     client_test_connect_in_t  in;
     client_test_connect_out_t out;
-    client_test_connect_args *args = (client_test_connect_args *)calloc(1, sizeof(client_test_connect_args));
+    client_test_connect_args *args =
+        (client_test_connect_args *)PDC_calloc(1, sizeof(client_test_connect_args));
 
     FUNC_ENTER(NULL);
 
@@ -1830,7 +1831,7 @@ HG_TEST_RPC_CB(notify_io_complete, handle)
     HG_Get_input(handle, &in);
     pdc_access_t type = (pdc_access_t)in.io_type;
 
-    client_read_info_t *read_info = (client_read_info_t *)calloc(1, sizeof(client_read_info_t));
+    client_read_info_t *read_info = (client_read_info_t *)PDC_calloc(1, sizeof(client_read_info_t));
     read_info->obj_id             = in.obj_id;
     strcpy(read_info->shm_addr, in.shm_addr);
     if (ret_value != HG_SUCCESS)
@@ -2012,16 +2013,16 @@ pdc_region_write_out_progress(void *arg)
     remote_reg_info->offset = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
     remote_reg_info->size   = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
     if (remote_reg_info->ndim >= 1) {
-        (remote_reg_info->offset)[0] = (bulk_args->remote_region_nounit).start_0;
-        (remote_reg_info->size)[0]   = (bulk_args->remote_region_nounit).count_0;
+        (remote_reg_info->offset)[0] = (bulk_args->remote_region_nounit).start[0];
+        (remote_reg_info->size)[0]   = (bulk_args->remote_region_nounit).count[0];
     }
     if (remote_reg_info->ndim >= 2) {
-        (remote_reg_info->offset)[1] = (bulk_args->remote_region_nounit).start_1;
-        (remote_reg_info->size)[1]   = (bulk_args->remote_region_nounit).count_1;
+        (remote_reg_info->offset)[1] = (bulk_args->remote_region_nounit).start[1];
+        (remote_reg_info->size)[1]   = (bulk_args->remote_region_nounit).count[1];
     }
     if (remote_reg_info->ndim >= 3) {
-        (remote_reg_info->offset)[2] = (bulk_args->remote_region_nounit).start_2;
-        (remote_reg_info->size)[2]   = (bulk_args->remote_region_nounit).count_2;
+        (remote_reg_info->offset)[2] = (bulk_args->remote_region_nounit).start[2];
+        (remote_reg_info->size)[2]   = (bulk_args->remote_region_nounit).count[2];
     }
 
     PDC_Server_data_write_out(bulk_args->remote_obj_id, remote_reg_info, bulk_args->data_buf,
@@ -2034,7 +2035,7 @@ pdc_region_write_out_progress(void *arg)
 
     remote_reg_info->offset = (uint64_t *)PDC_free(remote_reg_info->offset);
     remote_reg_info->size   = (uint64_t *)PDC_free(remote_reg_info->size);
-    remote_reg_info         = (pdc_region_info *)PDC_free(remote_reg_info);
+    remote_reg_info         = (struct pdc_region_info *)PDC_free(remote_reg_info);
 
 done:
     fflush(stdout);
@@ -2247,7 +2248,7 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
 
             else {
                 /* Prepare for the transform */
-                dims = (uint64_t *)calloc(ndim, sizeof(uint64_t));
+                dims = (uint64_t *)PDC_calloc(ndim, sizeof(uint64_t));
                 if (dims == NULL)
                     PGOTO_ERROR(HG_OTHER_ERROR, "TRANSFORM memory allocation failed");
                 dims[0] = bulk_args->remote_region.count[0] / type_extent;
@@ -2280,12 +2281,12 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
     target_reg = PDC_Server_get_obj_region(bulk_args->remote_obj_id);
     DL_FOREACH(target_reg->region_buf_map_head, elt)
     {
-        if ((bulk_args->remote_region).start_0 == elt->remote_region_unit.start_0 &&
-            (bulk_args->remote_region).count_0 == elt->remote_region_unit.count_0) {
+        if ((bulk_args->remote_region).start[0] == elt->remote_region_unit.start[0] &&
+            (bulk_args->remote_region).count[0] == elt->remote_region_unit.count[0]) {
             // replace the count_0 value with the transform_size
             if (use_transform_size) {
-                (bulk_args->remote_region).count_0 = transform_size;
-                (bulk_args->remote_region).ndim    = 1;
+                (bulk_args->remote_region).count[0] = transform_size;
+                (bulk_args->remote_region).ndim     = 1;
             }
             elt->bulk_args = (struct buf_map_release_bulk_args *)bulk_args;
         }
@@ -2361,7 +2362,7 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
 
     /* Prepare for the transform */
     ndim        = bulk_args->remote_region.ndim;
-    dims        = (uint64_t *)calloc(ndim, sizeof(uint64_t));
+    dims        = (uint64_t *)PDC_calloc(ndim, sizeof(uint64_t));
     type_extent = bulk_args->in.type_extent;
     /* FIXME: Support ONLY up to 4 dimensions */
     if (dims) {
@@ -2420,8 +2421,8 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
      * multiply all size argments to find the byte length of the data_buf...
      */
     remote_reg_info->ndim   = (bulk_args->remote_region).ndim;
-    remote_reg_info->offset = (uint64_t *)calloc(remote_reg_info->ndim, sizeof(uint64_t));
-    remote_reg_info->size   = (uint64_t *)calloc(remote_reg_info->ndim, sizeof(uint64_t));
+    remote_reg_info->offset = (uint64_t *)PDC_calloc(remote_reg_info->ndim, sizeof(uint64_t));
+    remote_reg_info->size   = (uint64_t *)PDC_calloc(remote_reg_info->ndim, sizeof(uint64_t));
 
     PDC_copy_region_desc((bulk_args->remote_region).start, remote_reg_info->offset, remote_reg_info->ndim,
                          remote_reg_info->ndim);
@@ -2440,8 +2441,8 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
         PGOTO_ERROR(HG_OTHER_ERROR, "local_reg_info memory allocation failed");
 
     local_reg_info->ndim   = bulk_args->in.region.ndim;
-    local_reg_info->offset = (uint64_t *)calloc(local_reg_info->ndim, sizeof(uint64_t));
-    local_reg_info->size   = (uint64_t *)calloc(local_reg_info->ndim, sizeof(uint64_t));
+    local_reg_info->offset = (uint64_t *)PDC_calloc(local_reg_info->ndim, sizeof(uint64_t));
+    local_reg_info->size   = (uint64_t *)PDC_calloc(local_reg_info->ndim, sizeof(uint64_t));
 
     PDC_copy_region_desc(bulk_args->in.region.start, local_reg_info->offset, local_reg_info->ndim,
                          local_reg_info->ndim);
@@ -2530,7 +2531,8 @@ buf_map_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     target_reg = PDC_Server_get_obj_region(bulk_args->remote_obj_id);
     DL_FOREACH(target_reg->region_buf_map_head, elt)
     {
-        if (PDC_region_info_transfer_t_is_equal(bulk_args->remote_region_unit, elt->remote_region_unit)) {
+        if (PDC_region_info_transfer_t_is_equal(&(bulk_args->remote_region_unit),
+                                                &(elt->remote_region_unit))) {
             elt->bulk_args = bulk_args;
         }
     }
@@ -2725,7 +2727,7 @@ HG_TEST_RPC_CB(region_release, handle)
                 hg_atomic_get32(&(elt->buf_map_refcount)) == 0) {
                 dirty_reg = 1;
                 size      = HG_Bulk_get_size(elt->bulk_handle);
-                data_buf  = (void *)calloc(1, size);
+                data_buf  = (void *)PDC_calloc(1, size);
                 // data transfer
                 server_region         = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
                 server_region->ndim   = 1;
@@ -3554,7 +3556,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                 hg_atomic_get32(&(elt->buf_map_refcount)) == 0) {
                 dirty_reg = 1;
                 size      = HG_Bulk_get_size(elt->bulk_handle);
-                data_buf  = (void *)calloc(1, size);
+                data_buf  = (void *)PDC_calloc(1, size);
                 // data transfer
                 server_region         = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
                 server_region->ndim   = 1;
@@ -4350,7 +4352,7 @@ update_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
         PGOTO_ERROR(HG_PROTOCOL_ERROR, "Error in callback");
     else {
         cnt = bulk_args->cnt;
-        buf = (void **)calloc(sizeof(void *), cnt);
+        buf = (void **)PDC_calloc(sizeof(void *), cnt);
 
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, &buf_1d, NULL, NULL);
 
@@ -4542,7 +4544,7 @@ HG_TEST_RPC_CB(data_server_read_check, handle)
     // Decode input
     data_server_read_check_in_t  in;
     data_server_read_check_out_t out;
-    server_read_check_out_t     *read_out = calloc(1, sizeof(server_read_check_out_t));
+    server_read_check_out_t     *read_out = PDC_calloc(1, sizeof(server_read_check_out_t));
 
     FUNC_ENTER(NULL);
 
@@ -4575,7 +4577,7 @@ HG_TEST_RPC_CB(data_server_write_check, handle)
     // Decode input
     data_server_write_check_in_t   in;
     data_server_write_check_out_t *out =
-        (data_server_write_check_out_t *)calloc(sizeof(data_server_write_check_out_t), 1);
+        (data_server_write_check_out_t *)PDC_calloc(sizeof(data_server_write_check_out_t), 1);
 
     FUNC_ENTER(NULL);
 
@@ -4611,7 +4613,7 @@ HG_TEST_RPC_CB(update_region_loc, handle)
 
     if (in.has_hist == 1) {
 
-        input_region->region_hist = (pdc_histogram_t *)calloc(1, sizeof(pdc_histogram_t));
+        input_region->region_hist = (pdc_histogram_t *)PDC_calloc(1, sizeof(pdc_histogram_t));
         PDC_copy_hist(input_region->region_hist, &in.hist);
     }
 
@@ -4823,7 +4825,7 @@ cont_add_del_objs_bulk_cb(const struct hg_cb_info *hg_cb_info)
 
         op      = bulk_args->op;
         cont_id = bulk_args->cont_id;
-        obj_ids = (uint64_t *)calloc(sizeof(uint64_t), cnt);
+        obj_ids = (uint64_t *)PDC_calloc(sizeof(uint64_t), cnt);
 
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, (void **)&obj_ids, NULL,
                        NULL);
@@ -4959,13 +4961,13 @@ query_read_obj_name_bulk_cb(const struct hg_cb_info *hg_cb_info)
         PGOTO_ERROR(HG_PROTOCOL_ERROR, "Error in callback");
     }
     else {
-        query_read_names_args      = (query_read_names_args_t *)calloc(1, sizeof(query_read_names_args_t));
-        query_read_names_args->cnt = bulk_args->cnt;
+        query_read_names_args = (query_read_names_args_t *)PDC_calloc(1, sizeof(query_read_names_args_t));
+        query_read_names_args->cnt           = bulk_args->cnt;
         query_read_names_args->client_seq_id = bulk_args->client_seq_id;
         query_read_names_args->client_id     = bulk_args->origin;
         query_read_names_args->is_select_all = 1;
-        query_read_names_args->obj_names     = (char **)calloc(sizeof(char *), bulk_args->cnt);
-        query_read_names_args->obj_names_1d  = (char *)calloc(sizeof(char), bulk_args->nbytes);
+        query_read_names_args->obj_names     = (char **)PDC_calloc(sizeof(char *), bulk_args->cnt);
+        query_read_names_args->obj_names_1d  = (char *)PDC_calloc(sizeof(char), bulk_args->nbytes);
 
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, (void **)&tmp_buf, NULL,
                        NULL);
@@ -5065,7 +5067,7 @@ HG_TEST_RPC_CB(storage_meta_name_query_rpc, handle)
 
     HG_Get_input(handle, &in);
     // Duplicate the structure so we can continue to use it after leaving this function
-    args            = (storage_meta_name_query_in_t *)calloc(1, sizeof(storage_meta_name_query_in_t));
+    args            = (storage_meta_name_query_in_t *)PDC_calloc(1, sizeof(storage_meta_name_query_in_t));
     args->obj_name  = strdup(in.obj_name);
     args->task_id   = in.task_id;
     args->origin_id = in.origin_id;
@@ -5132,7 +5134,7 @@ get_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     }
     else {
         n_regions = bulk_args->cnt;
-        buf       = (void *)calloc(1, bulk_args->nbytes);
+        buf       = (void *)PDC_calloc(1, bulk_args->nbytes);
 
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, &buf, NULL, NULL);
 
@@ -5150,7 +5152,7 @@ get_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
             offset     = *uint64_ptr;
             uint64_ptr++;
             region_info_ptr = (region_info_transfer_t *)uint64_ptr;
-            region_list     = (region_list_t *)calloc(1, sizeof(region_list_t));
+            region_list     = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
             PDC_init_region_list(region_list);
             PDC_region_transfer_t_to_list_t(region_info_ptr, region_list);
             strcpy(region_list->storage_location, file_path);
@@ -5345,7 +5347,7 @@ PDC_add_task_to_list(pdc_task_list_t **target_list, perr_t (*cb)(), void *cb_arg
     if (target_list == NULL)
         PGOTO_ERROR(-1, "== NULL input!");
 
-    new_task          = (pdc_task_list_t *)calloc(1, sizeof(pdc_task_list_t));
+    new_task          = (pdc_task_list_t *)PDC_calloc(1, sizeof(pdc_task_list_t));
     new_task->cb      = cb;
     new_task->cb_args = cb_args;
 
@@ -5538,7 +5540,7 @@ HG_TEST_RPC_CB(send_shm, handle)
 
     HG_Get_input(handle, &in);
 
-    shm_info            = (pdc_shm_info_t *)calloc(sizeof(pdc_shm_info_t), 1);
+    shm_info            = (pdc_shm_info_t *)PDC_calloc(sizeof(pdc_shm_info_t), 1);
     shm_info->client_id = in.client_id;
     shm_info->size      = in.size;
     strcpy(shm_info->shm_addr, in.shm_addr);
@@ -5574,13 +5576,13 @@ query_read_obj_name_client_bulk_cb(const struct hg_cb_info *hg_cb_info)
         PGOTO_ERROR(HG_PROTOCOL_ERROR, "Error in callback");
     }
     else {
-        query_read_names_args      = (query_read_names_args_t *)calloc(1, sizeof(query_read_names_args_t));
-        query_read_names_args->cnt = bulk_args->cnt;
+        query_read_names_args = (query_read_names_args_t *)PDC_calloc(1, sizeof(query_read_names_args_t));
+        query_read_names_args->cnt           = bulk_args->cnt;
         query_read_names_args->client_seq_id = bulk_args->client_seq_id;
         query_read_names_args->client_id     = bulk_args->origin;
         query_read_names_args->is_select_all = 1;
-        query_read_names_args->obj_names     = (char **)calloc(sizeof(char *), bulk_args->cnt);
-        query_read_names_args->obj_names_1d  = (char *)calloc(sizeof(char), bulk_args->nbytes);
+        query_read_names_args->obj_names     = (char **)PDC_calloc(sizeof(char *), bulk_args->cnt);
+        query_read_names_args->obj_names_1d  = (char *)PDC_calloc(sizeof(char), bulk_args->nbytes);
 
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, (void **)&tmp_buf, NULL,
                        NULL);
@@ -5689,7 +5691,7 @@ send_client_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
         memcpy(buf_cp, buf, bulk_args->nbytes);
 
         process_args =
-            (process_bulk_storage_meta_args_t *)calloc(sizeof(process_bulk_storage_meta_args_t), 1);
+            (process_bulk_storage_meta_args_t *)PDC_calloc(sizeof(process_bulk_storage_meta_args_t), 1);
         process_args->origin_id        = bulk_args->origin;
         process_args->n_storage_meta   = bulk_args->cnt;
         process_args->seq_id           = *((int *)buf_cp);
@@ -5993,7 +5995,7 @@ HG_TEST_RPC_CB(send_bulk_rpc, handle)
     if (ret_value != HG_SUCCESS)
         PGOTO_ERROR(ret_value, "Could not get input");
 
-    bulk_arg                = (struct bulk_args_t *)calloc(1, sizeof(struct bulk_args_t));
+    bulk_arg                = (struct bulk_args_t *)PDC_calloc(1, sizeof(struct bulk_args_t));
     bulk_arg->cnt           = in_struct.cnt;
     bulk_arg->total         = in_struct.total;
     bulk_arg->origin        = in_struct.origin;
@@ -6091,8 +6093,8 @@ HG_TEST_RPC_CB(dart_perform_one_server, handle)
     // Extract input from handle
     HG_Get_input(handle, &in);
 
-    n_obj_ids_ptr = (uint64_t *)calloc(1, sizeof(uint64_t));
-    buf_ptrs      = (uint64_t **)calloc(1, sizeof(uint64_t *));
+    n_obj_ids_ptr = (uint64_t *)PDC_calloc(1, sizeof(uint64_t));
+    buf_ptrs      = (uint64_t **)PDC_calloc(1, sizeof(uint64_t *));
 
     stopwatch_t server_timer;
     timer_start(&server_timer);
@@ -6113,7 +6115,7 @@ HG_TEST_RPC_CB(dart_perform_one_server, handle)
     }
 
     n_buf        = 1;
-    buf_sizes    = (size_t *)calloc(n_buf, sizeof(size_t));
+    buf_sizes    = (size_t *)PDC_calloc(n_buf, sizeof(size_t));
     buf_sizes[0] = sizeof(uint64_t) * (*n_obj_ids_ptr);
 
     // Create bulk handle
@@ -6711,12 +6713,12 @@ deSerialize(pdc_query_t **root, pdc_query_constraint_t *constraints, int *constr
         PGOTO_DONE_VOID;
     }
 
-    *root               = (pdc_query_t *)calloc(1, sizeof(pdc_query_t));
+    *root               = (pdc_query_t *)PDC_calloc(1, sizeof(pdc_query_t));
     (*root)->combine_op = combine_ops[*order_idx];
 
     if (combine_ops[*order_idx] == 0) {
         // Current node is leaf
-        (*root)->constraint = (pdc_query_constraint_t *)calloc(1, sizeof(pdc_query_constraint_t));
+        (*root)->constraint = (pdc_query_constraint_t *)PDC_calloc(1, sizeof(pdc_query_constraint_t));
         memcpy((*root)->constraint, &constraints[*constraint_idx], sizeof(pdc_query_constraint_t));
         (*constraint_idx)++;
     }
@@ -6834,17 +6836,17 @@ PDC_serialize_query(pdc_query_t *query)
     if (NULL == query)
         PGOTO_ERROR(NULL, "NULL input");
 
-    query_xfer = (pdc_query_xfer_t *)calloc(1, sizeof(pdc_query_xfer_t));
+    query_xfer = (pdc_query_xfer_t *)PDC_calloc(1, sizeof(pdc_query_xfer_t));
     nnode      = PDC_query_get_nnode(query);
 
     nleaf = 0;
     PDC_query_get_nleaf(query, &nleaf);
 
     query_xfer->n_constraints = nleaf;
-    query_xfer->constraints   = (pdc_query_constraint_t *)calloc(nleaf, sizeof(pdc_query_constraint_t));
+    query_xfer->constraints   = (pdc_query_constraint_t *)PDC_calloc(nleaf, sizeof(pdc_query_constraint_t));
 
     query_xfer->n_combine_ops = nnode * 2 + 1;
-    query_xfer->combine_ops   = (int *)calloc(nnode * 2 + 1, sizeof(int));
+    query_xfer->combine_ops   = (int *)PDC_calloc(nnode * 2 + 1, sizeof(int));
 
     ops_cnt = constraint_cnt = 0;
     serialize(query, query_xfer->combine_ops, &ops_cnt, query_xfer->constraints, &constraint_cnt);

--- a/src/server/pdc_client_server_common.c
+++ b/src/server/pdc_client_server_common.c
@@ -144,8 +144,7 @@ hg_proc_pdc_query_xfer_t(hg_proc_t proc, void *data)
                                   struct_data->n_constraints * sizeof(pdc_query_constraint_t));
                 break;
             case HG_FREE:
-                // free(struct_data->combine_ops); // Something is wrong with these 2 free
-                // free(struct_data->constraints);
+                // FIXME:: need to free struct_data->combine_ops & struct_data->constraints
             default:
                 break;
         }
@@ -1571,7 +1570,7 @@ HG_TEST_RPC_CB(metadata_query, handle)
     hg_return_t          ret_value = HG_SUCCESS;
     metadata_query_in_t  in;
     metadata_query_out_t out;
-    pdc_metadata_t *     query_result = NULL;
+    pdc_metadata_t      *query_result = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -1612,7 +1611,7 @@ HG_TEST_RPC_CB(obj_reset_dims, handle)
     hg_return_t          ret_value = HG_SUCCESS;
     obj_reset_dims_in_t  in;
     obj_reset_dims_out_t out;
-    pdc_metadata_t *     query_result = NULL;
+    pdc_metadata_t      *query_result = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -2000,18 +1999,18 @@ pdc_region_write_out_progress(void *arg)
 {
     HG_THREAD_RETURN_TYPE             ret_value       = (HG_THREAD_RETURN_TYPE)0;
     struct buf_map_release_bulk_args *bulk_args       = (struct buf_map_release_bulk_args *)arg;
-    struct pdc_region_info *          remote_reg_info = NULL;
+    struct pdc_region_info           *remote_reg_info = NULL;
     region_lock_out_t                 out;
 
     FUNC_ENTER(NULL);
 
-    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     if (remote_reg_info == NULL) {
         PGOTO_ERROR(ret_value, "pdc_region_write_out_progress: remote_reg_info memory allocation failed");
     }
     remote_reg_info->ndim   = (bulk_args->remote_region_nounit).ndim;
-    remote_reg_info->offset = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
-    remote_reg_info->size   = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
+    remote_reg_info->offset = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
+    remote_reg_info->size   = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
     if (remote_reg_info->ndim >= 1) {
         (remote_reg_info->offset)[0] = (bulk_args->remote_region_nounit).start_0;
         (remote_reg_info->size)[0]   = (bulk_args->remote_region_nounit).count_0;
@@ -2100,7 +2099,7 @@ pdc_region_read_from_progress(void *arg)
 {
     HG_THREAD_RETURN_TYPE             ret_value = (HG_THREAD_RETURN_TYPE)0;
     struct buf_map_release_bulk_args *bulk_args = (struct buf_map_release_bulk_args *)arg;
-    const struct hg_info *            hg_info   = NULL;
+    const struct hg_info             *hg_info   = NULL;
     hg_return_t                       hg_ret;
     size_t                            size;
     int                               error = 0;
@@ -2153,21 +2152,21 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
     hg_return_t                                     ret_value = HG_SUCCESS;
     region_lock_out_t                               out;
     struct buf_map_transform_and_release_bulk_args *bulk_args = NULL;
-    void *                                          data_buf;
-    char *                                          buf;
+    void                                           *data_buf;
+    char                                           *buf;
     int                                             ndim;
     int                                             transform_id;
     int                                             type_extent        = 0;
     int                                             use_transform_size = 0;
     size_t                                          unit               = 1;
     int64_t                                         transform_size, expected_size;
-    uint64_t *                                      dims = NULL;
+    uint64_t                                       *dims = NULL;
     pdc_var_type_t                                  destType;
-    struct _pdc_region_transform_ftn_info **        registry = NULL;
+    struct _pdc_region_transform_ftn_info         **registry = NULL;
     int                                             registered_count;
 #ifdef ENABLE_MULTITHREAD
     data_server_region_t *target_reg = NULL;
-    region_buf_map_t *    elt;
+    region_buf_map_t     *elt;
 #else
     struct pdc_region_info *remote_reg_info = NULL;
 #endif
@@ -2294,13 +2293,13 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
 
     hg_thread_pool_post(hg_test_thread_pool_fs_g, &(bulk_args->work));
 #else
-    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     if (remote_reg_info == NULL)
         PGOTO_ERROR(HG_OTHER_ERROR, "remote_reg_info memory allocation failed");
 
     remote_reg_info->ndim        = (bulk_args->remote_region).ndim;
-    remote_reg_info->offset      = (uint64_t *)malloc(sizeof(uint64_t));
-    remote_reg_info->size        = (uint64_t *)malloc(sizeof(uint64_t));
+    remote_reg_info->offset      = (uint64_t *)PDC_malloc(sizeof(uint64_t));
+    remote_reg_info->size        = (uint64_t *)PDC_malloc(sizeof(uint64_t));
     (remote_reg_info->offset)[0] = (bulk_args->remote_region).start[0];
     if (use_transform_size)
         (remote_reg_info->size)[0] = transform_size;
@@ -2338,12 +2337,12 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
     hg_return_t                                    ret_value = HG_SUCCESS;
     region_lock_out_t                              out;
     struct buf_map_analysis_and_release_bulk_args *bulk_args = NULL;
-    void *                                         data_buf;
+    void                                          *data_buf;
     int                                            ndim;
     uint64_t                                       type_extent;
-    uint64_t *                                     dims            = NULL;
-    struct pdc_region_info *                       remote_reg_info = NULL;
-    struct pdc_region_info *                       local_reg_info  = NULL;
+    uint64_t                                      *dims            = NULL;
+    struct pdc_region_info                        *remote_reg_info = NULL;
+    struct pdc_region_info                        *local_reg_info  = NULL;
     double                                         start_t, end_t, analysis_t, io_t;
     double                                         averages[4];
 
@@ -2396,7 +2395,7 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
 
         int registered_count = PDC_get_analysis_registry(&registry);
         if ((registered_count >= analysis_meta_index) && (registry != NULL)) {
-            int (*analysis_ftn)(pdcid_t iterIn, pdcid_t iterOut, struct _pdc_iterator_cbs_t * _cbs) =
+            int (*analysis_ftn)(pdcid_t iterIn, pdcid_t iterOut, struct _pdc_iterator_cbs_t *_cbs) =
                 registry[analysis_meta_index]->ftnPtr;
             int result = analysis_ftn(bulk_args->in.input_iter, bulk_args->in.output_iter, &iter_cbs);
             LOG_INFO("==PDC_SERVER: Analysis returned %d\n", result);
@@ -2407,7 +2406,7 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
     analysis_t = end_t - start_t;
     start_t    = end_t;
 #endif
-    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     if (remote_reg_info == NULL)
         PGOTO_ERROR(HG_OTHER_ERROR, "remote_reg_info memory allocation failed");
 
@@ -2436,7 +2435,7 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
     io_t  = end_t - start_t;
 #endif
     PDC_Data_Server_region_release((region_lock_in_t *)&bulk_args->in, &out);
-    local_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    local_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     if (local_reg_info == NULL)
         PGOTO_ERROR(HG_OTHER_ERROR, "local_reg_info memory allocation failed");
 
@@ -2495,7 +2494,7 @@ buf_map_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct buf_map_release_bulk_args *bulk_args = NULL;
 #ifdef ENABLE_MULTITHREAD
     data_server_region_t *target_reg = NULL;
-    region_buf_map_t *    elt;
+    region_buf_map_t     *elt;
 #else
     struct pdc_region_info *remote_reg_info = NULL;
 #endif
@@ -2539,13 +2538,13 @@ buf_map_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     hg_thread_pool_post(hg_test_thread_pool_fs_g, &(bulk_args->work));
 
 #else
-    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     if (remote_reg_info == NULL)
         PGOTO_ERROR(HG_OTHER_ERROR, "remote_reg_info memory allocation failed\n");
 
     remote_reg_info->ndim   = (bulk_args->remote_region_nounit).ndim;
-    remote_reg_info->offset = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
-    remote_reg_info->size   = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
+    remote_reg_info->offset = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
+    remote_reg_info->size   = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
 
     PDC_copy_region_desc(bulk_args->remote_region_nounit.start, remote_reg_info->offset,
                          remote_reg_info->ndim, remote_reg_info->ndim);
@@ -2680,23 +2679,23 @@ HG_TEST_RPC_CB(region_release, handle)
     hg_return_t                          hg_ret;
     region_lock_in_t                     in;
     region_lock_out_t                    out;
-    const struct hg_info *               hg_info = NULL;
-    data_server_region_t *               target_obj;
+    const struct hg_info                *hg_info = NULL;
+    data_server_region_t                *target_obj;
     int                                  error     = 0;
     int                                  dirty_reg = 0;
     hg_size_t                            size, size2;
-    void *                               data_buf;
-    struct pdc_region_info *             server_region;
-    region_list_t *                      elt, *request_region, *tmp, *elt_tmp;
+    void                                *data_buf;
+    struct pdc_region_info              *server_region;
+    region_list_t                       *elt, *request_region, *tmp, *elt_tmp;
     struct region_lock_update_bulk_args *lock_update_bulk_args = NULL;
-    struct buf_map_release_bulk_args *   buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
+    struct buf_map_release_bulk_args    *buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
     hg_bulk_t                            lock_local_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                            remote_bulk_handle     = HG_BULK_NULL;
-    struct pdc_region_info *             remote_reg_info;
-    region_buf_map_t *                   eltt, *eltt2, *eltt_tmp;
+    struct pdc_region_info              *remote_reg_info;
+    region_buf_map_t                    *eltt, *eltt2, *eltt_tmp;
     hg_uint32_t /*k, m, */               remote_count;
-    void **                              data_ptrs_to = NULL;
-    size_t *                             data_size_to = NULL;
+    void                               **data_ptrs_to = NULL;
+    size_t                              *data_size_to = NULL;
     // size_t                               type_size    = 0;
     // size_t                               dims[4]      = {0, 0, 0, 0};
 #ifdef PDC_TIMING
@@ -2714,7 +2713,7 @@ HG_TEST_RPC_CB(region_release, handle)
 
     if (in.access_type == PDC_READ) {
         // check region is dirty or not, if dirty transfer data
-        request_region = (region_list_t *)malloc(sizeof(region_list_t));
+        request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&in.region, request_region);
         target_obj = PDC_Server_get_obj_region(in.obj_id);
 #ifdef ENABLE_MULTITHREAD
@@ -2728,10 +2727,10 @@ HG_TEST_RPC_CB(region_release, handle)
                 size      = HG_Bulk_get_size(elt->bulk_handle);
                 data_buf  = (void *)calloc(1, size);
                 // data transfer
-                server_region              = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
-                server_region->ndim        = 1;
-                server_region->size        = (uint64_t *)malloc(sizeof(uint64_t));
-                server_region->offset      = (uint64_t *)malloc(sizeof(uint64_t));
+                server_region         = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
+                server_region->ndim   = 1;
+                server_region->size   = (uint64_t *)PDC_malloc(sizeof(uint64_t));
+                server_region->offset = (uint64_t *)PDC_malloc(sizeof(uint64_t));
                 (server_region->size)[0]   = size;
                 (server_region->offset)[0] = in.region.start[0];
 
@@ -2743,7 +2742,7 @@ HG_TEST_RPC_CB(region_release, handle)
                 if (hg_ret != HG_SUCCESS)
                     PGOTO_ERROR(hg_ret, "==PDC SERVER ERROR: Could not create bulk data handle");
 
-                lock_update_bulk_args = (struct region_lock_update_bulk_args *)malloc(
+                lock_update_bulk_args = (struct region_lock_update_bulk_args *)PDC_malloc(
                     sizeof(struct region_lock_update_bulk_args));
                 lock_update_bulk_args->handle           = handle;
                 lock_update_bulk_args->in               = in;
@@ -2764,7 +2763,7 @@ HG_TEST_RPC_CB(region_release, handle)
             if (PDC_is_same_region_list(request_region, elt) == 1 && elt->reg_dirty_from_buf == 1 &&
                 hg_atomic_get32(&(elt->buf_map_refcount)) > 0) {
                 dirty_reg = 1;
-                tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+                tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 DL_FOREACH_SAFE(target_obj->region_buf_map_head, eltt2, eltt_tmp)
                 {
                     PDC_region_transfer_t_to_list_t(&(eltt2->remote_region_unit), tmp);
@@ -2773,8 +2772,8 @@ HG_TEST_RPC_CB(region_release, handle)
                         data_buf = PDC_Server_get_region_buf_ptr(in.obj_id, in.region);
                         if (in.region.ndim > 0) {
                             remote_count  = 1;
-                            data_ptrs_to  = (void **)malloc(sizeof(void *));
-                            data_size_to  = (size_t *)malloc(sizeof(size_t));
+                            data_ptrs_to  = (void **)PDC_malloc(sizeof(void *));
+                            data_size_to  = (size_t *)PDC_malloc(sizeof(size_t));
                             *data_ptrs_to = data_buf;
                             PDC_copy_region_desc_bytes_to_elements((eltt2->remote_region_unit).count,
                                                                    data_size_to, in.region.ndim,
@@ -2791,14 +2790,15 @@ HG_TEST_RPC_CB(region_release, handle)
                         free(data_ptrs_to);
                         free(data_size_to);
 
-                        remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+                        remote_reg_info =
+                            (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
                         if (remote_reg_info == NULL) {
                             error = 1;
                             PGOTO_ERROR(HG_OTHER_ERROR, "==PDC SERVER:HG_TEST_RPC_CB(region_release, handle) "
                                                         "remote_reg_info memory allocation failed");
                         }
 
-                        obj_map_bulk_args = (struct buf_map_release_bulk_args *)malloc(
+                        obj_map_bulk_args = (struct buf_map_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_release_bulk_args));
                         memset(obj_map_bulk_args, 0, sizeof(struct buf_map_release_bulk_args));
                         obj_map_bulk_args->handle = handle;
@@ -2819,8 +2819,9 @@ HG_TEST_RPC_CB(region_release, handle)
 #endif
                         remote_reg_info->ndim = (obj_map_bulk_args->remote_region_unit).ndim;
                         remote_reg_info->offset =
-                            (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
-                        remote_reg_info->size = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
+                            (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
+                        remote_reg_info->size =
+                            (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
 
                         PDC_copy_region_desc(obj_map_bulk_args->remote_region_nounit.start,
                                              remote_reg_info->offset, remote_reg_info->ndim,
@@ -2889,7 +2890,7 @@ HG_TEST_RPC_CB(region_release, handle)
     // write lock release with mapping case
     // do data tranfer if it is write lock release with mapping.
     else {
-        request_region = (region_list_t *)malloc(sizeof(region_list_t));
+        request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&in.region, request_region);
         target_obj = PDC_Server_get_obj_region(in.obj_id);
 #ifdef ENABLE_MULTITHREAD
@@ -2900,7 +2901,7 @@ HG_TEST_RPC_CB(region_release, handle)
             if (PDC_is_same_region_list(request_region, elt) == 1 && elt->reg_dirty_from_buf == 1 &&
                 hg_atomic_get32(&(elt->buf_map_refcount)) > 0) {
                 dirty_reg = 1;
-                tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+                tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 DL_FOREACH(target_obj->region_buf_map_head, eltt)
                 {
                     PDC_region_transfer_t_to_list_t(&(eltt->remote_region_unit), tmp);
@@ -2910,8 +2911,8 @@ HG_TEST_RPC_CB(region_release, handle)
                         data_buf = PDC_Server_get_region_buf_ptr(in.obj_id, in.region);
                         if (in.region.ndim > 0) {
                             remote_count  = 1;
-                            data_ptrs_to  = (void **)malloc(sizeof(void *));
-                            data_size_to  = (size_t *)malloc(sizeof(size_t));
+                            data_ptrs_to  = (void **)PDC_malloc(sizeof(void *));
+                            data_size_to  = (size_t *)PDC_malloc(sizeof(size_t));
                             *data_ptrs_to = data_buf;
                             PDC_copy_region_desc_bytes_to_elements((eltt2->remote_region_unit).count,
                                                                    data_size_to, in.region.ndim,
@@ -2928,7 +2929,7 @@ HG_TEST_RPC_CB(region_release, handle)
                         free(data_ptrs_to);
                         free(data_size_to);
 
-                        buf_map_bulk_args = (struct buf_map_release_bulk_args *)malloc(
+                        buf_map_bulk_args = (struct buf_map_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_release_bulk_args));
                         if (buf_map_bulk_args == NULL) {
                             error = 1;
@@ -3036,10 +3037,10 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             remote_bulk_handle = HG_BULK_NULL;
     hg_uint32_t           remote_count;
-    void *                data_buf = NULL;
+    void                 *data_buf = NULL;
     ;
-    void **           data_ptrs_to = NULL;
-    size_t *          data_size_to = NULL;
+    void            **data_ptrs_to = NULL;
+    size_t           *data_size_to = NULL;
     region_buf_map_t *eltt2;
     region_lock_out_t out;
 
@@ -3048,9 +3049,9 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
     int    dirty_reg = 0;
 
     struct buf_map_transform_and_release_bulk_args *transform_release_bulk_args = NULL;
-    struct pdc_region_info *                        remote_reg_info             = NULL;
-    data_server_region_t *                          target_obj                  = NULL;
-    region_list_t *tmp, *elt, *request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    struct pdc_region_info                         *remote_reg_info             = NULL;
+    data_server_region_t                           *target_obj                  = NULL;
+    region_list_t *tmp, *elt, *request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
 
     FUNC_ENTER(NULL);
 
@@ -3074,7 +3075,7 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
         if ((PDC_is_same_region_list(request_region, elt) == 1) && (elt->reg_dirty_from_buf == 1) &&
             (hg_atomic_get32(&(elt->buf_map_refcount)) > 0)) {
             dirty_reg = 1;
-            tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+            tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
             DL_FOREACH(target_obj->region_buf_map_head, eltt2)
             {
                 PDC_region_transfer_t_to_list_t(&(eltt2->remote_region_unit), tmp);
@@ -3083,8 +3084,8 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
                     remote_count                = 1;
                     // get remote object memory addr
                     data_buf     = PDC_Server_get_region_buf_ptr(in->obj_id, in->region);
-                    data_ptrs_to = (void **)malloc(sizeof(void *));
-                    data_size_to = (size_t *)malloc(sizeof(size_t));
+                    data_ptrs_to = (void **)PDC_malloc(sizeof(void *));
+                    data_size_to = (size_t *)PDC_malloc(sizeof(size_t));
                     if ((data_ptrs_to == NULL) || (data_size_to == NULL)) {
                         PGOTO_ERROR(HG_OTHER_ERROR, "==PDC SERVER: Memory allocation failed");
                     }
@@ -3108,9 +3109,10 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
                     free(data_ptrs_to);
                     free(data_size_to);
 
-                    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
-                    transform_release_bulk_args = (struct buf_map_transform_and_release_bulk_args *)malloc(
-                        sizeof(struct buf_map_transform_and_release_bulk_args));
+                    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
+                    transform_release_bulk_args =
+                        (struct buf_map_transform_and_release_bulk_args *)PDC_malloc(
+                            sizeof(struct buf_map_transform_and_release_bulk_args));
                     if ((remote_reg_info == NULL) || (transform_release_bulk_args == NULL))
                         PGOTO_ERROR(HG_OTHER_ERROR, "==PDC SERVER: Memory allocation failed");
 
@@ -3126,8 +3128,8 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
                     transform_release_bulk_args->local_addr         = eltt2->local_addr;
                     transform_release_bulk_args->in                 = *in;
 
-                    remote_reg_info->offset = (uint64_t *)malloc(sizeof(uint64_t));
-                    remote_reg_info->size   = (uint64_t *)malloc(sizeof(uint64_t));
+                    remote_reg_info->offset = (uint64_t *)PDC_malloc(sizeof(uint64_t));
+                    remote_reg_info->size   = (uint64_t *)PDC_malloc(sizeof(uint64_t));
                     if ((remote_reg_info->offset == NULL) || (remote_reg_info->size == NULL))
                         PGOTO_ERROR(HG_OTHER_ERROR, "==PDC SERVER: Memory allocation failed");
 
@@ -3201,19 +3203,19 @@ HG_TEST_RPC_CB(transform_region_release, handle)
     region_transform_and_lock_in_t                  in;
     region_lock_in_t                                reg_lock_in;
     region_lock_out_t                               out;
-    const struct hg_info *                          hg_info = NULL;
-    data_server_region_t *                          target_obj;
+    const struct hg_info                           *hg_info = NULL;
+    data_server_region_t                           *target_obj;
     int                                             error     = 0;
     int                                             dirty_reg = 0;
     hg_size_t                                       size;
-    void *                                          data_buf;
-    region_list_t *                                 elt, *request_region, *tmp;
+    void                                           *data_buf;
+    region_list_t                                  *elt, *request_region, *tmp;
     struct buf_map_transform_and_release_bulk_args *buf_map_bulk_args  = NULL;
     hg_bulk_t                                       remote_bulk_handle = HG_BULK_NULL;
-    region_buf_map_t *                              eltt;
+    region_buf_map_t                               *eltt;
     hg_uint32_t                                     remote_count;
-    void **                                         data_ptrs_to = NULL;
-    size_t *                                        data_size_to = NULL;
+    void                                          **data_ptrs_to = NULL;
+    size_t                                         *data_size_to = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -3229,7 +3231,7 @@ HG_TEST_RPC_CB(transform_region_release, handle)
     // write lock release with mapping case
     // do data transfer if it is write lock release with mapping.
     else {
-        request_region = (region_list_t *)malloc(sizeof(region_list_t));
+        request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&in.region, request_region);
         target_obj = PDC_Server_get_obj_region(in.obj_id);
 #ifdef ENABLE_MULTITHREAD
@@ -3240,15 +3242,15 @@ HG_TEST_RPC_CB(transform_region_release, handle)
             if (PDC_is_same_region_list(request_region, elt) == 1 && elt->reg_dirty_from_buf == 1 &&
                 hg_atomic_get32(&(elt->buf_map_refcount)) > 0) {
                 dirty_reg = 1;
-                tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+                tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 DL_FOREACH(target_obj->region_buf_map_head, eltt)
                 {
                     PDC_region_transfer_t_to_list_t(&(eltt->remote_region_unit), tmp);
                     if (PDC_is_same_region_list(tmp, request_region) == 1) {
-                        data_buf     = malloc(in.transform_data_size);
+                        data_buf     = PDC_malloc(in.transform_data_size);
                         remote_count = 1;
-                        data_ptrs_to = (void **)malloc(sizeof(void *));
-                        data_size_to = (size_t *)malloc(sizeof(size_t));
+                        data_ptrs_to = (void **)PDC_malloc(sizeof(void *));
+                        data_size_to = (size_t *)PDC_malloc(sizeof(size_t));
                         if ((data_buf == NULL) || (data_ptrs_to == NULL) || (data_size_to == NULL))
                             PGOTO_ERROR(HG_OTHER_ERROR, "==PDC SERVER: Memory allocation failed");
 
@@ -3264,7 +3266,7 @@ HG_TEST_RPC_CB(transform_region_release, handle)
                             PGOTO_ERROR(hg_ret, "==PDC SERVER ERROR: Could not create bulk data handle");
                         }
                         /* Args that get passed to the callback function */
-                        buf_map_bulk_args = (struct buf_map_transform_and_release_bulk_args *)malloc(
+                        buf_map_bulk_args = (struct buf_map_transform_and_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_transform_and_release_bulk_args));
                         if (buf_map_bulk_args == NULL) {
                             PGOTO_ERROR(HG_OTHER_ERROR, "HG_TEST_RPC_CB(transform_region_release, handle): "
@@ -3349,14 +3351,14 @@ HG_TEST_RPC_CB(region_transform_release, handle)
     int                   dirty_reg = 0;
     hg_size_t             size, remote_size;
     ;
-    void *                            data_buf;
-    region_list_t *                   elt, *request_region, *tmp;
+    void                             *data_buf;
+    region_list_t                    *elt, *request_region, *tmp;
     struct buf_map_release_bulk_args *buf_map_bulk_args  = NULL;
     hg_bulk_t                         remote_bulk_handle = HG_BULK_NULL;
-    region_buf_map_t *                eltt;
+    region_buf_map_t                 *eltt;
     hg_uint32_t                       k, remote_count = 0;
-    void **                           data_ptrs_to = NULL;
-    size_t *                          data_size_to = NULL;
+    void                            **data_ptrs_to = NULL;
+    size_t                           *data_size_to = NULL;
     size_t                            type_size    = 0;
     ;
     size_t dims[4] = {0, 0, 0, 0};
@@ -3378,7 +3380,7 @@ HG_TEST_RPC_CB(region_transform_release, handle)
     // ************************************************************
     else {
         LOG_INFO("region_release_cb: release obj_id=%" PRIu64 " access_type==WRITE\n", in.obj_id);
-        request_region = (region_list_t *)malloc(sizeof(region_list_t));
+        request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&in.region, request_region);
         target_obj = PDC_Server_get_obj_region(in.obj_id);
 #ifdef ENABLE_MULTITHREAD
@@ -3389,7 +3391,7 @@ HG_TEST_RPC_CB(region_transform_release, handle)
             if (PDC_is_same_region_list(request_region, elt) == 1 && elt->reg_dirty_from_buf == 1 &&
                 hg_atomic_get32(&(elt->buf_map_refcount)) > 0) {
                 dirty_reg = 1;
-                tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+                tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 DL_FOREACH(target_obj->region_buf_map_head, eltt)
                 {
                     PDC_region_transfer_t_to_list_t(&(eltt->remote_region_unit), tmp);
@@ -3400,8 +3402,8 @@ HG_TEST_RPC_CB(region_transform_release, handle)
                         if (in.region.ndim == 1) {
                             dims[0]       = (eltt->remote_region_unit).count[0] / type_size;
                             remote_count  = 1;
-                            data_ptrs_to  = (void **)malloc(sizeof(void *));
-                            data_size_to  = (size_t *)malloc(sizeof(size_t));
+                            data_ptrs_to  = (void **)PDC_malloc(sizeof(void *));
+                            data_size_to  = (size_t *)PDC_malloc(sizeof(size_t));
                             *data_ptrs_to = data_buf;
                             *data_size_to = (eltt->remote_region_unit).count[0];
                         }
@@ -3409,8 +3411,8 @@ HG_TEST_RPC_CB(region_transform_release, handle)
                         else if (in.region.ndim == 2) {
                             dims[1]         = (eltt->remote_region_unit).count[1] / type_size;
                             remote_count    = (eltt->remote_region_nounit).count[0];
-                            data_ptrs_to    = (void **)malloc(remote_count * sizeof(void *));
-                            data_size_to    = (size_t *)malloc(remote_count * sizeof(size_t));
+                            data_ptrs_to    = (void **)PDC_malloc(remote_count * sizeof(void *));
+                            data_size_to    = (size_t *)PDC_malloc(remote_count * sizeof(size_t));
                             data_ptrs_to[0] = data_buf +
                                               type_size * dims[1] * (eltt->remote_region_nounit).start[0] +
                                               (eltt->remote_region_nounit).start[0];
@@ -3432,7 +3434,7 @@ HG_TEST_RPC_CB(region_transform_release, handle)
                         free(data_ptrs_to);
                         free(data_size_to);
 
-                        buf_map_bulk_args = (struct buf_map_release_bulk_args *)malloc(
+                        buf_map_bulk_args = (struct buf_map_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_release_bulk_args));
                         if (buf_map_bulk_args == NULL) {
                             PGOTO_ERROR(HG_OTHER_ERROR, "HG_TEST_RPC_CB(region_release, handle): "
@@ -3508,26 +3510,26 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
     } in;
 
     region_lock_out_t                              out;
-    const struct hg_info *                         hg_info = NULL;
-    data_server_region_t *                         target_obj;
-    data_server_region_t *                         lock_obj;
+    const struct hg_info                          *hg_info = NULL;
+    data_server_region_t                          *target_obj;
+    data_server_region_t                          *lock_obj;
     int                                            error     = 0;
     int                                            dirty_reg = 0;
     hg_size_t                                      size;
     hg_return_t                                    hg_ret;
-    void *                                         data_buf;
-    struct pdc_region_info *                       server_region;
-    region_list_t *                                elt, *request_region, *tmp;
-    struct region_lock_update_bulk_args *          lock_update_bulk_args = NULL;
+    void                                          *data_buf;
+    struct pdc_region_info                        *server_region;
+    region_list_t                                 *elt, *request_region, *tmp;
+    struct region_lock_update_bulk_args           *lock_update_bulk_args = NULL;
     struct buf_map_analysis_and_release_bulk_args *buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
     hg_bulk_t                                      lock_local_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                                      remote_bulk_handle     = HG_BULK_NULL;
-    struct pdc_region_info *                       remote_reg_info;
-    region_buf_map_t *                             eltt, *eltt2;
+    struct pdc_region_info                        *remote_reg_info;
+    region_buf_map_t                              *eltt, *eltt2;
 
     hg_uint32_t k, remote_count = 0;
-    void **     data_ptrs_to = NULL;
-    size_t *    data_size_to = NULL;
+    void      **data_ptrs_to = NULL;
+    size_t     *data_size_to = NULL;
     size_t      type_size    = 0;
     size_t      dims[4]      = {0, 0, 0, 0};
 
@@ -3540,7 +3542,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
 
     if (in.lock_release.access_type == PDC_READ) {
         // check region is dirty or not, if dirty transfer data
-        request_region = (region_list_t *)malloc(sizeof(region_list_t));
+        request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&in.lock_release.region, request_region);
         target_obj = PDC_Server_get_obj_region(in.lock_release.obj_id);
 #ifdef ENABLE_MULTITHREAD
@@ -3554,10 +3556,10 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                 size      = HG_Bulk_get_size(elt->bulk_handle);
                 data_buf  = (void *)calloc(1, size);
                 // data transfer
-                server_region              = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
-                server_region->ndim        = 1;
-                server_region->size        = (uint64_t *)malloc(sizeof(uint64_t));
-                server_region->offset      = (uint64_t *)malloc(sizeof(uint64_t));
+                server_region         = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
+                server_region->ndim   = 1;
+                server_region->size   = (uint64_t *)PDC_malloc(sizeof(uint64_t));
+                server_region->offset = (uint64_t *)PDC_malloc(sizeof(uint64_t));
                 (server_region->size)[0]   = size;
                 (server_region->offset)[0] = in.lock_release.region.start[0];
                 ret_value = PDC_Server_data_read_direct(elt->from_obj_id, server_region, data_buf);
@@ -3568,7 +3570,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                 if (hg_ret != HG_SUCCESS)
                     PGOTO_ERROR(hg_ret, "==PDC SERVER ERROR: Could not create bulk data handle");
 
-                lock_update_bulk_args = (struct region_lock_update_bulk_args *)malloc(
+                lock_update_bulk_args = (struct region_lock_update_bulk_args *)PDC_malloc(
                     sizeof(struct region_lock_update_bulk_args));
                 lock_update_bulk_args->handle           = handle;
                 lock_update_bulk_args->in               = in.lock_release;
@@ -3590,7 +3592,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
             if (PDC_is_same_region_list(request_region, elt) == 1 && elt->reg_dirty_from_buf == 1 &&
                 hg_atomic_get32(&(elt->buf_map_refcount)) > 0) {
                 dirty_reg = 1;
-                tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+                tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 DL_FOREACH(target_obj->region_buf_map_head, eltt2)
                 {
                     PDC_region_transfer_t_to_list_t(&(eltt2->remote_region_unit), tmp);
@@ -3602,8 +3604,8 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                             PDC_Server_get_region_buf_ptr(in.lock_release.obj_id, in.lock_release.region);
                         if (in.lock_release.region.ndim == 1) {
                             remote_count  = 1;
-                            data_ptrs_to  = (void **)malloc(sizeof(void *));
-                            data_size_to  = (size_t *)malloc(sizeof(size_t));
+                            data_ptrs_to  = (void **)PDC_malloc(sizeof(void *));
+                            data_size_to  = (size_t *)PDC_malloc(sizeof(size_t));
                             *data_ptrs_to = data_buf;
                             *data_size_to = (eltt2->remote_region_unit).count[0];
                         }
@@ -3618,14 +3620,15 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                         free(data_ptrs_to);
                         free(data_size_to);
 
-                        remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+                        remote_reg_info =
+                            (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
                         if (remote_reg_info == NULL) {
                             error = 1;
                             PGOTO_ERROR(HG_OTHER_ERROR, "==PDC SERVER:HG_TEST_RPC_CB(region_release, handle) "
                                                         "remote_reg_info memory allocation failed");
                         }
 
-                        obj_map_bulk_args = (struct buf_map_analysis_and_release_bulk_args *)malloc(
+                        obj_map_bulk_args = (struct buf_map_analysis_and_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_analysis_and_release_bulk_args));
                         // memset(obj_map_bulk_args, 0, sizeof(struct buf_map_release_bulk_args));
                         memset(obj_map_bulk_args, 0, sizeof(struct buf_map_analysis_and_release_bulk_args));
@@ -3643,8 +3646,9 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
 
                         remote_reg_info->ndim = (obj_map_bulk_args->remote_region).ndim;
                         remote_reg_info->offset =
-                            (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
-                        remote_reg_info->size = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
+                            (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
+                        remote_reg_info->size =
+                            (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
 
                         PDC_copy_region_desc((obj_map_bulk_args->remote_region).start,
                                              remote_reg_info->offset, remote_reg_info->ndim,
@@ -3707,7 +3711,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
     // write lock release with mapping case
     // do data transfer if it is write lock release with mapping.
     else {
-        request_region = (region_list_t *)malloc(sizeof(region_list_t));
+        request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&in.lock_release.region, request_region);
         lock_obj   = PDC_Server_get_obj_region(in.lock_release.obj_id);
         target_obj = PDC_Server_get_obj_region(in.analysis.output_obj_id);
@@ -3718,7 +3722,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
         {
             if (PDC_is_same_region_list(request_region, elt) == 1 && elt->obj_id == in.analysis.obj_id) {
                 dirty_reg = 1;
-                tmp       = (region_list_t *)malloc(sizeof(region_list_t));
+                tmp       = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 DL_FOREACH(target_obj->region_buf_map_head, eltt)
                 {
                     PDC_region_transfer_t_to_list_t(&(eltt->remote_region_unit), tmp);
@@ -3739,8 +3743,8 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                         if (in.lock_release.region.ndim == 1) {
                             dims[0]       = in.analysis.region.count[0] / type_size;
                             remote_count  = 1;
-                            data_ptrs_to  = (void **)malloc(sizeof(void *));
-                            data_size_to  = (size_t *)malloc(sizeof(size_t));
+                            data_ptrs_to  = (void **)PDC_malloc(sizeof(void *));
+                            data_size_to  = (size_t *)PDC_malloc(sizeof(size_t));
                             *data_ptrs_to = data_buf;
                             *data_size_to = eltt->local_region.count[0];
                         }
@@ -3750,8 +3754,8 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                             dims[0]         = in.analysis.region.count[0] / type_size;
                             dims[1]         = in.analysis.region.count[1] / type_size;
                             remote_count    = dims[0];
-                            data_ptrs_to    = (void **)malloc(remote_count * sizeof(void *));
-                            data_size_to    = (size_t *)malloc(remote_count * sizeof(size_t));
+                            data_ptrs_to    = (void **)PDC_malloc(remote_count * sizeof(void *));
+                            data_size_to    = (size_t *)PDC_malloc(remote_count * sizeof(size_t));
                             data_ptrs_to[0] = data_buf + type_size * dims[1] *
                                                              ((eltt->local_region.start[0] / type_size) +
                                                               (eltt->local_region.start[1] / type_size));
@@ -3767,8 +3771,8 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                             dims[1]         = in.analysis.region.count[1] / type_size;
                             dims[2]         = in.analysis.region.count[2] / type_size;
                             remote_count    = dims[0];
-                            data_ptrs_to    = (void **)malloc(remote_count * sizeof(void *));
-                            data_size_to    = (size_t *)malloc(remote_count * sizeof(size_t));
+                            data_ptrs_to    = (void **)PDC_malloc(remote_count * sizeof(void *));
+                            data_size_to    = (size_t *)PDC_malloc(remote_count * sizeof(size_t));
                             data_ptrs_to[0] = data_buf + type_size * dims[1] *
                                                              ((eltt->local_region.start[0] / type_size) +
                                                               (eltt->local_region.start[1] / type_size));
@@ -3791,7 +3795,7 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                         free(data_ptrs_to);
                         free(data_size_to);
 
-                        buf_map_bulk_args = (struct buf_map_analysis_and_release_bulk_args *)malloc(
+                        buf_map_bulk_args = (struct buf_map_analysis_and_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_analysis_and_release_bulk_args));
                         if (buf_map_bulk_args == NULL)
                             PGOTO_ERROR(HG_OTHER_ERROR, "HG_TEST_RPC_CB(region_release, handle): "
@@ -3961,7 +3965,7 @@ HG_TEST_RPC_CB(get_remote_metadata, handle)
     hg_return_t               ret_value = HG_SUCCESS;
     get_remote_metadata_in_t  in;
     get_remote_metadata_out_t out;
-    pdc_metadata_t *          meta;
+    pdc_metadata_t           *meta;
 
     FUNC_ENTER(NULL);
 
@@ -3996,7 +4000,7 @@ HG_TEST_RPC_CB(buf_unmap_server, handle)
     hg_return_t       ret_value = HG_SUCCESS;
     buf_unmap_in_t    in;
     buf_unmap_out_t   out;
-    pdc_metadata_t *  target_obj;
+    pdc_metadata_t   *target_obj;
     region_buf_map_t *tmp, *elt;
 
     FUNC_ENTER(NULL);
@@ -4045,8 +4049,8 @@ HG_TEST_RPC_CB(buf_map_server, handle)
     hg_return_t       ret_value = HG_SUCCESS;
     buf_map_in_t      in;
     buf_map_out_t     out;
-    pdc_metadata_t *  target_obj;
-    region_list_t *   elt, *request_region;
+    pdc_metadata_t   *target_obj;
+    region_list_t    *elt, *request_region;
     region_buf_map_t *buf_map_ptr;
 
     FUNC_ENTER(NULL);
@@ -4062,7 +4066,7 @@ HG_TEST_RPC_CB(buf_map_server, handle)
                     ") does not exist\n",
                     in.remote_obj_id);
     }
-    request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&in.remote_region_unit, request_region);
     DL_FOREACH(target_obj->region_lock_head, elt)
     {
@@ -4070,7 +4074,7 @@ HG_TEST_RPC_CB(buf_map_server, handle)
             hg_atomic_incr32(&(elt->buf_map_refcount));
         }
     }
-    buf_map_ptr                  = (region_buf_map_t *)malloc(sizeof(region_buf_map_t));
+    buf_map_ptr                  = (region_buf_map_t *)PDC_malloc(sizeof(region_buf_map_t));
     buf_map_ptr->local_reg_id    = in.local_reg_id;
     buf_map_ptr->local_region    = in.local_region;
     buf_map_ptr->local_ndim      = in.ndim;
@@ -4110,9 +4114,9 @@ HG_TEST_RPC_CB(buf_map, handle)
     buf_map_in_t          in;
     buf_map_out_t         out;
     const struct hg_info *info;
-    region_list_t *       request_region;
-    region_buf_map_t *    new_buf_map_ptr = NULL;
-    void *                data_ptr;
+    region_list_t        *request_region;
+    region_buf_map_t     *new_buf_map_ptr = NULL;
+    void                 *data_ptr;
     size_t                ndim;
 #ifdef PDC_TIMING
     double start, end;
@@ -4129,15 +4133,15 @@ HG_TEST_RPC_CB(buf_map, handle)
     // Use region dimension to allocate memory, rather than object dimension (different from client side)
     ndim = in.remote_region_unit.ndim;
     // allocate memory for the object by region size
-    data_ptr =
-        (void *)malloc(PDC_get_region_desc_size_bytes(in.remote_region_nounit.count, in.remote_unit, ndim));
+    data_ptr = (void *)PDC_malloc(
+        PDC_get_region_desc_size_bytes(in.remote_region_nounit.count, in.remote_unit, ndim));
 
     if (data_ptr == NULL) {
         out.ret = 0;
         PGOTO_ERROR(HG_OTHER_ERROR, "===PDC Data Server: object memory allocation failed");
     }
 
-    request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&in.remote_region_unit, request_region);
 
     info            = HG_Get_info(handle);
@@ -4177,9 +4181,9 @@ HG_TEST_RPC_CB(query_partial, handle)
     hg_return_t                   hg_ret;
     hg_bulk_t                     bulk_handle = HG_BULK_NULL;
     uint32_t                      i;
-    void **                       buf_ptrs;
-    size_t *                      buf_sizes;
-    uint32_t *                    n_meta_ptr, n_buf;
+    void                        **buf_ptrs;
+    size_t                       *buf_sizes;
+    uint32_t                     *n_meta_ptr, n_buf;
     metadata_query_transfer_in_t  in;
     metadata_query_transfer_out_t out;
 
@@ -4190,7 +4194,7 @@ HG_TEST_RPC_CB(query_partial, handle)
 
     out.ret = -1;
 
-    n_meta_ptr = (uint32_t *)malloc(sizeof(uint32_t));
+    n_meta_ptr = (uint32_t *)PDC_malloc(sizeof(uint32_t));
 
     stopwatch_t server_timer;
     timer_start(&server_timer);
@@ -4211,7 +4215,7 @@ HG_TEST_RPC_CB(query_partial, handle)
 
     n_buf = *n_meta_ptr;
 
-    buf_sizes = (size_t *)malloc((n_buf + 1) * sizeof(size_t));
+    buf_sizes = (size_t *)PDC_malloc((n_buf + 1) * sizeof(size_t));
     for (i = 0; i < *n_meta_ptr; i++) {
         buf_sizes[i] = sizeof(pdc_metadata_t);
     }
@@ -4235,7 +4239,7 @@ HG_TEST_RPC_CB(query_partial, handle)
     // hg_set_output(): Output size exceeds NA expected message size
     pdc_metadata_t *large_serial_meta_buf;
     if (*n_meta_ptr > 80) {
-        large_serial_meta_buf = (pdc_metadata_t *)malloc(sizeof(pdc_metadata_t) * (*n_meta_ptr));
+        large_serial_meta_buf = (pdc_metadata_t *)PDC_malloc(sizeof(pdc_metadata_t) * (*n_meta_ptr));
         for (i = 0; i < *n_meta_ptr; i++) {
             memcpy(&large_serial_meta_buf[i], buf_ptrs[i], sizeof(pdc_metadata_t));
         }
@@ -4272,7 +4276,7 @@ HG_TEST_RPC_CB(query_kvtag, handle)
     hg_return_t                   ret_value;
     hg_return_t                   hg_ret;
     hg_bulk_t                     bulk_handle = HG_BULK_NULL;
-    uint64_t *                    buf_ptr;
+    uint64_t                     *buf_ptr;
     size_t                        buf_size[1];
     uint32_t                      nmeta;
     pdc_kvtag_t                   in;
@@ -4333,10 +4337,10 @@ update_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 cnt, i;
-    uint64_t *          obj_id_ptr;
+    uint64_t           *obj_id_ptr;
     pdc_int_ret_t       out_struct;
-    void **             buf;
-    void *              buf_1d;
+    void              **buf;
+    void               *buf_1d;
 
     FUNC_ENTER(NULL);
 
@@ -4367,8 +4371,6 @@ update_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
                                                              cnt) == SUCCEED) {
 
             free(buf);
-            // Should not free buf_1d here
-            /* free(buf_1d); */
             out_struct.ret = 9999;
         }
     } // end of else
@@ -4392,13 +4394,13 @@ HG_TEST_RPC_CB(bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     int                   cnt;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
     bulk_args->handle = handle;
@@ -4454,7 +4456,7 @@ HG_TEST_RPC_CB(data_server_read, handle)
     // Decode input
     HG_Get_input(handle, &in);
 
-    data_server_io_info_t *io_info = (data_server_io_info_t *)malloc(sizeof(data_server_io_info_t));
+    data_server_io_info_t *io_info = (data_server_io_info_t *)PDC_malloc(sizeof(data_server_io_info_t));
 
     io_info->io_type          = PDC_READ;
     io_info->client_id        = in.client_id;
@@ -4499,7 +4501,7 @@ HG_TEST_RPC_CB(data_server_write, handle)
 
     HG_Get_input(handle, &in);
 
-    data_server_io_info_t *io_info = (data_server_io_info_t *)malloc(sizeof(data_server_io_info_t));
+    data_server_io_info_t *io_info = (data_server_io_info_t *)PDC_malloc(sizeof(data_server_io_info_t));
 
     io_info->io_type         = PDC_WRITE;
     io_info->client_id       = in.client_id;
@@ -4540,7 +4542,7 @@ HG_TEST_RPC_CB(data_server_read_check, handle)
     // Decode input
     data_server_read_check_in_t  in;
     data_server_read_check_out_t out;
-    server_read_check_out_t *    read_out = calloc(1, sizeof(server_read_check_out_t));
+    server_read_check_out_t     *read_out = calloc(1, sizeof(server_read_check_out_t));
 
     FUNC_ENTER(NULL);
 
@@ -4602,7 +4604,7 @@ HG_TEST_RPC_CB(update_region_loc, handle)
     // Decode input
     HG_Get_input(handle, &in);
 
-    region_list_t *input_region = (region_list_t *)malloc(sizeof(region_list_t));
+    region_list_t *input_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&in.region, input_region);
     strcpy(input_region->storage_location, in.storage_location);
     input_region->offset = in.offset;
@@ -4642,7 +4644,7 @@ HG_TEST_RPC_CB(get_metadata_by_id, handle)
     hg_return_t              ret_value = HG_SUCCESS;
     get_metadata_by_id_in_t  in;
     get_metadata_by_id_out_t out;
-    pdc_metadata_t *         target = NULL;
+    pdc_metadata_t          *target = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -4748,8 +4750,8 @@ char *
 PDC_find_in_path(char *workingDir, char *application)
 {
     struct stat fileStat;
-    char *      ret_value = NULL;
-    char *      pathVar   = getenv("PATH");
+    char       *ret_value = NULL;
+    char       *pathVar   = getenv("PATH");
     char        colon     = ':';
 
     char  checkPath[PATH_MAX];
@@ -4804,11 +4806,11 @@ cont_add_del_objs_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t ret_value = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t *        bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t         *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                   local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                         cnt, op;
     cont_add_del_objs_rpc_out_t out_struct;
-    uint64_t *                  obj_ids, cont_id;
+    uint64_t                   *obj_ids, cont_id;
 
     FUNC_ENTER(NULL);
 
@@ -4859,15 +4861,15 @@ done:
 HG_TEST_RPC_CB(cont_add_del_objs_rpc, handle)
 {
     hg_return_t                ret_value          = HG_SUCCESS;
-    const struct hg_info *     hg_info            = NULL;
-    struct bulk_args_t *       bulk_args          = NULL;
+    const struct hg_info      *hg_info            = NULL;
+    struct bulk_args_t        *bulk_args          = NULL;
     hg_bulk_t                  origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                  local_bulk_handle  = HG_BULK_NULL;
     cont_add_del_objs_rpc_in_t in_struct;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
     bulk_args->handle = handle;
@@ -4940,13 +4942,13 @@ query_read_obj_name_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_return_t ret_value = HG_SUCCESS;
     hg_return_t ret       = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t *      bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t       *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                 local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                       iter;
     size_t                    i;
-    char *                    tmp_buf;
+    char                     *tmp_buf;
     query_read_obj_name_out_t out_struct;
-    query_read_names_args_t * query_read_names_args;
+    query_read_names_args_t  *query_read_names_args;
 
     FUNC_ENTER(NULL);
 
@@ -5002,15 +5004,15 @@ HG_TEST_RPC_CB(query_read_obj_name_rpc, handle)
 {
     hg_return_t              ret_value          = HG_SUCCESS;
     hg_return_t              ret                = HG_SUCCESS;
-    const struct hg_info *   hg_info            = NULL;
-    struct bulk_args_t *     bulk_args          = NULL;
+    const struct hg_info    *hg_info            = NULL;
+    struct bulk_args_t      *bulk_args          = NULL;
     hg_bulk_t                origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                local_bulk_handle  = HG_BULK_NULL;
     query_read_obj_name_in_t in_struct;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
     bulk_args->handle = handle;
@@ -5111,13 +5113,13 @@ get_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 i, task_id, n_regions;
-    int *               int_ptr;
-    char *              char_ptr, *file_path;
-    uint64_t *          uint64_ptr, offset;
+    int                *int_ptr;
+    char               *char_ptr, *file_path;
+    uint64_t           *uint64_ptr, offset;
 
-    void *                  buf;
+    void                   *buf;
     region_info_transfer_t *region_info_ptr;
-    region_list_t *         region_list, *region_list_head = NULL;
+    region_list_t          *region_list, *region_list_head = NULL;
     pdc_int_ret_t           out_struct;
 
     FUNC_ENTER(NULL);
@@ -5187,14 +5189,14 @@ HG_TEST_RPC_CB(get_storage_meta_name_query_bulk_result_rpc, handle)
 {
     hg_return_t           ret_value          = HG_SUCCESS;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     bulk_rpc_in_t         in_struct;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
 
@@ -5240,8 +5242,8 @@ notify_client_multi_io_complete_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 n_shm;
-    void *              buf;
-    char *              buf_cp;
+    void               *buf;
+    char               *buf_cp;
     pdc_int_ret_t       out_struct;
 
     FUNC_ENTER(NULL);
@@ -5254,7 +5256,7 @@ notify_client_multi_io_complete_bulk_cb(const struct hg_cb_info *hg_cb_info)
     else {
         n_shm = bulk_args->cnt;
         HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, &buf, NULL, NULL);
-        buf_cp = (char *)malloc(bulk_args->nbytes);
+        buf_cp = (char *)PDC_malloc(bulk_args->nbytes);
         memcpy(buf_cp, buf, bulk_args->nbytes);
     }
 
@@ -5284,14 +5286,14 @@ HG_TEST_RPC_CB(notify_client_multi_io_complete_rpc, handle)
 {
     hg_return_t           ret_value          = HG_SUCCESS;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     bulk_rpc_in_t         in_struct;
 
     FUNC_ENTER(NULL);
 
-    bulk_args         = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args         = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
     bulk_args->handle = handle;
 
     ret_value = HG_Get_input(handle, &in_struct);
@@ -5327,7 +5329,7 @@ PDC_add_task_to_list(pdc_task_list_t **target_list, perr_t (*cb)(), void *cb_arg
 #ifdef ENABLE_MULTITHREAD
                      void *_mutex)
 #else
-                     void *_mutex    ATTRIBUTE(unused))
+                     void *_mutex ATTRIBUTE(unused))
 #endif
 {
     int              ret_value = 0;
@@ -5371,7 +5373,7 @@ PDC_del_task_from_list(pdc_task_list_t **target_list, pdc_task_list_t *del,
 #ifdef ENABLE_MULTITHREAD
                        void *_mutex)
 #else
-                       void *_mutex  ATTRIBUTE(unused))
+                       void *_mutex ATTRIBUTE(unused))
 #endif
 {
     perr_t           ret_value = SUCCEED;
@@ -5555,13 +5557,13 @@ query_read_obj_name_client_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t ret_value = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t *      bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t       *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                 local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                       iter;
     size_t                    i;
-    char *                    tmp_buf;
+    char                     *tmp_buf;
     query_read_obj_name_out_t out_struct;
-    query_read_names_args_t * query_read_names_args;
+    query_read_names_args_t  *query_read_names_args;
 
     FUNC_ENTER(NULL);
 
@@ -5617,15 +5619,15 @@ done:
 HG_TEST_RPC_CB(query_read_obj_name_client_rpc, handle)
 {
     hg_return_t              ret_value          = HG_SUCCESS;
-    const struct hg_info *   hg_info            = NULL;
-    struct bulk_args_t *     bulk_args          = NULL;
+    const struct hg_info    *hg_info            = NULL;
+    struct bulk_args_t      *bulk_args          = NULL;
     hg_bulk_t                origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                local_bulk_handle  = HG_BULK_NULL;
     query_read_obj_name_in_t in_struct;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
     bulk_args->handle = handle;
@@ -5668,9 +5670,9 @@ static hg_return_t
 send_client_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t                       ret_value         = HG_SUCCESS;
-    struct bulk_args_t *              bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t               *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                         local_bulk_handle = hg_cb_info->info.bulk.local_handle;
-    void *                            buf = NULL, *buf_cp = NULL;
+    void                             *buf = NULL, *buf_cp = NULL;
     process_bulk_storage_meta_args_t *process_args = NULL;
 
     FUNC_ENTER(NULL);
@@ -5715,14 +5717,14 @@ HG_TEST_RPC_CB(send_client_storage_meta_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     pdc_int_ret_t         out_struct;
     int                   cnt;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
     bulk_args->handle = handle;
@@ -5775,7 +5777,7 @@ server_recv_shm_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_return_t         ret_value         = HG_SUCCESS;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
-    void *              buf = NULL, *buf_cp = NULL;
+    void               *buf = NULL, *buf_cp = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5812,14 +5814,14 @@ HG_TEST_RPC_CB(send_shm_bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     pdc_int_ret_t         out_struct;
     int                   cnt;
 
     FUNC_ENTER(NULL);
 
-    bulk_args = (struct bulk_args_t *)malloc(sizeof(struct bulk_args_t));
+    bulk_args = (struct bulk_args_t *)PDC_malloc(sizeof(struct bulk_args_t));
 
     /* Keep handle to pass to callback */
     bulk_args->handle = handle;
@@ -5880,15 +5882,15 @@ HG_TEST_RPC_CB(send_data_query_rpc, handle)
 
     // Copy the received data
     size       = sizeof(pdc_query_xfer_t);
-    query_xfer = (pdc_query_xfer_t *)malloc(size);
+    query_xfer = (pdc_query_xfer_t *)PDC_malloc(size);
     memcpy(query_xfer, &in, size);
 
     size                    = sizeof(int) * query_xfer->n_combine_ops;
-    query_xfer->combine_ops = (int *)malloc(size);
+    query_xfer->combine_ops = (int *)PDC_malloc(size);
     memcpy(query_xfer->combine_ops, in.combine_ops, size);
 
     size                    = sizeof(pdc_query_constraint_t) * query_xfer->n_constraints;
-    query_xfer->constraints = (pdc_query_constraint_t *)malloc(size);
+    query_xfer->constraints = (pdc_query_constraint_t *)PDC_malloc(size);
     memcpy(query_xfer->constraints, in.constraints, size);
 
     out.ret   = 1;
@@ -5909,7 +5911,7 @@ HG_TEST_RPC_CB(send_nhits, handle)
 
     FUNC_ENTER(NULL);
 
-    in_cp = (send_nhits_t *)malloc(sizeof(send_nhits_t));
+    in_cp = (send_nhits_t *)PDC_malloc(sizeof(send_nhits_t));
 
     HG_Get_input(handle, &in);
 
@@ -5936,7 +5938,7 @@ HG_TEST_RPC_CB(send_read_sel_obj_id_rpc, handle)
 
     HG_Get_input(handle, &in);
 
-    in_cp = (get_sel_data_rpc_in_t *)malloc(sizeof(get_sel_data_rpc_in_t));
+    in_cp = (get_sel_data_rpc_in_t *)PDC_malloc(sizeof(get_sel_data_rpc_in_t));
     memcpy(in_cp, &in, sizeof(get_sel_data_rpc_in_t));
 
     out.ret   = 1;
@@ -5959,7 +5961,7 @@ HG_TEST_RPC_CB(get_sel_data_rpc, handle)
 
     HG_Get_input(handle, &in);
 
-    in_cp = (get_sel_data_rpc_in_t *)malloc(sizeof(get_sel_data_rpc_in_t));
+    in_cp = (get_sel_data_rpc_in_t *)PDC_malloc(sizeof(get_sel_data_rpc_in_t));
     memcpy(in_cp, &in, sizeof(get_sel_data_rpc_in_t));
 
     out.ret   = 1;
@@ -5980,7 +5982,7 @@ HG_TEST_RPC_CB(send_bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_arg           = NULL;
+    struct bulk_args_t   *bulk_arg           = NULL;
     bulk_rpc_in_t         in_struct;
     hg_return_t (*func_ptr)(const struct hg_cb_info *hg_cb_info);
     struct hg_cb_info callback_info;
@@ -6079,10 +6081,10 @@ HG_TEST_RPC_CB(dart_perform_one_server, handle)
     dart_perform_one_server_out_t out;
 
     hg_bulk_t  bulk_handle = HG_BULK_NULL;
-    uint64_t * n_obj_ids_ptr;
+    uint64_t  *n_obj_ids_ptr;
     uint64_t   n_buf;
     uint64_t **buf_ptrs;
-    size_t *   buf_sizes;
+    size_t    *buf_sizes;
     uint32_t   i;
 
     FUNC_ENTER(NULL);
@@ -6871,7 +6873,7 @@ PDC_deserialize_query(pdc_query_xfer_t *query_xfer)
         PGOTO_ERROR(NULL, "NULL input");
 
     deSerialize(&new_root, query_xfer->constraints, &constraint_idx, query_xfer->combine_ops, &order_idx);
-    new_root->region_constraint = (region_list_t *)malloc(sizeof(region_list_t));
+    new_root->region_constraint = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&query_xfer->region, new_root->region_constraint);
 
     ret_value = new_root;
@@ -6889,8 +6891,8 @@ PDCquery_free(pdc_query_t *query)
     if (NULL == query)
         PGOTO_DONE_VOID;
     if (query->constraint)
-        free(query->constraint);
-    free(query);
+        query->constraint = (pdc_query_constraint_t *)PDC_free(query->constraint);
+    query = (pdc_query_t *)PDC_free(query);
 
 done:
     FUNC_LEAVE_VOID;
@@ -6920,7 +6922,7 @@ PDCquery_free_all(pdc_query_t *root)
     PDCquery_free_all(root->left);
     PDCquery_free_all(root->right);
 
-    free(root);
+    root = (pdc_query_t *)PDC_free(root);
 
 done:
     FUNC_LEAVE_VOID;
@@ -6933,9 +6935,9 @@ PDC_query_xfer_free(pdc_query_xfer_t *query_xfer)
     FUNC_ENTER(NULL);
 
     if (NULL != query_xfer) {
-        free(query_xfer->combine_ops);
-        free(query_xfer->constraints);
-        free(query_xfer);
+        query_xfer->combine_ops = (int *)PDC_free(query_xfer->combine_ops);
+        query_xfer              = (pdc_query_constraint_t *)PDC_free(query_xfer->constraints);
+        query_xfer              = (pdc_query_xfer_t *)PDC_free(query_xfer);
     }
 
     FUNC_LEAVE_VOID;
@@ -6948,9 +6950,9 @@ PDCregion_free(struct pdc_region_info *region)
 
     if (region) {
         if (region->offset)
-            free(region->offset);
+            region->offset = (uint64_t *)PDC_free(region->offset);
         if (region->size)
-            free(region->size);
+            region->size = (uint64_t *)PDC_free(region->size);
     }
 
     FUNC_LEAVE_VOID;

--- a/src/server/pdc_client_server_common.c
+++ b/src/server/pdc_client_server_common.c
@@ -2032,9 +2032,9 @@ pdc_region_write_out_progress(void *arg)
 
     PDC_Server_release_lock_request(bulk_args->remote_obj_id, remote_reg_info);
 
-    free(remote_reg_info->offset);
-    free(remote_reg_info->size);
-    free(remote_reg_info);
+    remote_reg_info->offset = (uint64_t *)PDC_free(remote_reg_info->offset);
+    remote_reg_info->size   = (uint64_t *)PDC_free(remote_reg_info->size);
+    remote_reg_info         = (pdc_region_info *)PDC_free(remote_reg_info);
 
 done:
     fflush(stdout);
@@ -2078,9 +2078,9 @@ obj_map_region_release_bulk_transfer_thread_cb(const struct hg_cb_info *hg_cb_in
 
 done:
     fflush(stdout);
-    free(bulk_args->remote_reg_info->offset);
-    free(bulk_args->remote_reg_info->size);
-    free(bulk_args->remote_reg_info);
+    bulk_args->remote_reg_info->offset = (uint64_t *)PDC_free(bulk_args->remote_reg_info->offset);
+    bulk_args->remote_reg_info->size   = (uint64_t *)PDC_free(bulk_args->remote_reg_info->size);
+    bulk_args->remote_reg_info         = (struct pdc_region_info *)PDC_free(bulk_args->remote_reg_info);
 
     HG_Bulk_free(bulk_args->remote_bulk_handle);
     HG_Free_input(bulk_args->handle, &(bulk_args->in));
@@ -2266,8 +2266,8 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
                 LOG_INFO("==PDC_SERVER: transform returned %ld\n", result);
                 puts("----------------");
 
-                if ((use_transform_size == 0) && dims)
-                    free(dims);
+                if (use_transform_size == 0 && dims)
+                    dims = (uint64_t *)PDC_free(dims);
                 use_transform_size = 0;
             }
         }
@@ -2317,14 +2317,14 @@ done:
 
 #ifndef ENABLE_MULTITHREAD
     if (remote_reg_info) {
-        free(remote_reg_info->offset);
-        free(remote_reg_info->size);
-        free(remote_reg_info);
+        remote_reg_info->offset = (uint64_t *)PDC_free(remote_reg_info->offset);
+        remote_reg_info->size   = (uint64_t *)PDC_free(remote_reg_info->size);
+        remote_reg_info         = (struct pdc_region_info *)PDC_free(remote_reg_info);
     }
     HG_Bulk_free(bulk_args->remote_bulk_handle);
     HG_Free_input(bulk_args->handle, &(bulk_args->in));
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct buf_map_transform_and_release_bulk_args *)PDC_free(bulk_args);
 #endif
 
     FUNC_LEAVE(ret_value);
@@ -2468,18 +2468,18 @@ done:
     fflush(stdout);
 
 #ifndef ENABLE_MULTITHREAD
-    free(remote_reg_info->offset);
-    free(remote_reg_info->size);
-    free(remote_reg_info);
+    remote_reg_info->offset = (uint64_t *)PDC_free(remote_reg_info->offset);
+    remote_reg_info->size   = (uint64_t *)PDC_free(remote_reg_info->size);
+    remote_reg_info         = (struct pdc_region_info *)PDC_free(remote_reg_info);
 
-    free(local_reg_info->offset);
-    free(local_reg_info->size);
-    free(local_reg_info);
+    local_reg_info->offset = (uint64_t *)PDC_free(local_reg_info->offset);
+    local_reg_info->size   = (uint64_t *)PDC_free(local_reg_info->size);
+    local_reg_info         = (struct pdc_region_info *)PDC_free(local_reg_info);
 
     HG_Bulk_free(bulk_args->remote_bulk_handle);
     HG_Free_input(bulk_args->handle, &(bulk_args->in));
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct buf_map_analysis_and_release_bulk_args *)PDC_free(bulk_args);
 #endif
 
     FUNC_LEAVE(ret_value);
@@ -2574,14 +2574,14 @@ done:
     fflush(stdout);
 
 #ifndef ENABLE_MULTITHREAD
-    free(remote_reg_info->offset);
-    free(remote_reg_info->size);
-    free(remote_reg_info);
+    remote_reg_info->offset = (uint64_t *)PDC_free(remote_reg_info->offset);
+    remote_reg_info->size   = (uint64_t *)PDC_free(remote_reg_info->size);
+    remote_reg_info         = (struct pdc_region_info *)PDC_free(remote_reg_info);
 
     HG_Bulk_free(bulk_args->remote_bulk_handle);
     HG_Free_input(bulk_args->handle, &(bulk_args->in));
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct buf_map_release_bulk_args *)PDC_free(bulk_args);
 #endif
 
     FUNC_LEAVE(ret_value);
@@ -2630,10 +2630,10 @@ obj_map_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
 
 done:
     fflush(stdout);
-    free(bulk_args->remote_reg_info);
+    bulk_args->remote_reg_info = (struct pdc_region_info *)PDC_free(bulk_args->remote_reg_info);
     HG_Free_input(bulk_args->handle, &(bulk_args->in));
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct buf_map_release_bulk_args *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -2660,14 +2660,14 @@ region_release_update_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     PDC_Server_notify_region_update_to_client(bulk_args->remote_obj_id, bulk_args->remote_reg_id,
                                               bulk_args->remote_client_id);
 
-    free(bulk_args->server_region->size);
-    free(bulk_args->server_region->offset);
-    free(bulk_args->server_region);
-    free(bulk_args->data_buf);
+    bulk_args->server_region->size   = (uint64_t *)PDC_free(bulk_args->server_region->size);
+    bulk_args->server_region->offset = (uint64_t *)PDC_free(bulk_args->server_region->offset);
+    bulk_args->server_region         = (struct pdc_region_info *)PDC_free(bulk_args->server_region);
+    bulk_args->data_buf              = (void *)PDC_free(bulk_args->data_buf);
 
     HG_Free_input(handle, &(bulk_args->in));
     HG_Destroy(handle);
-    free(bulk_args);
+    bulk_args = (struct region_lock_update_bulk_args *)PDC_free(bulk_args);
 
     FUNC_LEAVE(hg_ret);
 }
@@ -2787,8 +2787,8 @@ HG_TEST_RPC_CB(region_release, handle)
                             error = 1;
                             PGOTO_ERROR(hg_ret, "==PDC SERVER: obj map Could not create bulk data handle");
                         }
-                        free(data_ptrs_to);
-                        free(data_size_to);
+                        data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                        data_size_to = (size_t *)PDC_free(data_size_to);
 
                         remote_reg_info =
                             (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
@@ -2871,13 +2871,13 @@ HG_TEST_RPC_CB(region_release, handle)
                         break;
                     }
                 }
-                free(tmp);
+                tmp = (region_list_t *)PDC_free(tmp);
             }
         }
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_unlock(&lock_list_mutex_g);
 #endif
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
 
         if (dirty_reg == 0) {
             // Perform lock release function
@@ -2926,8 +2926,8 @@ HG_TEST_RPC_CB(region_release, handle)
                             error = 1;
                             PGOTO_ERROR(hg_ret, "==PDC SERVER ERROR: Could not create bulk data handle");
                         }
-                        free(data_ptrs_to);
-                        free(data_size_to);
+                        data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                        data_size_to = (size_t *)PDC_free(data_size_to);
 
                         buf_map_bulk_args = (struct buf_map_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_release_bulk_args));
@@ -2974,14 +2974,14 @@ HG_TEST_RPC_CB(region_release, handle)
                         break;
                     }
                 }
-                free(tmp);
+                tmp = (region_list_t *)PDC_free(tmp);
                 break;
             }
         }
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_unlock(&lock_list_mutex_g);
 #endif
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
 
         if (dirty_reg == 0) {
             // Perform lock release function
@@ -3106,8 +3106,8 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
                     if (hg_ret != HG_SUCCESS)
                         PGOTO_ERROR(hg_ret, "==PDC SERVER: Could not create bulk data handle");
 
-                    free(data_ptrs_to);
-                    free(data_size_to);
+                    data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                    data_size_to = (size_t *)PDC_free(data_size_to);
 
                     remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
                     transform_release_bulk_args =
@@ -3175,7 +3175,7 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
 #endif
                 }
             }
-            free(tmp);
+            tmp = (region_list_t *)PDC_free(tmp);
         }
     }
 #ifdef ENABLE_MULTITHREAD
@@ -3183,7 +3183,7 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
 #endif
 
 done:
-    free(request_region);
+    request_region = (region_list_t *)PDC_free(request_region);
     if (dirty_reg == 0) {
         // Perform lock release function
         PDC_Data_Server_region_release((region_lock_in_t *)in, &out);
@@ -3286,8 +3286,8 @@ HG_TEST_RPC_CB(transform_region_release, handle)
                         hg_thread_mutex_init(&(buf_map_bulk_args->work_mutex));
                         hg_thread_cond_init(&(buf_map_bulk_args->work_cond));
 #endif
-                        free(data_ptrs_to);
-                        free(data_size_to);
+                        data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                        data_size_to = (size_t *)PDC_free(data_size_to);
 
                         /* Pull bulk data */
                         size = in.transform_data_size;
@@ -3308,14 +3308,14 @@ HG_TEST_RPC_CB(transform_region_release, handle)
                         }
                     }
                 }
-                free(tmp);
+                tmp = (region_list_t *)PDC_free(tmp);
             }
         }
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_unlock(&lock_list_mutex_g);
 #endif
 
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
 
         if (dirty_reg == 0) {
             // Perform lock release function
@@ -3431,8 +3431,8 @@ HG_TEST_RPC_CB(region_transform_release, handle)
                             error = 1;
                             PGOTO_ERROR(FAIL, "==PDC SERVER ERROR: Could not create bulk data handle");
                         }
-                        free(data_ptrs_to);
-                        free(data_size_to);
+                        data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                        data_size_to = (size_t *)PDC_free(data_size_to);
 
                         buf_map_bulk_args = (struct buf_map_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_release_bulk_args));
@@ -3471,13 +3471,13 @@ HG_TEST_RPC_CB(region_transform_release, handle)
                         }
                     }
                 }
-                free(tmp);
+                tmp = (region_list_t *)PDC_free(tmp);
             }
         }
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_unlock(&lock_list_mutex_g);
 #endif
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
 
         if (dirty_reg == 0) {
             // Perform lock release function
@@ -3617,8 +3617,8 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                             error = 1;
                             PGOTO_ERROR(hg_ret, "==PDC SERVER: obj map Could not create bulk data handle");
                         }
-                        free(data_ptrs_to);
-                        free(data_size_to);
+                        data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                        data_size_to = (size_t *)PDC_free(data_size_to);
 
                         remote_reg_info =
                             (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
@@ -3692,13 +3692,13 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
 #endif
                     }
                 }
-                free(tmp);
+                tmp = (region_list_t *)PDC_free(tmp);
             }
         }
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_unlock(&lock_list_mutex_g);
 #endif
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
 
         if (dirty_reg == 0) {
             // Perform lock release function
@@ -3792,8 +3792,8 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                             error = 1;
                             PGOTO_ERROR(hg_ret, "==PDC SERVER ERROR: Could not create bulk data handle");
                         }
-                        free(data_ptrs_to);
-                        free(data_size_to);
+                        data_ptrs_to = (void **)PDC_free(data_ptrs_to);
+                        data_size_to = (size_t *)PDC_free(data_size_to);
 
                         buf_map_bulk_args = (struct buf_map_analysis_and_release_bulk_args *)PDC_malloc(
                             sizeof(struct buf_map_analysis_and_release_bulk_args));
@@ -3835,13 +3835,13 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
                         }
                     }
                 }
-                free(tmp);
+                tmp = (region_list_t *)PDC_free(tmp);
             }
         }
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_unlock(&lock_list_mutex_g);
 #endif
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
 
         if (dirty_reg == 0) {
             // Perform lock release function
@@ -4025,7 +4025,7 @@ HG_TEST_RPC_CB(buf_unmap_server, handle)
         if (in.remote_obj_id == elt->remote_obj_id &&
             PDC_region_info_transfer_t_is_equal(&(in.remote_region), &(elt->remote_region_unit))) {
             DL_DELETE(target_obj->region_buf_map_head, elt);
-            free(elt);
+            elt     = (region_buf_map_t *)PDC_free(elt);
             out.ret = 1;
         }
     }
@@ -4094,8 +4094,8 @@ HG_TEST_RPC_CB(buf_map_server, handle)
     hg_thread_mutex_unlock(&meta_buf_map_mutex_g);
 #endif
 
-    out.ret = 1;
-    free(request_region);
+    out.ret        = 1;
+    request_region = (region_list_t *)PDC_free(request_region);
 
 done:
     fflush(stdout);
@@ -4148,8 +4148,8 @@ HG_TEST_RPC_CB(buf_map, handle)
     new_buf_map_ptr = PDC_Data_Server_buf_map(info, &in, request_region, data_ptr);
 
     if (new_buf_map_ptr == NULL) {
-        out.ret = 1;
-        free(data_ptr);
+        out.ret  = 1;
+        data_ptr = (void *)PDC_free(data_ptr);
         HG_Respond(handle, NULL, NULL, &out);
         HG_Free_input(handle, &in);
         HG_Destroy(handle);
@@ -4370,7 +4370,7 @@ update_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
         if (PDC_Server_update_region_storage_meta_bulk_local((update_region_storage_meta_bulk_t **)buf,
                                                              cnt) == SUCCEED) {
 
-            free(buf);
+            buf            = (void **)PDC_free(buf);
             out_struct.ret = 9999;
         }
     } // end of else
@@ -4380,7 +4380,7 @@ done:
     HG_Bulk_free(local_bulk_handle);
     HG_Respond(bulk_args->handle, NULL, NULL, &out_struct);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -4630,7 +4630,7 @@ HG_TEST_RPC_CB(update_region_loc, handle)
     HG_Free_input(handle, &in);
     HG_Destroy(handle);
 
-    free(input_region);
+    input_region = (region_list_t *)PDC_free(input_region);
 
 done:
     fflush(stdout);
@@ -4851,7 +4851,7 @@ done:
     HG_Bulk_free(local_bulk_handle);
     HG_Respond(bulk_args->handle, NULL, NULL, &out_struct);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
     fflush(stdout);
 
     FUNC_LEAVE(ret_value);
@@ -4994,7 +4994,7 @@ query_read_obj_name_bulk_cb(const struct hg_cb_info *hg_cb_info)
 done:
     fflush(stdout);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -5179,7 +5179,7 @@ get_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
 done:
     fflush(stdout);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -5276,7 +5276,7 @@ notify_client_multi_io_complete_bulk_cb(const struct hg_cb_info *hg_cb_info)
 done:
     fflush(stdout);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -5397,7 +5397,7 @@ PDC_del_task_from_list(pdc_task_list_t **target_list, pdc_task_list_t *del,
 #ifdef ENABLE_MULTITHREAD
     hg_thread_mutex_unlock(mutex);
 #endif
-    free(tmp);
+    tmp = (pdc_task_list_t *)PDC_free(tmp);
 
 done:
     fflush(stdout);
@@ -5482,7 +5482,7 @@ PDC_del_task_from_list_id(pdc_task_list_t **target_list, int id, hg_thread_mutex
 
     hg_thread_mutex_unlock(mutex);
 #endif
-    free(tmp);
+    tmp = (pdc_task_list_t *)PDC_free(tmp);
 
 done:
     fflush(stdout);
@@ -5610,7 +5610,7 @@ query_read_obj_name_client_bulk_cb(const struct hg_cb_info *hg_cb_info)
 done:
     fflush(stdout);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -5704,7 +5704,7 @@ done:
     /* Free bulk handle */
     HG_Bulk_free(local_bulk_handle);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -5802,7 +5802,7 @@ done:
     /* Free bulk handle */
     HG_Bulk_free(local_bulk_handle);
     HG_Destroy(bulk_args->handle);
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -6629,10 +6629,10 @@ PDC_free_kvtag(pdc_kvtag_t **kvtag)
 
     FUNC_ENTER(NULL);
 
-    free((void *)(*kvtag)->name);
-    free((void *)(*kvtag)->value);
-    free((void *)*kvtag);
-    *kvtag = NULL;
+    (*kvtag)->name  = (char *)PDC_free((*kvtag)->name);
+    (*kvtag)->value = (void *)PDC_free((*kvtag)->value);
+    *kvtag          = (pdc_kvtag_t *)PDC_free(*kvtag);
+    *kvtag          = NULL;
 
     FUNC_LEAVE(ret_value);
 }
@@ -6907,14 +6907,14 @@ PDCquery_free_all(pdc_query_t *root)
         PGOTO_DONE_VOID;
 
     if (root->sel && root->sel->coords_alloc > 0 && root->sel->coords != NULL) {
-        free(root->sel->coords);
+        root->sel->coords       = (uint64_t *)PDC_free(root->sel->coords);
         root->sel->coords_alloc = 0;
         root->sel->coords       = NULL;
     }
 
     if (root->left == NULL && root->right == NULL) {
         if (root->constraint) {
-            free(root->constraint);
+            root->constraint = (pdc_query_constraint_t *)PDC_free(root->constraint);
             root->constraint = NULL;
         }
     }
@@ -6936,7 +6936,7 @@ PDC_query_xfer_free(pdc_query_xfer_t *query_xfer)
 
     if (NULL != query_xfer) {
         query_xfer->combine_ops = (int *)PDC_free(query_xfer->combine_ops);
-        query_xfer              = (pdc_query_constraint_t *)PDC_free(query_xfer->constraints);
+        query_xfer->constraints = (pdc_query_constraint_t *)PDC_free(query_xfer->constraints);
         query_xfer              = (pdc_query_xfer_t *)PDC_free(query_xfer);
     }
 

--- a/src/server/pdc_client_server_common.c
+++ b/src/server/pdc_client_server_common.c
@@ -133,9 +133,9 @@ hg_proc_pdc_query_xfer_t(hg_proc_t proc, void *data)
     if (struct_data->n_constraints > 0) {
         switch (hg_proc_get_op(proc)) {
             case HG_DECODE:
-                struct_data->combine_ops = malloc(struct_data->n_combine_ops * sizeof(int));
+                struct_data->combine_ops = PDC_malloc(struct_data->n_combine_ops * sizeof(int));
                 struct_data->constraints =
-                    malloc(struct_data->n_constraints * sizeof(pdc_query_constraint_t));
+                    PDC_malloc(struct_data->n_constraints * sizeof(pdc_query_constraint_t));
                 // HG_FALLTHROUGH();
                 /* FALLTHRU */
             case HG_ENCODE:
@@ -1571,7 +1571,7 @@ HG_TEST_RPC_CB(metadata_query, handle)
     hg_return_t          ret_value = HG_SUCCESS;
     metadata_query_in_t  in;
     metadata_query_out_t out;
-    pdc_metadata_t *     query_result = NULL;
+    pdc_metadata_t      *query_result = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -1612,7 +1612,7 @@ HG_TEST_RPC_CB(obj_reset_dims, handle)
     hg_return_t          ret_value = HG_SUCCESS;
     obj_reset_dims_in_t  in;
     obj_reset_dims_out_t out;
-    pdc_metadata_t *     query_result = NULL;
+    pdc_metadata_t      *query_result = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -2000,7 +2000,7 @@ pdc_region_write_out_progress(void *arg)
 {
     HG_THREAD_RETURN_TYPE             ret_value       = (HG_THREAD_RETURN_TYPE)0;
     struct buf_map_release_bulk_args *bulk_args       = (struct buf_map_release_bulk_args *)arg;
-    struct pdc_region_info *          remote_reg_info = NULL;
+    struct pdc_region_info           *remote_reg_info = NULL;
     region_lock_out_t                 out;
 
     FUNC_ENTER(NULL);
@@ -2100,7 +2100,7 @@ pdc_region_read_from_progress(void *arg)
 {
     HG_THREAD_RETURN_TYPE             ret_value = (HG_THREAD_RETURN_TYPE)0;
     struct buf_map_release_bulk_args *bulk_args = (struct buf_map_release_bulk_args *)arg;
-    const struct hg_info *            hg_info   = NULL;
+    const struct hg_info             *hg_info   = NULL;
     hg_return_t                       hg_ret;
     size_t                            size;
     int                               error = 0;
@@ -2153,21 +2153,21 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
     hg_return_t                                     ret_value = HG_SUCCESS;
     region_lock_out_t                               out;
     struct buf_map_transform_and_release_bulk_args *bulk_args = NULL;
-    void *                                          data_buf;
-    char *                                          buf;
+    void                                           *data_buf;
+    char                                           *buf;
     int                                             ndim;
     int                                             transform_id;
     int                                             type_extent        = 0;
     int                                             use_transform_size = 0;
     size_t                                          unit               = 1;
     int64_t                                         transform_size, expected_size;
-    uint64_t *                                      dims = NULL;
+    uint64_t                                       *dims = NULL;
     pdc_var_type_t                                  destType;
-    struct _pdc_region_transform_ftn_info **        registry = NULL;
+    struct _pdc_region_transform_ftn_info         **registry = NULL;
     int                                             registered_count;
 #ifdef ENABLE_MULTITHREAD
     data_server_region_t *target_reg = NULL;
-    region_buf_map_t *    elt;
+    region_buf_map_t     *elt;
 #else
     struct pdc_region_info *remote_reg_info = NULL;
 #endif
@@ -2338,12 +2338,12 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
     hg_return_t                                    ret_value = HG_SUCCESS;
     region_lock_out_t                              out;
     struct buf_map_analysis_and_release_bulk_args *bulk_args = NULL;
-    void *                                         data_buf;
+    void                                          *data_buf;
     int                                            ndim;
     uint64_t                                       type_extent;
-    uint64_t *                                     dims            = NULL;
-    struct pdc_region_info *                       remote_reg_info = NULL;
-    struct pdc_region_info *                       local_reg_info  = NULL;
+    uint64_t                                      *dims            = NULL;
+    struct pdc_region_info                        *remote_reg_info = NULL;
+    struct pdc_region_info                        *local_reg_info  = NULL;
     double                                         start_t, end_t, analysis_t, io_t;
     double                                         averages[4];
 
@@ -2396,7 +2396,7 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
 
         int registered_count = PDC_get_analysis_registry(&registry);
         if ((registered_count >= analysis_meta_index) && (registry != NULL)) {
-            int (*analysis_ftn)(pdcid_t iterIn, pdcid_t iterOut, struct _pdc_iterator_cbs_t * _cbs) =
+            int (*analysis_ftn)(pdcid_t iterIn, pdcid_t iterOut, struct _pdc_iterator_cbs_t *_cbs) =
                 registry[analysis_meta_index]->ftnPtr;
             int result = analysis_ftn(bulk_args->in.input_iter, bulk_args->in.output_iter, &iter_cbs);
             LOG_INFO("==PDC_SERVER: Analysis returned %d\n", result);
@@ -2495,7 +2495,7 @@ buf_map_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct buf_map_release_bulk_args *bulk_args = NULL;
 #ifdef ENABLE_MULTITHREAD
     data_server_region_t *target_reg = NULL;
-    region_buf_map_t *    elt;
+    region_buf_map_t     *elt;
 #else
     struct pdc_region_info *remote_reg_info = NULL;
 #endif
@@ -2681,23 +2681,23 @@ HG_TEST_RPC_CB(region_release, handle)
     hg_return_t                          hg_ret;
     region_lock_in_t                     in;
     region_lock_out_t                    out;
-    const struct hg_info *               hg_info = NULL;
-    data_server_region_t *               target_obj;
+    const struct hg_info                *hg_info = NULL;
+    data_server_region_t                *target_obj;
     int                                  error     = 0;
     int                                  dirty_reg = 0;
     hg_size_t                            size, size2;
-    void *                               data_buf;
-    struct pdc_region_info *             server_region;
-    region_list_t *                      elt, *request_region, *tmp, *elt_tmp;
+    void                                *data_buf;
+    struct pdc_region_info              *server_region;
+    region_list_t                       *elt, *request_region, *tmp, *elt_tmp;
     struct region_lock_update_bulk_args *lock_update_bulk_args = NULL;
-    struct buf_map_release_bulk_args *   buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
+    struct buf_map_release_bulk_args    *buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
     hg_bulk_t                            lock_local_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                            remote_bulk_handle     = HG_BULK_NULL;
-    struct pdc_region_info *             remote_reg_info;
-    region_buf_map_t *                   eltt, *eltt2, *eltt_tmp;
+    struct pdc_region_info              *remote_reg_info;
+    region_buf_map_t                    *eltt, *eltt2, *eltt_tmp;
     hg_uint32_t /*k, m, */               remote_count;
-    void **                              data_ptrs_to = NULL;
-    size_t *                             data_size_to = NULL;
+    void                               **data_ptrs_to = NULL;
+    size_t                              *data_size_to = NULL;
     // size_t                               type_size    = 0;
     // size_t                               dims[4]      = {0, 0, 0, 0};
 #ifdef PDC_TIMING
@@ -3039,10 +3039,10 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             remote_bulk_handle = HG_BULK_NULL;
     hg_uint32_t           remote_count;
-    void *                data_buf = NULL;
+    void                 *data_buf = NULL;
     ;
-    void **           data_ptrs_to = NULL;
-    size_t *          data_size_to = NULL;
+    void            **data_ptrs_to = NULL;
+    size_t           *data_size_to = NULL;
     region_buf_map_t *eltt2;
     region_lock_out_t out;
 
@@ -3051,8 +3051,8 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
     int    dirty_reg = 0;
 
     struct buf_map_transform_and_release_bulk_args *transform_release_bulk_args = NULL;
-    struct pdc_region_info *                        remote_reg_info             = NULL;
-    data_server_region_t *                          target_obj                  = NULL;
+    struct pdc_region_info                         *remote_reg_info             = NULL;
+    data_server_region_t                           *target_obj                  = NULL;
     region_list_t *tmp, *elt, *request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
 
     FUNC_ENTER(NULL);
@@ -3205,19 +3205,19 @@ HG_TEST_RPC_CB(transform_region_release, handle)
     region_transform_and_lock_in_t                  in;
     region_lock_in_t                                reg_lock_in;
     region_lock_out_t                               out;
-    const struct hg_info *                          hg_info = NULL;
-    data_server_region_t *                          target_obj;
+    const struct hg_info                           *hg_info = NULL;
+    data_server_region_t                           *target_obj;
     int                                             error     = 0;
     int                                             dirty_reg = 0;
     hg_size_t                                       size;
-    void *                                          data_buf;
-    region_list_t *                                 elt, *request_region, *tmp;
+    void                                           *data_buf;
+    region_list_t                                  *elt, *request_region, *tmp;
     struct buf_map_transform_and_release_bulk_args *buf_map_bulk_args  = NULL;
     hg_bulk_t                                       remote_bulk_handle = HG_BULK_NULL;
-    region_buf_map_t *                              eltt;
+    region_buf_map_t                               *eltt;
     hg_uint32_t                                     remote_count;
-    void **                                         data_ptrs_to = NULL;
-    size_t *                                        data_size_to = NULL;
+    void                                          **data_ptrs_to = NULL;
+    size_t                                         *data_size_to = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -3353,14 +3353,14 @@ HG_TEST_RPC_CB(region_transform_release, handle)
     int                   dirty_reg = 0;
     hg_size_t             size, remote_size;
     ;
-    void *                            data_buf;
-    region_list_t *                   elt, *request_region, *tmp;
+    void                             *data_buf;
+    region_list_t                    *elt, *request_region, *tmp;
     struct buf_map_release_bulk_args *buf_map_bulk_args  = NULL;
     hg_bulk_t                         remote_bulk_handle = HG_BULK_NULL;
-    region_buf_map_t *                eltt;
+    region_buf_map_t                 *eltt;
     hg_uint32_t                       k, remote_count = 0;
-    void **                           data_ptrs_to = NULL;
-    size_t *                          data_size_to = NULL;
+    void                            **data_ptrs_to = NULL;
+    size_t                           *data_size_to = NULL;
     size_t                            type_size    = 0;
     ;
     size_t dims[4] = {0, 0, 0, 0};
@@ -3512,26 +3512,26 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
     } in;
 
     region_lock_out_t                              out;
-    const struct hg_info *                         hg_info = NULL;
-    data_server_region_t *                         target_obj;
-    data_server_region_t *                         lock_obj;
+    const struct hg_info                          *hg_info = NULL;
+    data_server_region_t                          *target_obj;
+    data_server_region_t                          *lock_obj;
     int                                            error     = 0;
     int                                            dirty_reg = 0;
     hg_size_t                                      size;
     hg_return_t                                    hg_ret;
-    void *                                         data_buf;
-    struct pdc_region_info *                       server_region;
-    region_list_t *                                elt, *request_region, *tmp;
-    struct region_lock_update_bulk_args *          lock_update_bulk_args = NULL;
+    void                                          *data_buf;
+    struct pdc_region_info                        *server_region;
+    region_list_t                                 *elt, *request_region, *tmp;
+    struct region_lock_update_bulk_args           *lock_update_bulk_args = NULL;
     struct buf_map_analysis_and_release_bulk_args *buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
     hg_bulk_t                                      lock_local_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                                      remote_bulk_handle     = HG_BULK_NULL;
-    struct pdc_region_info *                       remote_reg_info;
-    region_buf_map_t *                             eltt, *eltt2;
+    struct pdc_region_info                        *remote_reg_info;
+    region_buf_map_t                              *eltt, *eltt2;
 
     hg_uint32_t k, remote_count = 0;
-    void **     data_ptrs_to = NULL;
-    size_t *    data_size_to = NULL;
+    void      **data_ptrs_to = NULL;
+    size_t     *data_size_to = NULL;
     size_t      type_size    = 0;
     size_t      dims[4]      = {0, 0, 0, 0};
 
@@ -3967,7 +3967,7 @@ HG_TEST_RPC_CB(get_remote_metadata, handle)
     hg_return_t               ret_value = HG_SUCCESS;
     get_remote_metadata_in_t  in;
     get_remote_metadata_out_t out;
-    pdc_metadata_t *          meta;
+    pdc_metadata_t           *meta;
 
     FUNC_ENTER(NULL);
 
@@ -4002,7 +4002,7 @@ HG_TEST_RPC_CB(buf_unmap_server, handle)
     hg_return_t       ret_value = HG_SUCCESS;
     buf_unmap_in_t    in;
     buf_unmap_out_t   out;
-    pdc_metadata_t *  target_obj;
+    pdc_metadata_t   *target_obj;
     region_buf_map_t *tmp, *elt;
 
     FUNC_ENTER(NULL);
@@ -4051,8 +4051,8 @@ HG_TEST_RPC_CB(buf_map_server, handle)
     hg_return_t       ret_value = HG_SUCCESS;
     buf_map_in_t      in;
     buf_map_out_t     out;
-    pdc_metadata_t *  target_obj;
-    region_list_t *   elt, *request_region;
+    pdc_metadata_t   *target_obj;
+    region_list_t    *elt, *request_region;
     region_buf_map_t *buf_map_ptr;
 
     FUNC_ENTER(NULL);
@@ -4116,9 +4116,9 @@ HG_TEST_RPC_CB(buf_map, handle)
     buf_map_in_t          in;
     buf_map_out_t         out;
     const struct hg_info *info;
-    region_list_t *       request_region;
-    region_buf_map_t *    new_buf_map_ptr = NULL;
-    void *                data_ptr;
+    region_list_t        *request_region;
+    region_buf_map_t     *new_buf_map_ptr = NULL;
+    void                 *data_ptr;
     size_t                ndim;
 #ifdef PDC_TIMING
     double start, end;
@@ -4183,9 +4183,9 @@ HG_TEST_RPC_CB(query_partial, handle)
     hg_return_t                   hg_ret;
     hg_bulk_t                     bulk_handle = HG_BULK_NULL;
     uint32_t                      i;
-    void **                       buf_ptrs;
-    size_t *                      buf_sizes;
-    uint32_t *                    n_meta_ptr, n_buf;
+    void                        **buf_ptrs;
+    size_t                       *buf_sizes;
+    uint32_t                     *n_meta_ptr, n_buf;
     metadata_query_transfer_in_t  in;
     metadata_query_transfer_out_t out;
 
@@ -4230,7 +4230,7 @@ HG_TEST_RPC_CB(query_partial, handle)
     /*     size_t padding_size; */
     /*     /1* padding_size = (10 - *n_meta_ptr) * sizeof(pdc_metadata_t); *1/ */
     /*     padding_size = 5000 * sizeof(pdc_metadata_t); */
-    /*     padding = malloc(padding_size); */
+    /*     padding = PDC_malloc(padding_size); */
     /*     memcpy(padding, buf_ptrs[0], sizeof(pdc_metadata_t)); */
     /*     buf_ptrs[*n_meta_ptr] = padding; */
     /*     buf_sizes[*n_meta_ptr] = padding_size; */
@@ -4278,7 +4278,7 @@ HG_TEST_RPC_CB(query_kvtag, handle)
     hg_return_t                   ret_value;
     hg_return_t                   hg_ret;
     hg_bulk_t                     bulk_handle = HG_BULK_NULL;
-    uint64_t *                    buf_ptr;
+    uint64_t                     *buf_ptr;
     size_t                        buf_size[1];
     uint32_t                      nmeta;
     pdc_kvtag_t                   in;
@@ -4339,10 +4339,10 @@ update_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 cnt, i;
-    uint64_t *          obj_id_ptr;
+    uint64_t           *obj_id_ptr;
     pdc_int_ret_t       out_struct;
-    void **             buf;
-    void *              buf_1d;
+    void              **buf;
+    void               *buf_1d;
 
     FUNC_ENTER(NULL);
 
@@ -4396,7 +4396,7 @@ HG_TEST_RPC_CB(bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     int                   cnt;
 
@@ -4544,7 +4544,7 @@ HG_TEST_RPC_CB(data_server_read_check, handle)
     // Decode input
     data_server_read_check_in_t  in;
     data_server_read_check_out_t out;
-    server_read_check_out_t *    read_out = PDC_calloc(1, sizeof(server_read_check_out_t));
+    server_read_check_out_t     *read_out = PDC_calloc(1, sizeof(server_read_check_out_t));
 
     FUNC_ENTER(NULL);
 
@@ -4646,7 +4646,7 @@ HG_TEST_RPC_CB(get_metadata_by_id, handle)
     hg_return_t              ret_value = HG_SUCCESS;
     get_metadata_by_id_in_t  in;
     get_metadata_by_id_out_t out;
-    pdc_metadata_t *         target = NULL;
+    pdc_metadata_t          *target = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -4752,8 +4752,8 @@ char *
 PDC_find_in_path(char *workingDir, char *application)
 {
     struct stat fileStat;
-    char *      ret_value = NULL;
-    char *      pathVar   = getenv("PATH");
+    char       *ret_value = NULL;
+    char       *pathVar   = getenv("PATH");
     char        colon     = ':';
 
     char  checkPath[PATH_MAX];
@@ -4808,11 +4808,11 @@ cont_add_del_objs_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t ret_value = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t *        bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t         *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                   local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                         cnt, op;
     cont_add_del_objs_rpc_out_t out_struct;
-    uint64_t *                  obj_ids, cont_id;
+    uint64_t                   *obj_ids, cont_id;
 
     FUNC_ENTER(NULL);
 
@@ -4863,8 +4863,8 @@ done:
 HG_TEST_RPC_CB(cont_add_del_objs_rpc, handle)
 {
     hg_return_t                ret_value          = HG_SUCCESS;
-    const struct hg_info *     hg_info            = NULL;
-    struct bulk_args_t *       bulk_args          = NULL;
+    const struct hg_info      *hg_info            = NULL;
+    struct bulk_args_t        *bulk_args          = NULL;
     hg_bulk_t                  origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                  local_bulk_handle  = HG_BULK_NULL;
     cont_add_del_objs_rpc_in_t in_struct;
@@ -4944,13 +4944,13 @@ query_read_obj_name_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_return_t ret_value = HG_SUCCESS;
     hg_return_t ret       = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t *      bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t       *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                 local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                       iter;
     size_t                    i;
-    char *                    tmp_buf;
+    char                     *tmp_buf;
     query_read_obj_name_out_t out_struct;
-    query_read_names_args_t * query_read_names_args;
+    query_read_names_args_t  *query_read_names_args;
 
     FUNC_ENTER(NULL);
 
@@ -5006,8 +5006,8 @@ HG_TEST_RPC_CB(query_read_obj_name_rpc, handle)
 {
     hg_return_t              ret_value          = HG_SUCCESS;
     hg_return_t              ret                = HG_SUCCESS;
-    const struct hg_info *   hg_info            = NULL;
-    struct bulk_args_t *     bulk_args          = NULL;
+    const struct hg_info    *hg_info            = NULL;
+    struct bulk_args_t      *bulk_args          = NULL;
     hg_bulk_t                origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                local_bulk_handle  = HG_BULK_NULL;
     query_read_obj_name_in_t in_struct;
@@ -5115,13 +5115,13 @@ get_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 i, task_id, n_regions;
-    int *               int_ptr;
-    char *              char_ptr, *file_path;
-    uint64_t *          uint64_ptr, offset;
+    int                *int_ptr;
+    char               *char_ptr, *file_path;
+    uint64_t           *uint64_ptr, offset;
 
-    void *                  buf;
+    void                   *buf;
     region_info_transfer_t *region_info_ptr;
-    region_list_t *         region_list, *region_list_head = NULL;
+    region_list_t          *region_list, *region_list_head = NULL;
     pdc_int_ret_t           out_struct;
 
     FUNC_ENTER(NULL);
@@ -5191,7 +5191,7 @@ HG_TEST_RPC_CB(get_storage_meta_name_query_bulk_result_rpc, handle)
 {
     hg_return_t           ret_value          = HG_SUCCESS;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     bulk_rpc_in_t         in_struct;
@@ -5244,8 +5244,8 @@ notify_client_multi_io_complete_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 n_shm;
-    void *              buf;
-    char *              buf_cp;
+    void               *buf;
+    char               *buf_cp;
     pdc_int_ret_t       out_struct;
 
     FUNC_ENTER(NULL);
@@ -5288,7 +5288,7 @@ HG_TEST_RPC_CB(notify_client_multi_io_complete_rpc, handle)
 {
     hg_return_t           ret_value          = HG_SUCCESS;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     bulk_rpc_in_t         in_struct;
@@ -5331,7 +5331,7 @@ PDC_add_task_to_list(pdc_task_list_t **target_list, perr_t (*cb)(), void *cb_arg
 #ifdef ENABLE_MULTITHREAD
                      void *_mutex)
 #else
-                     void *_mutex    ATTRIBUTE(unused))
+                     void *_mutex ATTRIBUTE(unused))
 #endif
 {
     int              ret_value = 0;
@@ -5375,7 +5375,7 @@ PDC_del_task_from_list(pdc_task_list_t **target_list, pdc_task_list_t *del,
 #ifdef ENABLE_MULTITHREAD
                        void *_mutex)
 #else
-                       void *_mutex  ATTRIBUTE(unused))
+                       void *_mutex ATTRIBUTE(unused))
 #endif
 {
     perr_t           ret_value = SUCCEED;
@@ -5559,13 +5559,13 @@ query_read_obj_name_client_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t ret_value = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t *      bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t       *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                 local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                       iter;
     size_t                    i;
-    char *                    tmp_buf;
+    char                     *tmp_buf;
     query_read_obj_name_out_t out_struct;
-    query_read_names_args_t * query_read_names_args;
+    query_read_names_args_t  *query_read_names_args;
 
     FUNC_ENTER(NULL);
 
@@ -5621,8 +5621,8 @@ done:
 HG_TEST_RPC_CB(query_read_obj_name_client_rpc, handle)
 {
     hg_return_t              ret_value          = HG_SUCCESS;
-    const struct hg_info *   hg_info            = NULL;
-    struct bulk_args_t *     bulk_args          = NULL;
+    const struct hg_info    *hg_info            = NULL;
+    struct bulk_args_t      *bulk_args          = NULL;
     hg_bulk_t                origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                local_bulk_handle  = HG_BULK_NULL;
     query_read_obj_name_in_t in_struct;
@@ -5672,9 +5672,9 @@ static hg_return_t
 send_client_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t                       ret_value         = HG_SUCCESS;
-    struct bulk_args_t *              bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t               *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                         local_bulk_handle = hg_cb_info->info.bulk.local_handle;
-    void *                            buf = NULL, *buf_cp = NULL;
+    void                             *buf = NULL, *buf_cp = NULL;
     process_bulk_storage_meta_args_t *process_args = NULL;
 
     FUNC_ENTER(NULL);
@@ -5687,7 +5687,7 @@ send_client_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
         if (ret_value != HG_SUCCESS)
             PGOTO_ERROR(ret_value, "==PDC_CLIENT[x]: Error with bulk access");
 
-        buf_cp = malloc(bulk_args->nbytes);
+        buf_cp = PDC_malloc(bulk_args->nbytes);
         memcpy(buf_cp, buf, bulk_args->nbytes);
 
         process_args =
@@ -5719,7 +5719,7 @@ HG_TEST_RPC_CB(send_client_storage_meta_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     pdc_int_ret_t         out_struct;
     int                   cnt;
@@ -5779,7 +5779,7 @@ server_recv_shm_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_return_t         ret_value         = HG_SUCCESS;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
-    void *              buf = NULL, *buf_cp = NULL;
+    void               *buf = NULL, *buf_cp = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5791,7 +5791,7 @@ server_recv_shm_bulk_cb(const struct hg_cb_info *hg_cb_info)
         if (ret_value != HG_SUCCESS)
             PGOTO_ERROR(ret_value, "==PDC_CLIENT[x]: Error with bulk access");
 
-        buf_cp = malloc(bulk_args->nbytes);
+        buf_cp = PDC_malloc(bulk_args->nbytes);
         memcpy(buf_cp, buf, bulk_args->nbytes);
 
         // TODO now we have all storage info (region, shm_addr, offset, etc.) of data read by client
@@ -5816,7 +5816,7 @@ HG_TEST_RPC_CB(send_shm_bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_args          = NULL;
+    struct bulk_args_t   *bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     pdc_int_ret_t         out_struct;
     int                   cnt;
@@ -5984,7 +5984,7 @@ HG_TEST_RPC_CB(send_bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t *  bulk_arg           = NULL;
+    struct bulk_args_t   *bulk_arg           = NULL;
     bulk_rpc_in_t         in_struct;
     hg_return_t (*func_ptr)(const struct hg_cb_info *hg_cb_info);
     struct hg_cb_info callback_info;
@@ -6083,10 +6083,10 @@ HG_TEST_RPC_CB(dart_perform_one_server, handle)
     dart_perform_one_server_out_t out;
 
     hg_bulk_t  bulk_handle = HG_BULK_NULL;
-    uint64_t * n_obj_ids_ptr;
+    uint64_t  *n_obj_ids_ptr;
     uint64_t   n_buf;
     uint64_t **buf_ptrs;
-    size_t *   buf_sizes;
+    size_t    *buf_sizes;
     uint32_t   i;
 
     FUNC_ENTER(NULL);

--- a/src/server/pdc_client_server_common.c
+++ b/src/server/pdc_client_server_common.c
@@ -1571,7 +1571,7 @@ HG_TEST_RPC_CB(metadata_query, handle)
     hg_return_t          ret_value = HG_SUCCESS;
     metadata_query_in_t  in;
     metadata_query_out_t out;
-    pdc_metadata_t      *query_result = NULL;
+    pdc_metadata_t *     query_result = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -1612,7 +1612,7 @@ HG_TEST_RPC_CB(obj_reset_dims, handle)
     hg_return_t          ret_value = HG_SUCCESS;
     obj_reset_dims_in_t  in;
     obj_reset_dims_out_t out;
-    pdc_metadata_t      *query_result = NULL;
+    pdc_metadata_t *     query_result = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -2000,7 +2000,7 @@ pdc_region_write_out_progress(void *arg)
 {
     HG_THREAD_RETURN_TYPE             ret_value       = (HG_THREAD_RETURN_TYPE)0;
     struct buf_map_release_bulk_args *bulk_args       = (struct buf_map_release_bulk_args *)arg;
-    struct pdc_region_info           *remote_reg_info = NULL;
+    struct pdc_region_info *          remote_reg_info = NULL;
     region_lock_out_t                 out;
 
     FUNC_ENTER(NULL);
@@ -2100,7 +2100,7 @@ pdc_region_read_from_progress(void *arg)
 {
     HG_THREAD_RETURN_TYPE             ret_value = (HG_THREAD_RETURN_TYPE)0;
     struct buf_map_release_bulk_args *bulk_args = (struct buf_map_release_bulk_args *)arg;
-    const struct hg_info             *hg_info   = NULL;
+    const struct hg_info *            hg_info   = NULL;
     hg_return_t                       hg_ret;
     size_t                            size;
     int                               error = 0;
@@ -2153,21 +2153,21 @@ transform_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_inf
     hg_return_t                                     ret_value = HG_SUCCESS;
     region_lock_out_t                               out;
     struct buf_map_transform_and_release_bulk_args *bulk_args = NULL;
-    void                                           *data_buf;
-    char                                           *buf;
+    void *                                          data_buf;
+    char *                                          buf;
     int                                             ndim;
     int                                             transform_id;
     int                                             type_extent        = 0;
     int                                             use_transform_size = 0;
     size_t                                          unit               = 1;
     int64_t                                         transform_size, expected_size;
-    uint64_t                                       *dims = NULL;
+    uint64_t *                                      dims = NULL;
     pdc_var_type_t                                  destType;
-    struct _pdc_region_transform_ftn_info         **registry = NULL;
+    struct _pdc_region_transform_ftn_info **        registry = NULL;
     int                                             registered_count;
 #ifdef ENABLE_MULTITHREAD
     data_server_region_t *target_reg = NULL;
-    region_buf_map_t     *elt;
+    region_buf_map_t *    elt;
 #else
     struct pdc_region_info *remote_reg_info = NULL;
 #endif
@@ -2338,12 +2338,12 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
     hg_return_t                                    ret_value = HG_SUCCESS;
     region_lock_out_t                              out;
     struct buf_map_analysis_and_release_bulk_args *bulk_args = NULL;
-    void                                          *data_buf;
+    void *                                         data_buf;
     int                                            ndim;
     uint64_t                                       type_extent;
-    uint64_t                                      *dims            = NULL;
-    struct pdc_region_info                        *remote_reg_info = NULL;
-    struct pdc_region_info                        *local_reg_info  = NULL;
+    uint64_t *                                     dims            = NULL;
+    struct pdc_region_info *                       remote_reg_info = NULL;
+    struct pdc_region_info *                       local_reg_info  = NULL;
     double                                         start_t, end_t, analysis_t, io_t;
     double                                         averages[4];
 
@@ -2396,7 +2396,7 @@ analysis_and_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info
 
         int registered_count = PDC_get_analysis_registry(&registry);
         if ((registered_count >= analysis_meta_index) && (registry != NULL)) {
-            int (*analysis_ftn)(pdcid_t iterIn, pdcid_t iterOut, struct _pdc_iterator_cbs_t *_cbs) =
+            int (*analysis_ftn)(pdcid_t iterIn, pdcid_t iterOut, struct _pdc_iterator_cbs_t * _cbs) =
                 registry[analysis_meta_index]->ftnPtr;
             int result = analysis_ftn(bulk_args->in.input_iter, bulk_args->in.output_iter, &iter_cbs);
             LOG_INFO("==PDC_SERVER: Analysis returned %d\n", result);
@@ -2495,7 +2495,7 @@ buf_map_region_release_bulk_transfer_cb(const struct hg_cb_info *hg_cb_info)
     struct buf_map_release_bulk_args *bulk_args = NULL;
 #ifdef ENABLE_MULTITHREAD
     data_server_region_t *target_reg = NULL;
-    region_buf_map_t     *elt;
+    region_buf_map_t *    elt;
 #else
     struct pdc_region_info *remote_reg_info = NULL;
 #endif
@@ -2681,23 +2681,23 @@ HG_TEST_RPC_CB(region_release, handle)
     hg_return_t                          hg_ret;
     region_lock_in_t                     in;
     region_lock_out_t                    out;
-    const struct hg_info                *hg_info = NULL;
-    data_server_region_t                *target_obj;
+    const struct hg_info *               hg_info = NULL;
+    data_server_region_t *               target_obj;
     int                                  error     = 0;
     int                                  dirty_reg = 0;
     hg_size_t                            size, size2;
-    void                                *data_buf;
-    struct pdc_region_info              *server_region;
-    region_list_t                       *elt, *request_region, *tmp, *elt_tmp;
+    void *                               data_buf;
+    struct pdc_region_info *             server_region;
+    region_list_t *                      elt, *request_region, *tmp, *elt_tmp;
     struct region_lock_update_bulk_args *lock_update_bulk_args = NULL;
-    struct buf_map_release_bulk_args    *buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
+    struct buf_map_release_bulk_args *   buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
     hg_bulk_t                            lock_local_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                            remote_bulk_handle     = HG_BULK_NULL;
-    struct pdc_region_info              *remote_reg_info;
-    region_buf_map_t                    *eltt, *eltt2, *eltt_tmp;
+    struct pdc_region_info *             remote_reg_info;
+    region_buf_map_t *                   eltt, *eltt2, *eltt_tmp;
     hg_uint32_t /*k, m, */               remote_count;
-    void                               **data_ptrs_to = NULL;
-    size_t                              *data_size_to = NULL;
+    void **                              data_ptrs_to = NULL;
+    size_t *                             data_size_to = NULL;
     // size_t                               type_size    = 0;
     // size_t                               dims[4]      = {0, 0, 0, 0};
 #ifdef PDC_TIMING
@@ -3039,10 +3039,10 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             remote_bulk_handle = HG_BULK_NULL;
     hg_uint32_t           remote_count;
-    void                 *data_buf = NULL;
+    void *                data_buf = NULL;
     ;
-    void            **data_ptrs_to = NULL;
-    size_t           *data_size_to = NULL;
+    void **           data_ptrs_to = NULL;
+    size_t *          data_size_to = NULL;
     region_buf_map_t *eltt2;
     region_lock_out_t out;
 
@@ -3051,8 +3051,8 @@ region_read_transform_release(region_transform_and_lock_in_t *in, hg_handle_t ha
     int    dirty_reg = 0;
 
     struct buf_map_transform_and_release_bulk_args *transform_release_bulk_args = NULL;
-    struct pdc_region_info                         *remote_reg_info             = NULL;
-    data_server_region_t                           *target_obj                  = NULL;
+    struct pdc_region_info *                        remote_reg_info             = NULL;
+    data_server_region_t *                          target_obj                  = NULL;
     region_list_t *tmp, *elt, *request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
 
     FUNC_ENTER(NULL);
@@ -3205,19 +3205,19 @@ HG_TEST_RPC_CB(transform_region_release, handle)
     region_transform_and_lock_in_t                  in;
     region_lock_in_t                                reg_lock_in;
     region_lock_out_t                               out;
-    const struct hg_info                           *hg_info = NULL;
-    data_server_region_t                           *target_obj;
+    const struct hg_info *                          hg_info = NULL;
+    data_server_region_t *                          target_obj;
     int                                             error     = 0;
     int                                             dirty_reg = 0;
     hg_size_t                                       size;
-    void                                           *data_buf;
-    region_list_t                                  *elt, *request_region, *tmp;
+    void *                                          data_buf;
+    region_list_t *                                 elt, *request_region, *tmp;
     struct buf_map_transform_and_release_bulk_args *buf_map_bulk_args  = NULL;
     hg_bulk_t                                       remote_bulk_handle = HG_BULK_NULL;
-    region_buf_map_t                               *eltt;
+    region_buf_map_t *                              eltt;
     hg_uint32_t                                     remote_count;
-    void                                          **data_ptrs_to = NULL;
-    size_t                                         *data_size_to = NULL;
+    void **                                         data_ptrs_to = NULL;
+    size_t *                                        data_size_to = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -3353,14 +3353,14 @@ HG_TEST_RPC_CB(region_transform_release, handle)
     int                   dirty_reg = 0;
     hg_size_t             size, remote_size;
     ;
-    void                             *data_buf;
-    region_list_t                    *elt, *request_region, *tmp;
+    void *                            data_buf;
+    region_list_t *                   elt, *request_region, *tmp;
     struct buf_map_release_bulk_args *buf_map_bulk_args  = NULL;
     hg_bulk_t                         remote_bulk_handle = HG_BULK_NULL;
-    region_buf_map_t                 *eltt;
+    region_buf_map_t *                eltt;
     hg_uint32_t                       k, remote_count = 0;
-    void                            **data_ptrs_to = NULL;
-    size_t                           *data_size_to = NULL;
+    void **                           data_ptrs_to = NULL;
+    size_t *                          data_size_to = NULL;
     size_t                            type_size    = 0;
     ;
     size_t dims[4] = {0, 0, 0, 0};
@@ -3512,26 +3512,26 @@ HG_TEST_RPC_CB(region_analysis_release, handle)
     } in;
 
     region_lock_out_t                              out;
-    const struct hg_info                          *hg_info = NULL;
-    data_server_region_t                          *target_obj;
-    data_server_region_t                          *lock_obj;
+    const struct hg_info *                         hg_info = NULL;
+    data_server_region_t *                         target_obj;
+    data_server_region_t *                         lock_obj;
     int                                            error     = 0;
     int                                            dirty_reg = 0;
     hg_size_t                                      size;
     hg_return_t                                    hg_ret;
-    void                                          *data_buf;
-    struct pdc_region_info                        *server_region;
-    region_list_t                                 *elt, *request_region, *tmp;
-    struct region_lock_update_bulk_args           *lock_update_bulk_args = NULL;
+    void *                                         data_buf;
+    struct pdc_region_info *                       server_region;
+    region_list_t *                                elt, *request_region, *tmp;
+    struct region_lock_update_bulk_args *          lock_update_bulk_args = NULL;
     struct buf_map_analysis_and_release_bulk_args *buf_map_bulk_args = NULL, *obj_map_bulk_args = NULL;
     hg_bulk_t                                      lock_local_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                                      remote_bulk_handle     = HG_BULK_NULL;
-    struct pdc_region_info                        *remote_reg_info;
-    region_buf_map_t                              *eltt, *eltt2;
+    struct pdc_region_info *                       remote_reg_info;
+    region_buf_map_t *                             eltt, *eltt2;
 
     hg_uint32_t k, remote_count = 0;
-    void      **data_ptrs_to = NULL;
-    size_t     *data_size_to = NULL;
+    void **     data_ptrs_to = NULL;
+    size_t *    data_size_to = NULL;
     size_t      type_size    = 0;
     size_t      dims[4]      = {0, 0, 0, 0};
 
@@ -3967,7 +3967,7 @@ HG_TEST_RPC_CB(get_remote_metadata, handle)
     hg_return_t               ret_value = HG_SUCCESS;
     get_remote_metadata_in_t  in;
     get_remote_metadata_out_t out;
-    pdc_metadata_t           *meta;
+    pdc_metadata_t *          meta;
 
     FUNC_ENTER(NULL);
 
@@ -4002,7 +4002,7 @@ HG_TEST_RPC_CB(buf_unmap_server, handle)
     hg_return_t       ret_value = HG_SUCCESS;
     buf_unmap_in_t    in;
     buf_unmap_out_t   out;
-    pdc_metadata_t   *target_obj;
+    pdc_metadata_t *  target_obj;
     region_buf_map_t *tmp, *elt;
 
     FUNC_ENTER(NULL);
@@ -4051,8 +4051,8 @@ HG_TEST_RPC_CB(buf_map_server, handle)
     hg_return_t       ret_value = HG_SUCCESS;
     buf_map_in_t      in;
     buf_map_out_t     out;
-    pdc_metadata_t   *target_obj;
-    region_list_t    *elt, *request_region;
+    pdc_metadata_t *  target_obj;
+    region_list_t *   elt, *request_region;
     region_buf_map_t *buf_map_ptr;
 
     FUNC_ENTER(NULL);
@@ -4116,9 +4116,9 @@ HG_TEST_RPC_CB(buf_map, handle)
     buf_map_in_t          in;
     buf_map_out_t         out;
     const struct hg_info *info;
-    region_list_t        *request_region;
-    region_buf_map_t     *new_buf_map_ptr = NULL;
-    void                 *data_ptr;
+    region_list_t *       request_region;
+    region_buf_map_t *    new_buf_map_ptr = NULL;
+    void *                data_ptr;
     size_t                ndim;
 #ifdef PDC_TIMING
     double start, end;
@@ -4183,9 +4183,9 @@ HG_TEST_RPC_CB(query_partial, handle)
     hg_return_t                   hg_ret;
     hg_bulk_t                     bulk_handle = HG_BULK_NULL;
     uint32_t                      i;
-    void                        **buf_ptrs;
-    size_t                       *buf_sizes;
-    uint32_t                     *n_meta_ptr, n_buf;
+    void **                       buf_ptrs;
+    size_t *                      buf_sizes;
+    uint32_t *                    n_meta_ptr, n_buf;
     metadata_query_transfer_in_t  in;
     metadata_query_transfer_out_t out;
 
@@ -4278,7 +4278,7 @@ HG_TEST_RPC_CB(query_kvtag, handle)
     hg_return_t                   ret_value;
     hg_return_t                   hg_ret;
     hg_bulk_t                     bulk_handle = HG_BULK_NULL;
-    uint64_t                     *buf_ptr;
+    uint64_t *                    buf_ptr;
     size_t                        buf_size[1];
     uint32_t                      nmeta;
     pdc_kvtag_t                   in;
@@ -4339,10 +4339,10 @@ update_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 cnt, i;
-    uint64_t           *obj_id_ptr;
+    uint64_t *          obj_id_ptr;
     pdc_int_ret_t       out_struct;
-    void              **buf;
-    void               *buf_1d;
+    void **             buf;
+    void *              buf_1d;
 
     FUNC_ENTER(NULL);
 
@@ -4396,7 +4396,7 @@ HG_TEST_RPC_CB(bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t   *bulk_args          = NULL;
+    struct bulk_args_t *  bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     int                   cnt;
 
@@ -4544,7 +4544,7 @@ HG_TEST_RPC_CB(data_server_read_check, handle)
     // Decode input
     data_server_read_check_in_t  in;
     data_server_read_check_out_t out;
-    server_read_check_out_t     *read_out = PDC_calloc(1, sizeof(server_read_check_out_t));
+    server_read_check_out_t *    read_out = PDC_calloc(1, sizeof(server_read_check_out_t));
 
     FUNC_ENTER(NULL);
 
@@ -4646,7 +4646,7 @@ HG_TEST_RPC_CB(get_metadata_by_id, handle)
     hg_return_t              ret_value = HG_SUCCESS;
     get_metadata_by_id_in_t  in;
     get_metadata_by_id_out_t out;
-    pdc_metadata_t          *target = NULL;
+    pdc_metadata_t *         target = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -4752,8 +4752,8 @@ char *
 PDC_find_in_path(char *workingDir, char *application)
 {
     struct stat fileStat;
-    char       *ret_value = NULL;
-    char       *pathVar   = getenv("PATH");
+    char *      ret_value = NULL;
+    char *      pathVar   = getenv("PATH");
     char        colon     = ':';
 
     char  checkPath[PATH_MAX];
@@ -4808,11 +4808,11 @@ cont_add_del_objs_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t ret_value = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t         *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t *        bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                   local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                         cnt, op;
     cont_add_del_objs_rpc_out_t out_struct;
-    uint64_t                   *obj_ids, cont_id;
+    uint64_t *                  obj_ids, cont_id;
 
     FUNC_ENTER(NULL);
 
@@ -4863,8 +4863,8 @@ done:
 HG_TEST_RPC_CB(cont_add_del_objs_rpc, handle)
 {
     hg_return_t                ret_value          = HG_SUCCESS;
-    const struct hg_info      *hg_info            = NULL;
-    struct bulk_args_t        *bulk_args          = NULL;
+    const struct hg_info *     hg_info            = NULL;
+    struct bulk_args_t *       bulk_args          = NULL;
     hg_bulk_t                  origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                  local_bulk_handle  = HG_BULK_NULL;
     cont_add_del_objs_rpc_in_t in_struct;
@@ -4944,13 +4944,13 @@ query_read_obj_name_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_return_t ret_value = HG_SUCCESS;
     hg_return_t ret       = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t       *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t *      bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                 local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                       iter;
     size_t                    i;
-    char                     *tmp_buf;
+    char *                    tmp_buf;
     query_read_obj_name_out_t out_struct;
-    query_read_names_args_t  *query_read_names_args;
+    query_read_names_args_t * query_read_names_args;
 
     FUNC_ENTER(NULL);
 
@@ -5006,8 +5006,8 @@ HG_TEST_RPC_CB(query_read_obj_name_rpc, handle)
 {
     hg_return_t              ret_value          = HG_SUCCESS;
     hg_return_t              ret                = HG_SUCCESS;
-    const struct hg_info    *hg_info            = NULL;
-    struct bulk_args_t      *bulk_args          = NULL;
+    const struct hg_info *   hg_info            = NULL;
+    struct bulk_args_t *     bulk_args          = NULL;
     hg_bulk_t                origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                local_bulk_handle  = HG_BULK_NULL;
     query_read_obj_name_in_t in_struct;
@@ -5115,13 +5115,13 @@ get_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 i, task_id, n_regions;
-    int                *int_ptr;
-    char               *char_ptr, *file_path;
-    uint64_t           *uint64_ptr, offset;
+    int *               int_ptr;
+    char *              char_ptr, *file_path;
+    uint64_t *          uint64_ptr, offset;
 
-    void                   *buf;
+    void *                  buf;
     region_info_transfer_t *region_info_ptr;
-    region_list_t          *region_list, *region_list_head = NULL;
+    region_list_t *         region_list, *region_list_head = NULL;
     pdc_int_ret_t           out_struct;
 
     FUNC_ENTER(NULL);
@@ -5191,7 +5191,7 @@ HG_TEST_RPC_CB(get_storage_meta_name_query_bulk_result_rpc, handle)
 {
     hg_return_t           ret_value          = HG_SUCCESS;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t   *bulk_args          = NULL;
+    struct bulk_args_t *  bulk_args          = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     bulk_rpc_in_t         in_struct;
@@ -5244,8 +5244,8 @@ notify_client_multi_io_complete_bulk_cb(const struct hg_cb_info *hg_cb_info)
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                 n_shm;
-    void               *buf;
-    char               *buf_cp;
+    void *              buf;
+    char *              buf_cp;
     pdc_int_ret_t       out_struct;
 
     FUNC_ENTER(NULL);
@@ -5288,7 +5288,7 @@ HG_TEST_RPC_CB(notify_client_multi_io_complete_rpc, handle)
 {
     hg_return_t           ret_value          = HG_SUCCESS;
     const struct hg_info *hg_info            = NULL;
-    struct bulk_args_t   *bulk_args          = NULL;
+    struct bulk_args_t *  bulk_args          = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
     bulk_rpc_in_t         in_struct;
@@ -5331,7 +5331,7 @@ PDC_add_task_to_list(pdc_task_list_t **target_list, perr_t (*cb)(), void *cb_arg
 #ifdef ENABLE_MULTITHREAD
                      void *_mutex)
 #else
-                     void *_mutex ATTRIBUTE(unused))
+                     void *_mutex    ATTRIBUTE(unused))
 #endif
 {
     int              ret_value = 0;
@@ -5375,7 +5375,7 @@ PDC_del_task_from_list(pdc_task_list_t **target_list, pdc_task_list_t *del,
 #ifdef ENABLE_MULTITHREAD
                        void *_mutex)
 #else
-                       void *_mutex ATTRIBUTE(unused))
+                       void *_mutex  ATTRIBUTE(unused))
 #endif
 {
     perr_t           ret_value = SUCCEED;
@@ -5559,13 +5559,13 @@ query_read_obj_name_client_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t ret_value = HG_SUCCESS;
     // Server executes after received request from client
-    struct bulk_args_t       *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t *      bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                 local_bulk_handle = hg_cb_info->info.bulk.local_handle;
     int                       iter;
     size_t                    i;
-    char                     *tmp_buf;
+    char *                    tmp_buf;
     query_read_obj_name_out_t out_struct;
-    query_read_names_args_t  *query_read_names_args;
+    query_read_names_args_t * query_read_names_args;
 
     FUNC_ENTER(NULL);
 
@@ -5621,8 +5621,8 @@ done:
 HG_TEST_RPC_CB(query_read_obj_name_client_rpc, handle)
 {
     hg_return_t              ret_value          = HG_SUCCESS;
-    const struct hg_info    *hg_info            = NULL;
-    struct bulk_args_t      *bulk_args          = NULL;
+    const struct hg_info *   hg_info            = NULL;
+    struct bulk_args_t *     bulk_args          = NULL;
     hg_bulk_t                origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t                local_bulk_handle  = HG_BULK_NULL;
     query_read_obj_name_in_t in_struct;
@@ -5672,9 +5672,9 @@ static hg_return_t
 send_client_storage_meta_bulk_cb(const struct hg_cb_info *hg_cb_info)
 {
     hg_return_t                       ret_value         = HG_SUCCESS;
-    struct bulk_args_t               *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
+    struct bulk_args_t *              bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t                         local_bulk_handle = hg_cb_info->info.bulk.local_handle;
-    void                             *buf = NULL, *buf_cp = NULL;
+    void *                            buf = NULL, *buf_cp = NULL;
     process_bulk_storage_meta_args_t *process_args = NULL;
 
     FUNC_ENTER(NULL);
@@ -5719,7 +5719,7 @@ HG_TEST_RPC_CB(send_client_storage_meta_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t   *bulk_args          = NULL;
+    struct bulk_args_t *  bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     pdc_int_ret_t         out_struct;
     int                   cnt;
@@ -5779,7 +5779,7 @@ server_recv_shm_bulk_cb(const struct hg_cb_info *hg_cb_info)
     hg_return_t         ret_value         = HG_SUCCESS;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)hg_cb_info->arg;
     hg_bulk_t           local_bulk_handle = hg_cb_info->info.bulk.local_handle;
-    void               *buf = NULL, *buf_cp = NULL;
+    void *              buf = NULL, *buf_cp = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -5816,7 +5816,7 @@ HG_TEST_RPC_CB(send_shm_bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t   *bulk_args          = NULL;
+    struct bulk_args_t *  bulk_args          = NULL;
     bulk_rpc_in_t         in_struct;
     pdc_int_ret_t         out_struct;
     int                   cnt;
@@ -5984,7 +5984,7 @@ HG_TEST_RPC_CB(send_bulk_rpc, handle)
     const struct hg_info *hg_info            = NULL;
     hg_bulk_t             origin_bulk_handle = HG_BULK_NULL;
     hg_bulk_t             local_bulk_handle  = HG_BULK_NULL;
-    struct bulk_args_t   *bulk_arg           = NULL;
+    struct bulk_args_t *  bulk_arg           = NULL;
     bulk_rpc_in_t         in_struct;
     hg_return_t (*func_ptr)(const struct hg_cb_info *hg_cb_info);
     struct hg_cb_info callback_info;
@@ -6083,10 +6083,10 @@ HG_TEST_RPC_CB(dart_perform_one_server, handle)
     dart_perform_one_server_out_t out;
 
     hg_bulk_t  bulk_handle = HG_BULK_NULL;
-    uint64_t  *n_obj_ids_ptr;
+    uint64_t * n_obj_ids_ptr;
     uint64_t   n_buf;
     uint64_t **buf_ptrs;
-    size_t    *buf_sizes;
+    size_t *   buf_sizes;
     uint32_t   i;
 
     FUNC_ENTER(NULL);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -82,7 +82,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t   *hg_class_g   = NULL;
+hg_class_t *  hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -90,10 +90,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t        *pdc_client_info_g        = NULL;
+pdc_client_info_t *       pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char                     *all_addr_strings_1d_g    = NULL;
-char                    **all_addr_strings_g       = NULL;
+char *                    all_addr_strings_1d_g    = NULL;
+char **                   all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -146,7 +146,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char             *gBinningOption               = NULL;
+char *            gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -164,9 +164,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -378,7 +378,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS    *ftsp = NULL;
+    FTS *   ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -542,7 +542,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -662,7 +662,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char                *target_addr_string;
+    char *               target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -798,7 +798,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char             *auth_key;
+    char *            auth_key;
     int               rc;
 #endif
 
@@ -1050,7 +1050,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t             *region_elt = NULL, *region_tmp = NULL;
+    region_list_t *            region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1216,21 +1216,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t              *elt;
-    region_list_t               *region_elt;
-    pdc_kvtag_list_t            *kvlist_elt;
-    pdc_hash_table_entry_head   *head;
+    pdc_metadata_t *             elt;
+    region_list_t *              region_elt;
+    pdc_kvtag_list_t *           kvlist_elt;
+    pdc_hash_table_entry_head *  head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char             *checkpoint;
-    char             *env_char;
+    char *            checkpoint;
+    char *            env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE             *file;
+    FILE *            file;
 
     FUNC_ENTER(NULL);
 
@@ -1351,7 +1351,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    } // End for hash table metadata entry
+    }     // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1445,14 +1445,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t              *metadata, *elt;
-    region_list_t               *region_list;
-    pdc_hash_table_entry_head   *entry;
+    pdc_metadata_t *             metadata, *elt;
+    region_list_t *              region_list;
+    pdc_hash_table_entry_head *  entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t                    *hash_key;
+    uint32_t *                   hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char                        *checkpoint_buf;
+    char *                       checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1733,8 +1733,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj     = nobj;
-    all_n_region = total_region;
+    all_nobj          = nobj;
+    all_n_region      = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1762,7 +1762,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t         *context = (hg_context_t *)arg;
+    hg_context_t *        context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2247,7 +2247,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -295,7 +295,7 @@ PDC_Server_get_client_addr(const struct hg_cb_info *callback_info)
 #endif
     if (pdc_client_info_g == NULL) {
         pdc_client_num_g  = in->nclient;
-        pdc_client_info_g = (pdc_client_info_t *)calloc(sizeof(pdc_client_info_t), in->nclient);
+        pdc_client_info_g = (pdc_client_info_t *)PDC_calloc(sizeof(pdc_client_info_t), in->nclient);
         if (pdc_client_info_g == NULL) {
             LOG_ERROR("==PDC_SERVER: PDC_Server_get_client_addr - unable to allocate space\n");
             ret_value = FAIL;
@@ -538,7 +538,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
     if (remote_server_id == pdc_server_rank_g || pdc_remote_server_info_g[remote_server_id].addr_valid == 1)
         return SUCCEED;
 
-    lookup_args = (server_lookup_args_t *)calloc(1, sizeof(server_lookup_args_t));
+    lookup_args = (server_lookup_args_t *)PDC_calloc(1, sizeof(server_lookup_args_t));
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
@@ -810,8 +810,8 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     // Create server tmp dir
     PDC_mkdir(pdc_server_tmp_dir_g);
 
-    all_addr_strings_1d_g = (char *)calloc(sizeof(char), pdc_server_size_g * ADDR_MAX);
-    all_addr_strings_g    = (char **)calloc(sizeof(char *), pdc_server_size_g);
+    all_addr_strings_1d_g = (char *)PDC_calloc(sizeof(char), pdc_server_size_g * ADDR_MAX);
+    all_addr_strings_g    = (char **)PDC_calloc(sizeof(char *), pdc_server_size_g);
     total_mem_usage_g += (sizeof(char) + sizeof(char *));
 
     if ((hg_transport = getenv("HG_TRANSPORT")) == NULL) {
@@ -887,7 +887,7 @@ drc_access_again:
 
     // Init server to server communication.
     pdc_remote_server_info_g =
-        (pdc_remote_server_info_t *)calloc(sizeof(pdc_remote_server_info_t), pdc_server_size_g);
+        (pdc_remote_server_info_t *)PDC_calloc(sizeof(pdc_remote_server_info_t), pdc_server_size_g);
 
     for (i = 0; i < pdc_server_size_g; i++) {
         ret_value = PDC_Server_remote_server_info_init(&pdc_remote_server_info_g[i]);
@@ -1534,7 +1534,7 @@ PDC_Server_restart(char *filename)
         // Init hash table metadata (w/ bloom) with first obj
         PDC_Server_hash_table_list_init(entry, hash_key);
 
-        metadata = (pdc_metadata_t *)calloc(sizeof(pdc_metadata_t), count);
+        metadata = (pdc_metadata_t *)PDC_calloc(sizeof(pdc_metadata_t), count);
         for (i = 0; i < count; i++) {
             if (fread(metadata + i, sizeof(pdc_metadata_t), 1, file) != 1) {
                 LOG_ERROR("Read failed for metadata\n");
@@ -1555,7 +1555,7 @@ PDC_Server_restart(char *filename)
                 LOG_ERROR("Read failed for n_kvtag\n");
             }
             for (j = 0; j < n_kvtag; j++) {
-                pdc_kvtag_list_t *kvtag_list = (pdc_kvtag_list_t *)calloc(1, sizeof(pdc_kvtag_list_t));
+                pdc_kvtag_list_t *kvtag_list = (pdc_kvtag_list_t *)PDC_calloc(1, sizeof(pdc_kvtag_list_t));
                 kvtag_list->kvtag            = (pdc_kvtag_t *)PDC_malloc(sizeof(pdc_kvtag_t));
                 if (fread(&key_len, sizeof(int), 1, file) != 1) {
                     LOG_ERROR("Read failed for key_len\n");
@@ -1698,7 +1698,7 @@ PDC_Server_restart(char *filename)
 
     for (i = 0; i < n_objs; ++i) {
         data_server_region_t *new_obj_reg =
-            (data_server_region_t *)calloc(1, sizeof(struct data_server_region_t));
+            (data_server_region_t *)PDC_calloc(1, sizeof(struct data_server_region_t));
         new_obj_reg->fd               = -1;
         new_obj_reg->storage_location = (char *)PDC_malloc(sizeof(char) * ADDR_MAX);
         if (fread(&new_obj_reg->obj_id, sizeof(uint64_t), 1, file) != 1) {

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -82,7 +82,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t *  hg_class_g   = NULL;
+hg_class_t   *hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -90,10 +90,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t *       pdc_client_info_g        = NULL;
+pdc_client_info_t        *pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char *                    all_addr_strings_1d_g    = NULL;
-char **                   all_addr_strings_g       = NULL;
+char                     *all_addr_strings_1d_g    = NULL;
+char                    **all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -146,7 +146,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char *            gBinningOption               = NULL;
+char             *gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -164,9 +164,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -378,7 +378,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS *   ftsp = NULL;
+    FTS    *ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -542,7 +542,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -662,7 +662,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char *               target_addr_string;
+    char                *target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -687,7 +687,7 @@ done:
 static hg_return_t
 PDC_hg_handle_create_cb(hg_handle_t handle, void *arg)
 {
-    struct hg_thread_work *hg_thread_work = malloc(sizeof(struct hg_thread_work));
+    struct hg_thread_work *hg_thread_work = PDC_malloc(sizeof(struct hg_thread_work));
     hg_return_t            ret            = HG_SUCCESS;
 
     if (!hg_thread_work) {
@@ -798,7 +798,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -1051,7 +1051,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t *            region_elt = NULL, *region_tmp = NULL;
+    region_list_t             *region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1217,21 +1217,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t *             elt;
-    region_list_t *              region_elt;
-    pdc_kvtag_list_t *           kvlist_elt;
-    pdc_hash_table_entry_head *  head;
+    pdc_metadata_t              *elt;
+    region_list_t               *region_elt;
+    pdc_kvtag_list_t            *kvlist_elt;
+    pdc_hash_table_entry_head   *head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char *            checkpoint;
-    char *            env_char;
+    char             *checkpoint;
+    char             *env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE *            file;
+    FILE             *file;
 
     FUNC_ENTER(NULL);
 
@@ -1352,7 +1352,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    }     // End for hash table metadata entry
+    } // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1446,14 +1446,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t *             metadata, *elt;
-    region_list_t *              region_list;
-    pdc_hash_table_entry_head *  entry;
+    pdc_metadata_t              *metadata, *elt;
+    region_list_t               *region_list;
+    pdc_hash_table_entry_head   *entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t *                   hash_key;
+    uint32_t                    *hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char *                       checkpoint_buf;
+    char                        *checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1570,7 +1570,7 @@ PDC_Server_restart(char *filename)
                 if (fread(&kvtag_list->kvtag->type, sizeof(int8_t), 1, file) != 1) {
                     LOG_ERROR("Read failed for kvtag_list->kvtag->type\n");
                 }
-                kvtag_list->kvtag->value = malloc(kvtag_list->kvtag->size);
+                kvtag_list->kvtag->value = PDC_malloc(kvtag_list->kvtag->size);
                 if (fread(kvtag_list->kvtag->value, kvtag_list->kvtag->size, 1, file) != 1) {
                     LOG_ERROR("Read failed for kvtag_list->kvtag->value\n");
                 }
@@ -1734,8 +1734,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj          = nobj;
-    all_n_region      = total_region;
+    all_nobj     = nobj;
+    all_n_region = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1763,7 +1763,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t *        context = (hg_context_t *)arg;
+    hg_context_t         *context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2248,7 +2248,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -819,7 +819,6 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     }
     memset(hostname, 0, HOSTNAME_LEN);
     gethostname(hostname, HOSTNAME_LEN - 1);
-    strcpy(hostname, "eno1");
     snprintf(na_info_string, NA_STRING_INFO_LEN, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_server_rank_g == 0)
         LOG_INFO("==PDC_SERVER[%d]: using %.7s\n", pdc_server_rank_g, na_info_string);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -83,7 +83,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t *  hg_class_g   = NULL;
+hg_class_t   *hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -91,10 +91,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t *       pdc_client_info_g        = NULL;
+pdc_client_info_t        *pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char *                    all_addr_strings_1d_g    = NULL;
-char **                   all_addr_strings_g       = NULL;
+char                     *all_addr_strings_1d_g    = NULL;
+char                    **all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -147,7 +147,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char *            gBinningOption               = NULL;
+char             *gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -165,9 +165,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -379,7 +379,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS *   ftsp = NULL;
+    FTS    *ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -543,7 +543,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -663,7 +663,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char *               target_addr_string;
+    char                *target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -784,8 +784,9 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     int                 i         = 0;
     char                self_addr_string[ADDR_MAX];
     char                na_info_string[NA_STRING_INFO_LEN];
-    char *              hostname;
-    struct hg_init_info init_info = {0};
+    char               *hostname;
+    pbool_t             free_hostname = false;
+    struct hg_init_info init_info     = {0};
 
     /* Set the default mercury transport
      * but enable overriding that to any of:
@@ -799,7 +800,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -822,12 +823,14 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
         hostname = PDC_malloc(HOSTNAME_LEN);
         memset(hostname, 0, HOSTNAME_LEN);
         gethostname(hostname, HOSTNAME_LEN - 1);
+        free_hostname = true;
     }
     snprintf(na_info_string, NA_STRING_INFO_LEN, "%s://%s:%d", hg_transport, hostname, port);
+
     if (pdc_server_rank_g == 0)
         LOG_INFO("==PDC_SERVER[%d]: using %s\n", pdc_server_rank_g, na_info_string);
-
-    free(hostname);
+    if (free_hostname)
+        hostname = PDC_free(hostname);
 
     // Clean up all the tmp files etc
     HG_Cleanup();
@@ -1056,7 +1059,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t *            region_elt = NULL, *region_tmp = NULL;
+    region_list_t             *region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1222,21 +1225,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t *             elt;
-    region_list_t *              region_elt;
-    pdc_kvtag_list_t *           kvlist_elt;
-    pdc_hash_table_entry_head *  head;
+    pdc_metadata_t              *elt;
+    region_list_t               *region_elt;
+    pdc_kvtag_list_t            *kvlist_elt;
+    pdc_hash_table_entry_head   *head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char *            checkpoint;
-    char *            env_char;
+    char             *checkpoint;
+    char             *env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE *            file;
+    FILE             *file;
 
     FUNC_ENTER(NULL);
 
@@ -1357,7 +1360,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    }     // End for hash table metadata entry
+    } // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1451,14 +1454,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t *             metadata, *elt;
-    region_list_t *              region_list;
-    pdc_hash_table_entry_head *  entry;
+    pdc_metadata_t              *metadata, *elt;
+    region_list_t               *region_list;
+    pdc_hash_table_entry_head   *entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t *                   hash_key;
+    uint32_t                    *hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char *                       checkpoint_buf;
+    char                        *checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1739,8 +1742,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj          = nobj;
-    all_n_region      = total_region;
+    all_nobj     = nobj;
+    all_n_region = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1768,7 +1771,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t *        context = (hg_context_t *)arg;
+    hg_context_t         *context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2253,7 +2256,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -83,7 +83,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t   *hg_class_g   = NULL;
+hg_class_t *  hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -91,10 +91,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t        *pdc_client_info_g        = NULL;
+pdc_client_info_t *       pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char                     *all_addr_strings_1d_g    = NULL;
-char                    **all_addr_strings_g       = NULL;
+char *                    all_addr_strings_1d_g    = NULL;
+char **                   all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -147,7 +147,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char             *gBinningOption               = NULL;
+char *            gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -165,9 +165,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -379,7 +379,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS    *ftsp = NULL;
+    FTS *   ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -543,7 +543,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -663,7 +663,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char                *target_addr_string;
+    char *               target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -784,7 +784,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     int                 i         = 0;
     char                self_addr_string[ADDR_MAX];
     char                na_info_string[NA_STRING_INFO_LEN];
-    char               *hostname;
+    char *              hostname;
     pbool_t             free_hostname = false;
     struct hg_init_info init_info     = {0};
 
@@ -800,7 +800,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char             *auth_key;
+    char *            auth_key;
     int               rc;
 #endif
 
@@ -1059,7 +1059,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t             *region_elt = NULL, *region_tmp = NULL;
+    region_list_t *            region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1225,21 +1225,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t              *elt;
-    region_list_t               *region_elt;
-    pdc_kvtag_list_t            *kvlist_elt;
-    pdc_hash_table_entry_head   *head;
+    pdc_metadata_t *             elt;
+    region_list_t *              region_elt;
+    pdc_kvtag_list_t *           kvlist_elt;
+    pdc_hash_table_entry_head *  head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char             *checkpoint;
-    char             *env_char;
+    char *            checkpoint;
+    char *            env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE             *file;
+    FILE *            file;
 
     FUNC_ENTER(NULL);
 
@@ -1360,7 +1360,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    } // End for hash table metadata entry
+    }     // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1454,14 +1454,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t              *metadata, *elt;
-    region_list_t               *region_list;
-    pdc_hash_table_entry_head   *entry;
+    pdc_metadata_t *             metadata, *elt;
+    region_list_t *              region_list;
+    pdc_hash_table_entry_head *  entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t                    *hash_key;
+    uint32_t *                   hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char                        *checkpoint_buf;
+    char *                       checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1742,8 +1742,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj     = nobj;
-    all_n_region = total_region;
+    all_nobj          = nobj;
+    all_n_region      = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1771,7 +1771,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t         *context = (hg_context_t *)arg;
+    hg_context_t *        context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2256,7 +2256,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -82,7 +82,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t *  hg_class_g   = NULL;
+hg_class_t   *hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -90,10 +90,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t *       pdc_client_info_g        = NULL;
+pdc_client_info_t        *pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char *                    all_addr_strings_1d_g    = NULL;
-char **                   all_addr_strings_g       = NULL;
+char                     *all_addr_strings_1d_g    = NULL;
+char                    **all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -146,7 +146,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char *            gBinningOption               = NULL;
+char             *gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -164,9 +164,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -378,7 +378,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS *   ftsp = NULL;
+    FTS    *ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -542,7 +542,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -662,7 +662,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char *               target_addr_string;
+    char                *target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -798,7 +798,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -1050,7 +1050,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t *            region_elt = NULL, *region_tmp = NULL;
+    region_list_t             *region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1216,21 +1216,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t *             elt;
-    region_list_t *              region_elt;
-    pdc_kvtag_list_t *           kvlist_elt;
-    pdc_hash_table_entry_head *  head;
+    pdc_metadata_t              *elt;
+    region_list_t               *region_elt;
+    pdc_kvtag_list_t            *kvlist_elt;
+    pdc_hash_table_entry_head   *head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char *            checkpoint;
-    char *            env_char;
+    char             *checkpoint;
+    char             *env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE *            file;
+    FILE             *file;
 
     FUNC_ENTER(NULL);
 
@@ -1351,7 +1351,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    }     // End for hash table metadata entry
+    } // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1445,14 +1445,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t *             metadata, *elt;
-    region_list_t *              region_list;
-    pdc_hash_table_entry_head *  entry;
+    pdc_metadata_t              *metadata, *elt;
+    region_list_t               *region_list;
+    pdc_hash_table_entry_head   *entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t *                   hash_key;
+    uint32_t                    *hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char *                       checkpoint_buf;
+    char                        *checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1733,8 +1733,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj          = nobj;
-    all_n_region      = total_region;
+    all_nobj     = nobj;
+    all_n_region = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1762,7 +1762,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t *        context = (hg_context_t *)arg;
+    hg_context_t         *context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2247,7 +2247,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -82,7 +82,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t *  hg_class_g   = NULL;
+hg_class_t   *hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -90,10 +90,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t *       pdc_client_info_g        = NULL;
+pdc_client_info_t        *pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char *                    all_addr_strings_1d_g    = NULL;
-char **                   all_addr_strings_g       = NULL;
+char                     *all_addr_strings_1d_g    = NULL;
+char                    **all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -146,7 +146,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char *            gBinningOption               = NULL;
+char             *gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -164,9 +164,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -227,7 +227,7 @@ PDC_Server_destroy_client_info(pdc_client_info_t *info)
         }
     } // end of for
 
-    free(info);
+    info = (pdc_client_info_t *)PDC_free(info);
 done:
     FUNC_LEAVE(ret_value);
 }
@@ -378,7 +378,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS *   ftsp = NULL;
+    FTS    *ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -515,7 +515,7 @@ lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     lookup_args->ret_int = 1;
 
 done:
-    free(lookup_args);
+    lookup_args = (server_lookup_args_t *)PDC_free(lookup_args);
     FUNC_LEAVE(ret_value);
 }
 
@@ -542,7 +542,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -662,7 +662,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char *               target_addr_string;
+    char                *target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -798,7 +798,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char *            auth_key;
+    char             *auth_key;
     int               rc;
 #endif
 
@@ -819,6 +819,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     }
     memset(hostname, 0, HOSTNAME_LEN);
     gethostname(hostname, HOSTNAME_LEN - 1);
+    strcpy(hostname, "eno1");
     snprintf(na_info_string, NA_STRING_INFO_LEN, "%s://%s:%d", hg_transport, hostname, port);
     if (pdc_server_rank_g == 0)
         LOG_INFO("==PDC_SERVER[%d]: using %.7s\n", pdc_server_rank_g, na_info_string);
@@ -1050,7 +1051,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t *            region_elt = NULL, *region_tmp = NULL;
+    region_list_t             *region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1073,7 +1074,7 @@ PDC_Server_finalize()
             if (region_elt->shm_fd > 0)
                 ret_value = PDC_Server_close_shm(region_elt, 1);
             DL_DELETE(io_elt->region_list_head, region_elt);
-            free(region_elt);
+            region_elt = (region_list_t *)PDC_free(region_elt);
         }
         io_elt->region_list_head = NULL;
     }
@@ -1178,8 +1179,8 @@ PDC_Server_finalize()
         LOG_ERROR("==PDC_SERVER[%d]: Error with HG_Finalize\n", pdc_server_rank_g);
 
 done:
-    free(all_addr_strings_g);
-    free(all_addr_strings_1d_g);
+    all_addr_strings_g    = (char **)PDC_free(all_addr_strings_g);
+    all_addr_strings_1d_g = (char *)PDC_free(all_addr_strings_1d_g);
 
     FUNC_LEAVE(ret_value);
 }
@@ -1216,21 +1217,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t *             elt;
-    region_list_t *              region_elt;
-    pdc_kvtag_list_t *           kvlist_elt;
-    pdc_hash_table_entry_head *  head;
+    pdc_metadata_t              *elt;
+    region_list_t               *region_elt;
+    pdc_kvtag_list_t            *kvlist_elt;
+    pdc_hash_table_entry_head   *head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char *            checkpoint;
-    char *            env_char;
+    char             *checkpoint;
+    char             *env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE *            file;
+    FILE             *file;
 
     FUNC_ENTER(NULL);
 
@@ -1351,7 +1352,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    }     // End for hash table metadata entry
+    } // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1445,14 +1446,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t *             metadata, *elt;
-    region_list_t *              region_list;
-    pdc_hash_table_entry_head *  entry;
+    pdc_metadata_t              *metadata, *elt;
+    region_list_t               *region_list;
+    pdc_hash_table_entry_head   *entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t *                   hash_key;
+    uint32_t                    *hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char *                       checkpoint_buf;
+    char                        *checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1484,14 +1485,14 @@ PDC_Server_restart(char *filename)
     }
     all_cont = n_cont;
     while (n_cont > 0) {
-        hash_key = (uint32_t *)malloc(sizeof(uint32_t));
+        hash_key = (uint32_t *)PDC_malloc(sizeof(uint32_t));
         if (fread(hash_key, sizeof(uint32_t), 1, file) != 1) {
             LOG_ERROR("Read failed for hash_key\n");
         }
         total_mem_usage_g += sizeof(uint32_t);
 
         // Reconstruct hash table
-        cont_entry = (pdc_cont_hash_table_entry_t *)malloc(sizeof(pdc_cont_hash_table_entry_t));
+        cont_entry = (pdc_cont_hash_table_entry_t *)PDC_malloc(sizeof(pdc_cont_hash_table_entry_t));
         total_mem_usage_g += sizeof(pdc_cont_hash_table_entry_t);
         if (fread(cont_entry, sizeof(pdc_cont_hash_table_entry_t), 1, file) != 1) {
             LOG_ERROR("Read failed for cont_entry\n");
@@ -1519,14 +1520,14 @@ PDC_Server_restart(char *filename)
             LOG_ERROR("Read failed for count\n");
         }
 
-        hash_key = (uint32_t *)malloc(sizeof(uint32_t));
+        hash_key = (uint32_t *)PDC_malloc(sizeof(uint32_t));
         if (fread(hash_key, sizeof(uint32_t), 1, file) != 1) {
             LOG_ERROR("Read failed for hash_key\n");
         }
         total_mem_usage_g += sizeof(uint32_t);
 
         // Reconstruct hash table
-        entry           = (pdc_hash_table_entry_head *)malloc(sizeof(pdc_hash_table_entry_head));
+        entry           = (pdc_hash_table_entry_head *)PDC_malloc(sizeof(pdc_hash_table_entry_head));
         entry->n_obj    = 0;
         entry->bloom    = NULL;
         entry->metadata = NULL;
@@ -1555,11 +1556,11 @@ PDC_Server_restart(char *filename)
             }
             for (j = 0; j < n_kvtag; j++) {
                 pdc_kvtag_list_t *kvtag_list = (pdc_kvtag_list_t *)calloc(1, sizeof(pdc_kvtag_list_t));
-                kvtag_list->kvtag            = (pdc_kvtag_t *)malloc(sizeof(pdc_kvtag_t));
+                kvtag_list->kvtag            = (pdc_kvtag_t *)PDC_malloc(sizeof(pdc_kvtag_t));
                 if (fread(&key_len, sizeof(int), 1, file) != 1) {
                     LOG_ERROR("Read failed for key_len\n");
                 }
-                kvtag_list->kvtag->name = malloc(key_len);
+                kvtag_list->kvtag->name = PDC_malloc(key_len);
                 if (fread((void *)(kvtag_list->kvtag->name), key_len, 1, file) != 1) {
                     LOG_ERROR("Read failed for kvtag_list->kvtag->name\n");
                 }
@@ -1591,7 +1592,7 @@ PDC_Server_restart(char *filename)
             total_region += n_region;
 
             for (j = 0; j < n_region; j++) {
-                region_list = (region_list_t *)malloc(sizeof(region_list_t));
+                region_list = (region_list_t *)PDC_malloc(sizeof(region_list_t));
                 if (fread(region_list, sizeof(region_list_t), 1, file) != 1) {
                     LOG_ERROR("Read failed for region_list\n");
                 }
@@ -1601,7 +1602,7 @@ PDC_Server_restart(char *filename)
                     LOG_ERROR("Read failed for has_list\n");
                 }
                 if (has_hist == 1) {
-                    region_list->region_hist = (pdc_histogram_t *)malloc(sizeof(pdc_histogram_t));
+                    region_list->region_hist = (pdc_histogram_t *)PDC_malloc(sizeof(pdc_histogram_t));
                     if (fread(&region_list->region_hist->dtype, sizeof(int), 1, file) != 1) {
                         LOG_ERROR("Read failed for region_list->region_hist->dtype\n");
                     }
@@ -1614,9 +1615,9 @@ PDC_Server_restart(char *filename)
                     }
 
                     region_list->region_hist->range =
-                        (double *)malloc(sizeof(double) * region_list->region_hist->nbin * 2);
+                        (double *)PDC_malloc(sizeof(double) * region_list->region_hist->nbin * 2);
                     region_list->region_hist->bin =
-                        (uint64_t *)malloc(sizeof(uint64_t) * region_list->region_hist->nbin);
+                        (uint64_t *)PDC_malloc(sizeof(uint64_t) * region_list->region_hist->nbin);
 
                     if (fread(region_list->region_hist->range, sizeof(double),
                               region_list->region_hist->nbin * 2, file) != 1) {
@@ -1699,7 +1700,7 @@ PDC_Server_restart(char *filename)
         data_server_region_t *new_obj_reg =
             (data_server_region_t *)calloc(1, sizeof(struct data_server_region_t));
         new_obj_reg->fd               = -1;
-        new_obj_reg->storage_location = (char *)malloc(sizeof(char) * ADDR_MAX);
+        new_obj_reg->storage_location = (char *)PDC_malloc(sizeof(char) * ADDR_MAX);
         if (fread(&new_obj_reg->obj_id, sizeof(uint64_t), 1, file) != 1) {
             LOG_ERROR("Read failed for obj_id\n");
         }
@@ -1708,7 +1709,7 @@ PDC_Server_restart(char *filename)
         }
         DL_APPEND(dataserver_region_g, new_obj_reg);
         for (j = 0; j < n_region; j++) {
-            region_list_t *new_region_list = (region_list_t *)malloc(sizeof(region_list_t));
+            region_list_t *new_region_list = (region_list_t *)PDC_malloc(sizeof(region_list_t));
             if (fread(new_region_list, sizeof(region_list_t), 1, file) != 1) {
                 LOG_ERROR("Read failed for new_region_list\n");
             }
@@ -1719,12 +1720,12 @@ PDC_Server_restart(char *filename)
     if (fread(&checkpoint_size, sizeof(uint64_t), 1, file) != 1) {
         LOG_ERROR("Read failed for checkpoint size\n");
     }
-    checkpoint_buf = (char *)malloc(checkpoint_size);
+    checkpoint_buf = (char *)PDC_malloc(checkpoint_size);
     if (fread(checkpoint_buf, checkpoint_size, 1, file) != 1) {
         LOG_ERROR("Read failed for checkpoint buf\n");
     }
     transfer_request_metadata_query_init(pdc_server_size_g, checkpoint_buf);
-    free(checkpoint_buf);
+    checkpoint_buf = (char *)PDC_free(checkpoint_buf);
 
     fclose(file);
     file = NULL;
@@ -1733,8 +1734,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj          = nobj;
-    all_n_region      = total_region;
+    all_nobj     = nobj;
+    all_n_region = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1762,7 +1763,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t *        context = (hg_context_t *)arg;
+    hg_context_t         *context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2247,7 +2248,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server.c
+++ b/src/server/pdc_server.c
@@ -82,7 +82,7 @@ sqlite3 *sqlite3_db_g;
 int is_debug_g       = 0;
 int pdc_client_num_g = 0;
 
-hg_class_t   *hg_class_g   = NULL;
+hg_class_t *  hg_class_g   = NULL;
 hg_context_t *hg_context_g = NULL;
 
 // Below three are guarded by pdc_server_task_mutex_g for multi-thread
@@ -90,10 +90,10 @@ pdc_task_list_t *pdc_server_agg_task_head_g = NULL;
 pdc_task_list_t *pdc_server_s2s_task_head_g = NULL;
 int              pdc_server_task_id_g       = PDC_SERVER_TASK_INIT_VALUE;
 
-pdc_client_info_t        *pdc_client_info_g        = NULL;
+pdc_client_info_t *       pdc_client_info_g        = NULL;
 pdc_remote_server_info_t *pdc_remote_server_info_g = NULL;
-char                     *all_addr_strings_1d_g    = NULL;
-char                    **all_addr_strings_g       = NULL;
+char *                    all_addr_strings_1d_g    = NULL;
+char **                   all_addr_strings_g       = NULL;
 int                       is_hash_table_init_g     = 0;
 int                       lustre_stripe_size_mb_g  = 16;
 int                       lustre_total_ost_g       = 0;
@@ -146,7 +146,7 @@ int               gen_fastbit_idx_g            = 0;
 int               use_fastbit_idx_g            = 0;
 int               use_rocksdb_g                = 0;
 int               use_sqlite3_g                = 0;
-char             *gBinningOption               = NULL;
+char *            gBinningOption               = NULL;
 
 double server_write_time_g                  = 0.0;
 double server_read_time_g                   = 0.0;
@@ -164,9 +164,9 @@ volatile int dbg_sleep_g = 1;
 double total_mem_usage_g = 0.0;
 
 // Data server related
-pdc_data_server_io_list_t   *pdc_data_server_read_list_head_g    = NULL;
-pdc_data_server_io_list_t   *pdc_data_server_write_list_head_g   = NULL;
-update_storage_meta_list_t  *pdc_update_storage_meta_list_head_g = NULL;
+pdc_data_server_io_list_t *  pdc_data_server_read_list_head_g    = NULL;
+pdc_data_server_io_list_t *  pdc_data_server_write_list_head_g   = NULL;
+update_storage_meta_list_t * pdc_update_storage_meta_list_head_g = NULL;
 extern data_server_region_t *dataserver_region_g;
 
 /*
@@ -378,7 +378,7 @@ static int
 remove_directory(const char *dir)
 {
     int     ret  = 0;
-    FTS    *ftsp = NULL;
+    FTS *   ftsp = NULL;
     FTSENT *curr;
 
     // Cast needed (in C) because fts_open() takes a "char * const *", instead
@@ -542,7 +542,7 @@ PDC_Server_lookup_server_id(int remote_server_id)
 
     lookup_args->server_id = remote_server_id;
     hg_ret                 = HG_Addr_lookup(hg_context_g, lookup_remote_server_cb, lookup_args,
-                                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         LOG_ERROR("==PDC_SERVER: Connection to remote server FAILED!\n");
         ret_value = FAIL;
@@ -662,7 +662,7 @@ PDC_Server_lookup_client(uint32_t client_id)
 
     // Lookup and fill the client info
     server_lookup_args_t lookup_args;
-    char                *target_addr_string;
+    char *               target_addr_string;
 
     lookup_args.server_id   = pdc_server_rank_g;
     lookup_args.client_id   = client_id;
@@ -798,7 +798,7 @@ PDC_Server_init(int port, hg_class_t **hg_class, hg_context_t **hg_context)
     uint32_t          credential = 0, cookie;
     drc_info_handle_t credential_info;
     char              pdc_auth_key[256] = {'\0'};
-    char             *auth_key;
+    char *            auth_key;
     int               rc;
 #endif
 
@@ -1051,7 +1051,7 @@ perr_t
 PDC_Server_finalize()
 {
     pdc_data_server_io_list_t *io_elt     = NULL;
-    region_list_t             *region_elt = NULL, *region_tmp = NULL;
+    region_list_t *            region_elt = NULL, *region_tmp = NULL;
     perr_t                     ret_value = SUCCEED;
     hg_return_t                hg_ret;
 
@@ -1217,21 +1217,21 @@ perr_t
 PDC_Server_checkpoint()
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_metadata_t              *elt;
-    region_list_t               *region_elt;
-    pdc_kvtag_list_t            *kvlist_elt;
-    pdc_hash_table_entry_head   *head;
+    pdc_metadata_t *             elt;
+    region_list_t *              region_elt;
+    pdc_kvtag_list_t *           kvlist_elt;
+    pdc_hash_table_entry_head *  head;
     pdc_cont_hash_table_entry_t *cont_head;
     int n_entry, metadata_size = 0, region_count = 0, n_region, n_objs, n_write_region = 0, n_kvtag, key_len;
     uint32_t          hash_key;
     HashTablePair     pair;
     char              checkpoint_file[ADDR_MAX], checkpoint_file_local[ADDR_MAX], cmd[4096];
     HashTableIterator hash_table_iter;
-    char             *checkpoint;
-    char             *env_char;
+    char *            checkpoint;
+    char *            env_char;
     uint64_t          checkpoint_size;
     bool              use_tmpfs = false;
-    FILE             *file;
+    FILE *            file;
 
     FUNC_ENTER(NULL);
 
@@ -1352,7 +1352,7 @@ PDC_Server_checkpoint()
             metadata_size++;
             region_count += n_region;
         } // End for metadata entry linked list
-    } // End for hash table metadata entry
+    }     // End for hash table metadata entry
 
     // Note data server region are managed by data server instead of metadata server
     data_server_region_t *region = NULL;
@@ -1446,14 +1446,14 @@ PDC_Server_restart(char *filename)
     int    n_entry, count, i, j, nobj = 0, all_nobj = 0, all_n_region, n_region, n_objs, total_region = 0,
                               n_kvtag, key_len;
     int                          n_cont, all_cont;
-    pdc_metadata_t              *metadata, *elt;
-    region_list_t               *region_list;
-    pdc_hash_table_entry_head   *entry;
+    pdc_metadata_t *             metadata, *elt;
+    region_list_t *              region_list;
+    pdc_hash_table_entry_head *  entry;
     pdc_cont_hash_table_entry_t *cont_entry;
-    uint32_t                    *hash_key;
+    uint32_t *                   hash_key;
     unsigned                     idx;
     uint64_t                     checkpoint_size;
-    char                        *checkpoint_buf;
+    char *                       checkpoint_buf;
 #ifdef PDC_TIMING
     double start = MPI_Wtime();
 #endif
@@ -1734,8 +1734,8 @@ PDC_Server_restart(char *filename)
     MPI_Reduce(&nobj, &all_nobj, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&total_region, &all_n_region, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_nobj     = nobj;
-    all_n_region = total_region;
+    all_nobj          = nobj;
+    all_n_region      = total_region;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1763,7 +1763,7 @@ done:
 static HG_THREAD_RETURN_TYPE
 hg_progress_thread(void *arg)
 {
-    hg_context_t         *context = (hg_context_t *)arg;
+    hg_context_t *        context = (hg_context_t *)arg;
     HG_THREAD_RETURN_TYPE tret    = (HG_THREAD_RETURN_TYPE)0;
     hg_return_t           ret     = HG_SUCCESS;
 
@@ -2248,7 +2248,7 @@ server_run(int argc, char *argv[])
         rocksdb_options_set_create_if_missing(options, 1);
 
         rocksdb_block_based_table_options_t *table_options = rocksdb_block_based_options_create();
-        rocksdb_filterpolicy_t              *filter_policy = rocksdb_filterpolicy_create_bloom(10);
+        rocksdb_filterpolicy_t *             filter_policy = rocksdb_filterpolicy_create_bloom(10);
         rocksdb_block_based_options_set_filter_policy(table_options, filter_policy);
 
         rocksdb_options_set_block_based_table_factory(options, table_options);

--- a/src/server/pdc_server_analysis/pdc_server_analysis.c
+++ b/src/server/pdc_server_analysis/pdc_server_analysis.c
@@ -88,7 +88,7 @@ perr_t
 PDC_Server_instantiate_data_iterator(obj_data_iterator_in_t *in, obj_data_iterator_out_t *out)
 {
     perr_t                     ret_value        = SUCCEED;
-    data_server_region_t *     region_reference = NULL;
+    data_server_region_t      *region_reference = NULL;
     struct _pdc_iterator_info *thisIter;
 
     FUNC_ENTER(NULL);
@@ -169,7 +169,7 @@ void *
 PDC_Server_get_ftn_reference(char *ftn)
 {
     static void *appHandle = NULL;
-    void *       ftnHandle = NULL;
+    void        *ftnHandle = NULL;
     if (appHandle == NULL) {
         /* We need the in_process address of the function */
         if ((appHandle = dlopen(0, RTLD_NOW)) == NULL) {
@@ -218,7 +218,7 @@ PDCobj_data_getNextBlock(pdcid_t iter, void **nextBlock, size_t *dims)
         if (thisIter->srcStart == NULL) {
             if (execution_locus == SERVER_MEMORY) {
                 if ((thisIter->srcNext = PDC_Server_get_region_data_ptr(thisIter->objectId)) == NULL)
-                    thisIter->srcNext = malloc(thisIter->totalElements * thisIter->element_size);
+                    thisIter->srcNext = PDC_malloc(thisIter->totalElements * thisIter->element_size);
                 if ((thisIter->srcStart = thisIter->srcNext) == NULL) {
                     LOG_ERROR("==PDC_ANALYSIS_SERVER: Unable to allocate iterator storage\n");
                     return 0;

--- a/src/server/pdc_server_analysis/pdc_server_analysis.c
+++ b/src/server/pdc_server_analysis/pdc_server_analysis.c
@@ -88,7 +88,7 @@ perr_t
 PDC_Server_instantiate_data_iterator(obj_data_iterator_in_t *in, obj_data_iterator_out_t *out)
 {
     perr_t                     ret_value        = SUCCEED;
-    data_server_region_t      *region_reference = NULL;
+    data_server_region_t *     region_reference = NULL;
     struct _pdc_iterator_info *thisIter;
 
     FUNC_ENTER(NULL);
@@ -169,7 +169,7 @@ void *
 PDC_Server_get_ftn_reference(char *ftn)
 {
     static void *appHandle = NULL;
-    void        *ftnHandle = NULL;
+    void *       ftnHandle = NULL;
     if (appHandle == NULL) {
         /* We need the in_process address of the function */
         if ((appHandle = dlopen(0, RTLD_NOW)) == NULL) {

--- a/src/server/pdc_server_metadata.c
+++ b/src/server/pdc_server_metadata.c
@@ -1520,9 +1520,9 @@ PDC_Server_get_partial_query_result(metadata_query_transfer_in_t *in, uint32_t *
 
     // n_buf = n_metadata_g + 1 for potential padding array
     n_buf     = n_metadata_g + 1;
-    *buf_ptrs = (void **)calloc(n_buf, sizeof(void *));
+    *buf_ptrs = (void **)PDC_calloc(n_buf, sizeof(void *));
     for (i = 0; i < n_buf; i++) {
-        (*buf_ptrs)[i] = (void *)calloc(1, sizeof(void *));
+        (*buf_ptrs)[i] = (void *)PDC_calloc(1, sizeof(void *));
     }
     // TODO: free buf_ptrs
     if (metadata_hash_table_g != NULL) {
@@ -1567,7 +1567,7 @@ num_query_action_someta(void *cond_exact, void *cond_lo, void *cond_hi, int lo_i
     size_t               input_size = ((pdc_kvtag_t *)input)->size;
     libhl_cmp_callback_t cmp_func   = LIBHL_CMP_CB(num_type);
     *out_len                        = 1;
-    *out                            = calloc(1, sizeof(uint64_t));
+    *out                            = PDC_calloc(1, sizeof(uint64_t));
     pbool_t ret_value               = FALSE;
     if (cond_exact != NULL) { // Exact
         ret_value = cmp_func(input_val, input_size, cond_exact, get_size_by_dtype(num_type)) == 0;
@@ -1643,7 +1643,7 @@ sqlite_query_kvtag_callback(void *data, int argc, char **argv, char **colName)
         pdcid_t id = strtoull(argv[0], NULL, 10);
         if (query_data->nobj >= query_data->nalloc) {
             query_data->nalloc *= 2;
-            *query_data->obj_ids = realloc(*query_data->obj_ids, query_data->nalloc * sizeof(uint64_t));
+            *query_data->obj_ids = PDC_realloc(*query_data->obj_ids, query_data->nalloc * sizeof(uint64_t));
         }
         (*query_data->obj_ids)[query_data->nobj] = id;
         query_data->nobj += 1;
@@ -1686,7 +1686,7 @@ PDC_Server_query_kvtag_rocksdb(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj
         if (_is_matching_kvtag(in, &tmp) == TRUE) {
             if (iter >= alloc_size) {
                 alloc_size *= 2;
-                *obj_ids = (void *)realloc(*obj_ids, alloc_size * sizeof(uint64_t));
+                *obj_ids = (void *)PDC_realloc(*obj_ids, alloc_size * sizeof(uint64_t));
             }
             (*obj_ids)[iter++] = obj_id;
         }
@@ -1845,7 +1845,7 @@ PDC_Server_query_kvtag_someta(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
 #endif
                         if (iter >= alloc_size) {
                             alloc_size *= 2;
-                            *obj_ids = (void *)realloc(*obj_ids, alloc_size * sizeof(uint64_t));
+                            *obj_ids = (void *)PDC_realloc(*obj_ids, alloc_size * sizeof(uint64_t));
                         }
                         (*obj_ids)[iter++] = elt->obj_id;
                         // break; // FIXME: shall we break here? or continue to check other kvtags?
@@ -1882,7 +1882,7 @@ PDC_Server_get_kvtag_query_result(pdc_kvtag_t *in /*FIXME: query input should be
     FUNC_ENTER(NULL);
 
     *n_meta  = 0;
-    *obj_ids = (void *)calloc(alloc_size, sizeof(uint64_t));
+    *obj_ids = (void *)PDC_calloc(alloc_size, sizeof(uint64_t));
 
     char *v_query = (char *)in->value;
     LOG_INFO("==PDC_SERVER[%d] before stripQuotes: Querying kvtag with key [%s], value [%s]\n",
@@ -2239,7 +2239,7 @@ PDC_Server_create_container(gen_cont_id_in_t *in, gen_cont_id_out_t *out)
             *hash_key = in->hash_value;
 
             pdc_cont_hash_table_entry_t *entry =
-                (pdc_cont_hash_table_entry_t *)calloc(1, sizeof(pdc_cont_hash_table_entry_t));
+                (pdc_cont_hash_table_entry_t *)PDC_calloc(1, sizeof(pdc_cont_hash_table_entry_t));
             strcpy(entry->cont_name, in->cont_name);
             entry->n_obj       = 0;
             entry->n_allocated = 0;
@@ -2588,7 +2588,7 @@ PDC_copy_all_storage_meta(pdc_metadata_t *meta, region_storage_meta_t **storage_
     region_head = meta->storage_region_list_head;
     DL_COUNT(region_head, region_elt, region_cnt);
     *n_region     = region_cnt;
-    *storage_meta = (region_storage_meta_t *)calloc(sizeof(region_storage_meta_t), region_cnt);
+    *storage_meta = (region_storage_meta_t *)PDC_calloc(sizeof(region_storage_meta_t), region_cnt);
 
     i = 0;
     DL_FOREACH(region_head, region_elt)
@@ -2633,8 +2633,8 @@ PDC_Server_get_storage_meta_by_names(query_read_names_args_t *args)
     FUNC_ENTER(NULL);
 
     // Get the storage meta for each queried object name
-    all_storage_meta = (region_storage_meta_t **)calloc(sizeof(region_storage_meta_t *), args->cnt);
-    all_nregion      = (int *)calloc(sizeof(int), args->cnt);
+    all_storage_meta = (region_storage_meta_t **)PDC_calloc(sizeof(region_storage_meta_t *), args->cnt);
+    all_nregion      = (int *)PDC_calloc(sizeof(int), args->cnt);
 
     total_region = 0;
     for (i = 0; i < args->cnt; i++) {
@@ -2679,8 +2679,8 @@ PDC_Server_get_storage_meta_by_names(query_read_names_args_t *args)
     // bulk transfer to args->origin_id
     // Prepare bulk ptrs, buf_ptrs[0] is task_id
     int nbuf  = total_region + 1;
-    buf_sizes = (hg_size_t *)calloc(nbuf, sizeof(hg_size_t));
-    buf_ptrs  = (void **)calloc(nbuf, sizeof(void *));
+    buf_sizes = (hg_size_t *)PDC_calloc(nbuf, sizeof(hg_size_t));
+    buf_ptrs  = (void **)PDC_calloc(nbuf, sizeof(void *));
 
     buf_ptrs[0]  = &(args->client_seq_id);
     buf_sizes[0] = sizeof(int);

--- a/src/server/pdc_server_metadata.c
+++ b/src/server/pdc_server_metadata.c
@@ -126,7 +126,7 @@ PDC_Server_metadata_int_hash_key_free(void *key)
 static void
 PDC_Server_metadata_hash_value_free(void *value)
 {
-    pdc_metadata_t            *elt, *tmp;
+    pdc_metadata_t *           elt, *tmp;
     pdc_hash_table_entry_head *head;
 
     FUNC_ENTER(NULL);
@@ -253,9 +253,9 @@ done:
 pdc_metadata_t *
 find_metadata_by_id(uint64_t obj_id)
 {
-    pdc_metadata_t            *ret_value = NULL;
+    pdc_metadata_t *           ret_value = NULL;
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t            *elt;
+    pdc_metadata_t *           elt;
     HashTableIterator          hash_table_iter;
     HashTablePair              pair;
     int                        n_entry;
@@ -321,7 +321,7 @@ static pdc_metadata_t *
 find_identical_metadata(pdc_hash_table_entry_head *entry, pdc_metadata_t *a)
 {
     pdc_metadata_t *ret_value = NULL;
-    BLOOM_TYPE_T   *bloom;
+    BLOOM_TYPE_T *  bloom;
     int             bloom_check;
     char            combined_string[TAG_LEN_MAX];
     pdc_metadata_t *elt;
@@ -774,8 +774,8 @@ PDC_Server_update_metadata(metadata_update_in_t *in, metadata_update_out_t *out)
     perr_t                     ret_value = SUCCEED;
     uint64_t                   obj_id;
     pdc_hash_table_entry_head *lookup_value;
-    uint32_t                  *hash_key = NULL;
-    pdc_metadata_t            *target;
+    uint32_t *                 hash_key = NULL;
+    pdc_metadata_t *           target;
 
     FUNC_ENTER(NULL);
 
@@ -899,7 +899,7 @@ perr_t
 PDC_Server_delete_metadata_by_id(metadata_delete_by_id_in_t *in, metadata_delete_by_id_out_t *out)
 {
     perr_t            ret_value = FAIL;
-    pdc_metadata_t   *elt;
+    pdc_metadata_t *  elt;
     HashTableIterator hash_table_iter;
     HashTablePair     pair;
     uint64_t          target_obj_id;
@@ -985,8 +985,8 @@ PDC_Server_delete_metadata_by_id(metadata_delete_by_id_in_t *in, metadata_delete
                     ret_value = SUCCEED;
                 }
             } // DL_FOREACH
-        } // while
-    } // if (metadata_hash_table_g != NULL)
+        }     // while
+    }         // if (metadata_hash_table_g != NULL)
     else {
         LOG_ERROR("==PDC_SERVER: metadata_hash_table_g not initialized!\n");
         ret_value = FAIL;
@@ -1040,7 +1040,7 @@ perr_t
 PDC_delete_metadata_from_hash_table(metadata_delete_in_t *in, metadata_delete_out_t *out)
 {
     perr_t          ret_value = SUCCEED;
-    uint32_t       *hash_key  = NULL;
+    uint32_t *      hash_key  = NULL;
     pdc_metadata_t *target;
 
     FUNC_ENTER(NULL);
@@ -1170,7 +1170,7 @@ PDC_insert_metadata_to_hash_table(gen_obj_id_in_t *in, gen_obj_id_out_t *out)
 {
     perr_t          ret_value = SUCCEED;
     pdc_metadata_t *metadata;
-    uint32_t       *hash_key, i;
+    uint32_t *      hash_key, i;
     int             unlocked = 0;
 
     // DEBUG
@@ -1231,7 +1231,7 @@ PDC_insert_metadata_to_hash_table(gen_obj_id_in_t *in, gen_obj_id_out_t *out)
     *hash_key = in->hash_value;
 
     pdc_hash_table_entry_head *lookup_value;
-    pdc_metadata_t            *found_identical;
+    pdc_metadata_t *           found_identical;
 
     if (debug_flag == 1)
         LOG_DEBUG("checking hash table with key=%d\n", *hash_key);
@@ -1336,7 +1336,7 @@ PDC_Server_print_all_metadata()
 {
     perr_t                     ret_value = SUCCEED;
     HashTableIterator          hash_table_iter;
-    pdc_metadata_t            *elt;
+    pdc_metadata_t *           elt;
     pdc_hash_table_entry_head *head;
     HashTablePair              pair;
 
@@ -1391,7 +1391,7 @@ PDC_Server_metadata_duplicate_check()
     int                        all_maybe, all_total, all_entry;
     int                        has_dup_obj = 0;
     int                        all_dup_obj = 0;
-    pdc_metadata_t            *elt, *elt_next;
+    pdc_metadata_t *           elt, *elt_next;
     pdc_hash_table_entry_head *head;
 
     FUNC_ENTER(NULL);
@@ -1403,9 +1403,9 @@ PDC_Server_metadata_duplicate_check()
     MPI_Reduce(&n_bloom_total_g, &all_total, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&n_entry, &all_entry, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_maybe = n_bloom_maybe_g;
-    all_total = n_bloom_total_g;
-    all_entry = n_entry;
+    all_maybe   = n_bloom_maybe_g;
+    all_total   = n_bloom_total_g;
+    all_entry   = n_entry;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1511,7 +1511,7 @@ PDC_Server_get_partial_query_result(metadata_query_transfer_in_t *in, uint32_t *
     uint32_t                   i;
     uint32_t                   n_buf, iter = 0;
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t            *elt;
+    pdc_metadata_t *           elt;
     HashTableIterator          hash_table_iter;
     int                        n_entry;
     HashTablePair              pair;
@@ -1563,7 +1563,7 @@ void
 num_query_action_someta(void *cond_exact, void *cond_lo, void *cond_hi, int lo_inclusive, int hi_inclusive,
                         pdc_c_var_type_t num_type, void *input, void **out, uint64_t *out_len)
 {
-    void                *input_val  = ((pdc_kvtag_t *)input)->value;
+    void *               input_val  = ((pdc_kvtag_t *)input)->value;
     size_t               input_size = ((pdc_kvtag_t *)input)->size;
     libhl_cmp_callback_t cmp_func   = LIBHL_CMP_CB(num_type);
     *out_len                        = 1;
@@ -1589,7 +1589,7 @@ num_query_action_someta(void *cond_exact, void *cond_lo, void *cond_hi, int lo_i
         pbool_t hi_rst = (hi_inclusive)
                              ? cmp_func(input_val, input_size, cond_hi, get_size_by_dtype(num_type)) <= 0
                              : cmp_func(input_val, input_size, cond_hi, get_size_by_dtype(num_type)) < 0;
-        ret_value      = lo_rst && hi_rst;
+        ret_value = lo_rst && hi_rst;
     }
     else {
     }
@@ -1670,7 +1670,7 @@ PDC_Server_query_kvtag_rocksdb(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj
     uint32_t    iter = 0;
 
     rocksdb_readoptions_t *readoptions  = rocksdb_readoptions_create();
-    rocksdb_iterator_t    *rocksdb_iter = rocksdb_create_iterator(rocksdb_g, readoptions);
+    rocksdb_iterator_t *   rocksdb_iter = rocksdb_create_iterator(rocksdb_g, readoptions);
     rocksdb_iter_seek_to_first(rocksdb_iter);
 
     // Iterate over all rocksdb kv
@@ -1713,8 +1713,8 @@ PDC_Server_query_kvtag_sqlite(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
     perr_t ret_value = SUCCEED;
 #ifdef ENABLE_SQLITE3
     char                sql[TAG_LEN_MAX];
-    char               *errMessage = NULL;
-    char               *tmp_value, *tmp_name, *current_pos;
+    char *              errMessage = NULL;
+    char *              tmp_value, *tmp_name, *current_pos;
     pdc_sqlite3_query_t query_data;
 
     // Check if there is * in tag name
@@ -1815,8 +1815,8 @@ PDC_Server_query_kvtag_someta(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
     perr_t                     ret_value = SUCCEED;
     uint32_t                   iter      = 0;
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t            *elt;
-    pdc_kvtag_list_t          *kvtag_list_elt;
+    pdc_metadata_t *           elt;
+    pdc_kvtag_list_t *         kvtag_list_elt;
     HashTableIterator          hash_table_iter;
     int                        n_entry, is_name_match, is_value_match;
     HashTablePair              pair;
@@ -1856,8 +1856,8 @@ PDC_Server_query_kvtag_someta(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
 #endif
                     }
                 } // End for each kvtag in list
-            } // End for each metadata from hash table entry
-        } // End looping metadata hash table
+            }     // End for each metadata from hash table entry
+        }         // End looping metadata hash table
         *n_meta = iter;
 #ifdef PDC_DEBUG_OUTPUT
         LOG_DEBUG("==PDC_SERVER[%d]: found %d objids \n", pdc_server_rank_g, iter);
@@ -1931,7 +1931,7 @@ PDC_Server_search_with_name_timestep(const char *obj_name, uint32_t hash_key, ui
     perr_t                     ret_value = SUCCEED;
     pdc_hash_table_entry_head *lookup_value;
     pdc_metadata_t             metadata;
-    const char                *name;
+    const char *               name;
 
     FUNC_ENTER(NULL);
 
@@ -1982,7 +1982,7 @@ PDC_Server_search_with_name_hash(const char *obj_name, uint32_t hash_key, pdc_me
     perr_t                     ret_value = SUCCEED;
     pdc_hash_table_entry_head *lookup_value;
     pdc_metadata_t             metadata;
-    const char                *name;
+    const char *               name;
 
     FUNC_ENTER(NULL);
 
@@ -2034,7 +2034,7 @@ PDC_Server_get_local_metadata_by_id(uint64_t obj_id, pdc_metadata_t **res_meta_p
     perr_t ret_value = SUCCEED;
 
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t            *elt;
+    pdc_metadata_t *           elt;
     HashTableIterator          hash_table_iter;
     int                        n_entry;
     HashTablePair              pair;
@@ -2084,7 +2084,7 @@ PDC_Server_get_metadata_by_id_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                ret_value;
     hg_handle_t                handle;
-    pdc_metadata_t            *meta = NULL;
+    pdc_metadata_t *           meta = NULL;
     get_metadata_by_id_args_t *cb_args;
     get_metadata_by_id_out_t   output;
 
@@ -2131,7 +2131,7 @@ done:
 perr_t
 PDC_Server_get_metadata_by_id_with_cb(uint64_t obj_id, perr_t (*cb)(), void *args)
 {
-    pdc_metadata_t            *res_meta_ptr = NULL;
+    pdc_metadata_t *           res_meta_ptr = NULL;
     hg_return_t                hg_ret;
     perr_t                     ret_value = SUCCEED;
     uint32_t                   server_id = 0;
@@ -2622,14 +2622,14 @@ PDC_Server_get_storage_meta_by_names(query_read_names_args_t *args)
     hg_handle_t             rpc_handle;
     hg_bulk_t               bulk_handle;
     bulk_rpc_in_t           bulk_rpc_in;
-    void                  **buf_ptrs;
-    hg_size_t              *buf_sizes;
+    void **                 buf_ptrs;
+    hg_size_t *             buf_sizes;
     uint32_t                client_id;
-    char                   *obj_name;
-    pdc_metadata_t         *meta = NULL;
+    char *                  obj_name;
+    pdc_metadata_t *        meta = NULL;
     int                     i = 0, j = 0;
     region_storage_meta_t **all_storage_meta;
-    int                    *all_nregion, total_region;
+    int *                   all_nregion, total_region;
     FUNC_ENTER(NULL);
 
     // Get the storage meta for each queried object name
@@ -2772,7 +2772,7 @@ PDC_add_kvtag_to_list(pdc_kvtag_list_t **list_head, pdc_kvtag_t *tag)
 {
     perr_t            ret_value = SUCCEED;
     pdc_kvtag_list_t *new_list_item;
-    pdc_kvtag_t      *newtag;
+    pdc_kvtag_t *     newtag;
     FUNC_ENTER(NULL);
 
     PDC_kvtag_dup(tag, &newtag);
@@ -2861,7 +2861,7 @@ static perr_t
 PDC_Server_add_kvtag_someta(metadata_add_kvtag_in_t *in, metadata_add_tag_out_t *out)
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_hash_table_entry_head   *lookup_value;
+    pdc_hash_table_entry_head *  lookup_value;
     pdc_cont_hash_table_entry_t *cont_lookup_value;
     uint32_t                     hash_key;
 
@@ -2880,7 +2880,7 @@ PDC_Server_add_kvtag_someta(metadata_add_kvtag_in_t *in, metadata_add_tag_out_t 
             ret_value = FAIL;
             out->ret  = -1;
         }
-    } // if lookup_value != NULL
+    }      // if lookup_value != NULL
     else { // look for containers
         cont_lookup_value = hash_table_lookup(container_hash_table_g, &hash_key);
         if (cont_lookup_value != NULL) {
@@ -3056,9 +3056,9 @@ PDC_Server_get_kvtag_rocksdb(metadata_get_kvtag_in_t *in, metadata_get_kvtag_out
     rocksdb_readoptions_t *readoptions              = rocksdb_readoptions_create();
     char                   rocksdb_key[TAG_LEN_MAX] = {0};
     sprintf(rocksdb_key, "%lu`%s", in->obj_id, in->key);
-    char  *err = NULL;
+    char * err = NULL;
     size_t len;
-    char  *value = rocksdb_get(rocksdb_g, readoptions, rocksdb_key, strlen(rocksdb_key) + 1, &len, &err);
+    char * value = rocksdb_get(rocksdb_g, readoptions, rocksdb_key, strlen(rocksdb_key) + 1, &len, &err);
     if (value == NULL) {
         LOG_ERROR("==PDC_SERVER[%d]: Error with rocksdb_get %s, [%s]!\n", pdc_server_rank_g, in->key, err);
         ret_value = FAIL;
@@ -3110,7 +3110,7 @@ PDC_Server_get_kvtag_someta(metadata_get_kvtag_in_t *in, metadata_get_kvtag_out_
     perr_t                       ret_value = SUCCEED;
     uint32_t                     hash_key;
     uint64_t                     obj_id;
-    pdc_hash_table_entry_head   *lookup_value;
+    pdc_hash_table_entry_head *  lookup_value;
     pdc_cont_hash_table_entry_t *cont_lookup_value;
 
     hash_key = in->hash_value;
@@ -3257,7 +3257,7 @@ PDC_Server_del_kvtag_rocksdb(metadata_get_kvtag_in_t *in, metadata_add_tag_out_t
 {
     perr_t ret_value = SUCCEED;
 #ifdef ENABLE_ROCKSDB
-    char                   *err                      = NULL;
+    char *                  err                      = NULL;
     char                    rocksdb_key[TAG_LEN_MAX] = {0};
     rocksdb_writeoptions_t *writeoptions             = rocksdb_writeoptions_create();
 
@@ -3309,7 +3309,7 @@ PDC_Server_del_kvtag_someta(metadata_get_kvtag_in_t *in, metadata_add_tag_out_t 
     perr_t                       ret_value = SUCCEED;
     uint32_t                     hash_key;
     uint64_t                     obj_id;
-    pdc_hash_table_entry_head   *lookup_value;
+    pdc_hash_table_entry_head *  lookup_value;
     pdc_cont_hash_table_entry_t *cont_lookup_value;
 
     hash_key = in->hash_value;

--- a/src/server/pdc_server_metadata.c
+++ b/src/server/pdc_server_metadata.c
@@ -159,7 +159,7 @@ PDC_Server_container_hash_value_free(void *value)
 {
     pdc_cont_hash_table_entry_t *head = (pdc_cont_hash_table_entry_t *)value;
     if (head->obj_ids != NULL)
-        free(head->obj_ids);
+        head->obj_ids = (uint64_t *)PDC_free(head->obj_ids);
 }
 
 /*
@@ -2122,7 +2122,7 @@ PDC_Server_get_metadata_by_id_cb(const struct hg_cb_info *callback_info)
 
 done:
     HG_Free_output(handle, &output);
-    free(cb_args);
+    cb_args = (get_metadata_by_id_args_t *)PDC_free(cb_args);
     HG_Destroy(handle);
 
     FUNC_LEAVE(ret_value);

--- a/src/server/pdc_server_metadata.c
+++ b/src/server/pdc_server_metadata.c
@@ -113,7 +113,7 @@ PDC_Server_metadata_int_hash(void *vlocation)
 static void
 PDC_Server_metadata_int_hash_key_free(void *key)
 {
-    free((uint32_t *)key);
+    key = (void *)PDC_free((uint32_t *)key);
 }
 
 /*
@@ -126,7 +126,7 @@ PDC_Server_metadata_int_hash_key_free(void *key)
 static void
 PDC_Server_metadata_hash_value_free(void *value)
 {
-    pdc_metadata_t *           elt, *tmp;
+    pdc_metadata_t            *elt, *tmp;
     pdc_hash_table_entry_head *head;
 
     FUNC_ENTER(NULL);
@@ -142,7 +142,7 @@ PDC_Server_metadata_hash_value_free(void *value)
     if (is_restart_g == 0) {
         DL_FOREACH_SAFE(head->metadata, elt, tmp)
         {
-            free(elt);
+            elt = (pdc_metadata_t *)PDC_free(elt);
         }
     }
 }
@@ -253,9 +253,9 @@ done:
 pdc_metadata_t *
 find_metadata_by_id(uint64_t obj_id)
 {
-    pdc_metadata_t *           ret_value = NULL;
+    pdc_metadata_t            *ret_value = NULL;
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t *           elt;
+    pdc_metadata_t            *elt;
     HashTableIterator          hash_table_iter;
     HashTablePair              pair;
     int                        n_entry;
@@ -321,7 +321,7 @@ static pdc_metadata_t *
 find_identical_metadata(pdc_hash_table_entry_head *entry, pdc_metadata_t *a)
 {
     pdc_metadata_t *ret_value = NULL;
-    BLOOM_TYPE_T *  bloom;
+    BLOOM_TYPE_T   *bloom;
     int             bloom_check;
     char            combined_string[TAG_LEN_MAX];
     pdc_metadata_t *elt;
@@ -668,7 +668,7 @@ PDC_Server_add_tag_metadata(metadata_add_tag_in_t *in, metadata_add_tag_out_t *o
     gettimeofday(&pdc_timer_start, 0);
 #endif
 
-    hash_key = (uint32_t *)malloc(sizeof(uint32_t));
+    hash_key = (uint32_t *)PDC_malloc(sizeof(uint32_t));
     if (hash_key == NULL) {
         LOG_ERROR("==PDC_SERVER: Cannot allocate hash_key!\n");
         goto done;
@@ -774,8 +774,8 @@ PDC_Server_update_metadata(metadata_update_in_t *in, metadata_update_out_t *out)
     perr_t                     ret_value = SUCCEED;
     uint64_t                   obj_id;
     pdc_hash_table_entry_head *lookup_value;
-    uint32_t *                 hash_key = NULL;
-    pdc_metadata_t *           target;
+    uint32_t                  *hash_key = NULL;
+    pdc_metadata_t            *target;
 
     FUNC_ENTER(NULL);
 
@@ -788,7 +788,7 @@ PDC_Server_update_metadata(metadata_update_in_t *in, metadata_update_out_t *out)
     gettimeofday(&pdc_timer_start, 0);
 #endif
 
-    hash_key = (uint32_t *)malloc(sizeof(uint32_t));
+    hash_key = (uint32_t *)PDC_malloc(sizeof(uint32_t));
     if (hash_key == NULL) {
         LOG_ERROR("==PDC_SERVER: Cannot allocate hash_key!\n");
         goto done;
@@ -899,7 +899,7 @@ perr_t
 PDC_Server_delete_metadata_by_id(metadata_delete_by_id_in_t *in, metadata_delete_by_id_out_t *out)
 {
     perr_t            ret_value = FAIL;
-    pdc_metadata_t *  elt;
+    pdc_metadata_t   *elt;
     HashTableIterator hash_table_iter;
     HashTablePair     pair;
     uint64_t          target_obj_id;
@@ -985,8 +985,8 @@ PDC_Server_delete_metadata_by_id(metadata_delete_by_id_in_t *in, metadata_delete
                     ret_value = SUCCEED;
                 }
             } // DL_FOREACH
-        }     // while
-    }         // if (metadata_hash_table_g != NULL)
+        } // while
+    } // if (metadata_hash_table_g != NULL)
     else {
         LOG_ERROR("==PDC_SERVER: metadata_hash_table_g not initialized!\n");
         ret_value = FAIL;
@@ -1040,7 +1040,7 @@ perr_t
 PDC_delete_metadata_from_hash_table(metadata_delete_in_t *in, metadata_delete_out_t *out)
 {
     perr_t          ret_value = SUCCEED;
-    uint32_t *      hash_key  = NULL;
+    uint32_t       *hash_key  = NULL;
     pdc_metadata_t *target;
 
     FUNC_ENTER(NULL);
@@ -1054,7 +1054,7 @@ PDC_delete_metadata_from_hash_table(metadata_delete_in_t *in, metadata_delete_ou
     gettimeofday(&pdc_timer_start, 0);
 #endif
 
-    hash_key = (uint32_t *)malloc(sizeof(uint32_t));
+    hash_key = (uint32_t *)PDC_malloc(sizeof(uint32_t));
     if (hash_key == NULL) {
         LOG_ERROR("==PDC_SERVER: Cannot allocate hash_key!\n");
         goto done;
@@ -1170,7 +1170,7 @@ PDC_insert_metadata_to_hash_table(gen_obj_id_in_t *in, gen_obj_id_out_t *out)
 {
     perr_t          ret_value = SUCCEED;
     pdc_metadata_t *metadata;
-    uint32_t *      hash_key, i;
+    uint32_t       *hash_key, i;
     int             unlocked = 0;
 
     // DEBUG
@@ -1231,7 +1231,7 @@ PDC_insert_metadata_to_hash_table(gen_obj_id_in_t *in, gen_obj_id_out_t *out)
     *hash_key = in->hash_value;
 
     pdc_hash_table_entry_head *lookup_value;
-    pdc_metadata_t *           found_identical;
+    pdc_metadata_t            *found_identical;
 
     if (debug_flag == 1)
         LOG_DEBUG("checking hash table with key=%d\n", *hash_key);
@@ -1254,7 +1254,7 @@ PDC_insert_metadata_to_hash_table(gen_obj_id_in_t *in, gen_obj_id_out_t *out)
                 LOG_ERROR("==PDC_SERVER[%d]: Found identical metadata with name %s!\n", pdc_server_rank_g,
                           metadata->obj_name);
                 out->obj_id = 0;
-                free(metadata);
+                metadata    = (pdc_metadata_t *)PDC_free(metadata);
                 goto done;
             }
             else {
@@ -1336,7 +1336,7 @@ PDC_Server_print_all_metadata()
 {
     perr_t                     ret_value = SUCCEED;
     HashTableIterator          hash_table_iter;
-    pdc_metadata_t *           elt;
+    pdc_metadata_t            *elt;
     pdc_hash_table_entry_head *head;
     HashTablePair              pair;
 
@@ -1391,7 +1391,7 @@ PDC_Server_metadata_duplicate_check()
     int                        all_maybe, all_total, all_entry;
     int                        has_dup_obj = 0;
     int                        all_dup_obj = 0;
-    pdc_metadata_t *           elt, *elt_next;
+    pdc_metadata_t            *elt, *elt_next;
     pdc_hash_table_entry_head *head;
 
     FUNC_ENTER(NULL);
@@ -1403,9 +1403,9 @@ PDC_Server_metadata_duplicate_check()
     MPI_Reduce(&n_bloom_total_g, &all_total, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&n_entry, &all_entry, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
 #else
-    all_maybe   = n_bloom_maybe_g;
-    all_total   = n_bloom_total_g;
-    all_entry   = n_entry;
+    all_maybe = n_bloom_maybe_g;
+    all_total = n_bloom_total_g;
+    all_entry = n_entry;
 #endif
 
     if (pdc_server_rank_g == 0) {
@@ -1511,7 +1511,7 @@ PDC_Server_get_partial_query_result(metadata_query_transfer_in_t *in, uint32_t *
     uint32_t                   i;
     uint32_t                   n_buf, iter = 0;
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t *           elt;
+    pdc_metadata_t            *elt;
     HashTableIterator          hash_table_iter;
     int                        n_entry;
     HashTablePair              pair;
@@ -1563,7 +1563,7 @@ void
 num_query_action_someta(void *cond_exact, void *cond_lo, void *cond_hi, int lo_inclusive, int hi_inclusive,
                         pdc_c_var_type_t num_type, void *input, void **out, uint64_t *out_len)
 {
-    void *               input_val  = ((pdc_kvtag_t *)input)->value;
+    void                *input_val  = ((pdc_kvtag_t *)input)->value;
     size_t               input_size = ((pdc_kvtag_t *)input)->size;
     libhl_cmp_callback_t cmp_func   = LIBHL_CMP_CB(num_type);
     *out_len                        = 1;
@@ -1589,7 +1589,7 @@ num_query_action_someta(void *cond_exact, void *cond_lo, void *cond_hi, int lo_i
         pbool_t hi_rst = (hi_inclusive)
                              ? cmp_func(input_val, input_size, cond_hi, get_size_by_dtype(num_type)) <= 0
                              : cmp_func(input_val, input_size, cond_hi, get_size_by_dtype(num_type)) < 0;
-        ret_value = lo_rst && hi_rst;
+        ret_value      = lo_rst && hi_rst;
     }
     else {
     }
@@ -1670,7 +1670,7 @@ PDC_Server_query_kvtag_rocksdb(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj
     uint32_t    iter = 0;
 
     rocksdb_readoptions_t *readoptions  = rocksdb_readoptions_create();
-    rocksdb_iterator_t *   rocksdb_iter = rocksdb_create_iterator(rocksdb_g, readoptions);
+    rocksdb_iterator_t    *rocksdb_iter = rocksdb_create_iterator(rocksdb_g, readoptions);
     rocksdb_iter_seek_to_first(rocksdb_iter);
 
     // Iterate over all rocksdb kv
@@ -1713,8 +1713,8 @@ PDC_Server_query_kvtag_sqlite(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
     perr_t ret_value = SUCCEED;
 #ifdef ENABLE_SQLITE3
     char                sql[TAG_LEN_MAX];
-    char *              errMessage = NULL;
-    char *              tmp_value, *tmp_name, *current_pos;
+    char               *errMessage = NULL;
+    char               *tmp_value, *tmp_name, *current_pos;
     pdc_sqlite3_query_t query_data;
 
     // Check if there is * in tag name
@@ -1740,7 +1740,7 @@ PDC_Server_query_kvtag_sqlite(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
                 sprintf(sql, "SELECT objid FROM objects WHERE name = \'%s\' AND value_text LIKE \'%s\';",
                         in->name, tmp_value);
                 if (tmp_value)
-                    free(tmp_value);
+                    tmp_value = (char *)PDC_free(tmp_value);
             }
         }
         else {
@@ -1779,7 +1779,7 @@ PDC_Server_query_kvtag_sqlite(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
                 sprintf(sql, "SELECT objid FROM objects WHERE name LIKE \'%s\' AND value_text LIKE \'%s\';",
                         tmp_name, tmp_value);
                 if (tmp_value)
-                    free(tmp_value);
+                    tmp_value = (char *)PDC_free(tmp_value);
             }
         }
         else {
@@ -1788,7 +1788,7 @@ PDC_Server_query_kvtag_sqlite(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
         }
 
         if (tmp_name)
-            free(tmp_name);
+            tmp_name = (char *)PDC_free(tmp_name);
     }
 
     query_data.nobj    = 0;
@@ -1815,8 +1815,8 @@ PDC_Server_query_kvtag_someta(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
     perr_t                     ret_value = SUCCEED;
     uint32_t                   iter      = 0;
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t *           elt;
-    pdc_kvtag_list_t *         kvtag_list_elt;
+    pdc_metadata_t            *elt;
+    pdc_kvtag_list_t          *kvtag_list_elt;
     HashTableIterator          hash_table_iter;
     int                        n_entry, is_name_match, is_value_match;
     HashTablePair              pair;
@@ -1856,8 +1856,8 @@ PDC_Server_query_kvtag_someta(pdc_kvtag_t *in, uint32_t *n_meta, uint64_t **obj_
 #endif
                     }
                 } // End for each kvtag in list
-            }     // End for each metadata from hash table entry
-        }         // End looping metadata hash table
+            } // End for each metadata from hash table entry
+        } // End looping metadata hash table
         *n_meta = iter;
 #ifdef PDC_DEBUG_OUTPUT
         LOG_DEBUG("==PDC_SERVER[%d]: found %d objids \n", pdc_server_rank_g, iter);
@@ -1931,7 +1931,7 @@ PDC_Server_search_with_name_timestep(const char *obj_name, uint32_t hash_key, ui
     perr_t                     ret_value = SUCCEED;
     pdc_hash_table_entry_head *lookup_value;
     pdc_metadata_t             metadata;
-    const char *               name;
+    const char                *name;
 
     FUNC_ENTER(NULL);
 
@@ -1982,7 +1982,7 @@ PDC_Server_search_with_name_hash(const char *obj_name, uint32_t hash_key, pdc_me
     perr_t                     ret_value = SUCCEED;
     pdc_hash_table_entry_head *lookup_value;
     pdc_metadata_t             metadata;
-    const char *               name;
+    const char                *name;
 
     FUNC_ENTER(NULL);
 
@@ -2034,7 +2034,7 @@ PDC_Server_get_local_metadata_by_id(uint64_t obj_id, pdc_metadata_t **res_meta_p
     perr_t ret_value = SUCCEED;
 
     pdc_hash_table_entry_head *head;
-    pdc_metadata_t *           elt;
+    pdc_metadata_t            *elt;
     HashTableIterator          hash_table_iter;
     int                        n_entry;
     HashTablePair              pair;
@@ -2084,7 +2084,7 @@ PDC_Server_get_metadata_by_id_cb(const struct hg_cb_info *callback_info)
 {
     hg_return_t                ret_value;
     hg_handle_t                handle;
-    pdc_metadata_t *           meta = NULL;
+    pdc_metadata_t            *meta = NULL;
     get_metadata_by_id_args_t *cb_args;
     get_metadata_by_id_out_t   output;
 
@@ -2102,7 +2102,7 @@ PDC_Server_get_metadata_by_id_cb(const struct hg_cb_info *callback_info)
 
     if (output.res_meta.obj_id != 0) {
         // TODO free metdata
-        meta = (pdc_metadata_t *)malloc(sizeof(pdc_metadata_t));
+        meta = (pdc_metadata_t *)PDC_malloc(sizeof(pdc_metadata_t));
         PDC_transfer_t_to_metadata_t(&output.res_meta, meta);
     }
     else {
@@ -2131,7 +2131,7 @@ done:
 perr_t
 PDC_Server_get_metadata_by_id_with_cb(uint64_t obj_id, perr_t (*cb)(), void *args)
 {
-    pdc_metadata_t *           res_meta_ptr = NULL;
+    pdc_metadata_t            *res_meta_ptr = NULL;
     hg_return_t                hg_ret;
     perr_t                     ret_value = SUCCEED;
     uint32_t                   server_id = 0;
@@ -2165,7 +2165,7 @@ PDC_Server_get_metadata_by_id_with_cb(uint64_t obj_id, perr_t (*cb)(), void *arg
         HG_Create(hg_context_g, pdc_remote_server_info_g[server_id].addr, get_metadata_by_id_register_id_g,
                   &get_metadata_by_id_handle);
 
-        cb_args       = (get_metadata_by_id_args_t *)malloc(sizeof(get_metadata_by_id_args_t));
+        cb_args       = (get_metadata_by_id_args_t *)PDC_malloc(sizeof(get_metadata_by_id_args_t));
         in.obj_id     = obj_id;
         cb_args->cb   = cb;
         cb_args->args = args;
@@ -2230,7 +2230,7 @@ PDC_Server_create_container(gen_cont_id_in_t *in, gen_cont_id_out_t *out)
             out->cont_id = lookup_value->cont_id;
         }
         else {
-            hash_key = (uint32_t *)malloc(sizeof(uint32_t));
+            hash_key = (uint32_t *)PDC_malloc(sizeof(uint32_t));
             if (hash_key == NULL) {
                 LOG_ERROR("Cannot allocate hash_key!\n");
                 ret_value = FAIL;
@@ -2622,14 +2622,14 @@ PDC_Server_get_storage_meta_by_names(query_read_names_args_t *args)
     hg_handle_t             rpc_handle;
     hg_bulk_t               bulk_handle;
     bulk_rpc_in_t           bulk_rpc_in;
-    void **                 buf_ptrs;
-    hg_size_t *             buf_sizes;
+    void                  **buf_ptrs;
+    hg_size_t              *buf_sizes;
     uint32_t                client_id;
-    char *                  obj_name;
-    pdc_metadata_t *        meta = NULL;
+    char                   *obj_name;
+    pdc_metadata_t         *meta = NULL;
     int                     i = 0, j = 0;
     region_storage_meta_t **all_storage_meta;
-    int *                   all_nregion, total_region;
+    int                    *all_nregion, total_region;
     FUNC_ENTER(NULL);
 
     // Get the storage meta for each queried object name
@@ -2772,7 +2772,7 @@ PDC_add_kvtag_to_list(pdc_kvtag_list_t **list_head, pdc_kvtag_t *tag)
 {
     perr_t            ret_value = SUCCEED;
     pdc_kvtag_list_t *new_list_item;
-    pdc_kvtag_t *     newtag;
+    pdc_kvtag_t      *newtag;
     FUNC_ENTER(NULL);
 
     PDC_kvtag_dup(tag, &newtag);
@@ -2861,7 +2861,7 @@ static perr_t
 PDC_Server_add_kvtag_someta(metadata_add_kvtag_in_t *in, metadata_add_tag_out_t *out)
 {
     perr_t                       ret_value = SUCCEED;
-    pdc_hash_table_entry_head *  lookup_value;
+    pdc_hash_table_entry_head   *lookup_value;
     pdc_cont_hash_table_entry_t *cont_lookup_value;
     uint32_t                     hash_key;
 
@@ -2880,7 +2880,7 @@ PDC_Server_add_kvtag_someta(metadata_add_kvtag_in_t *in, metadata_add_tag_out_t 
             ret_value = FAIL;
             out->ret  = -1;
         }
-    }      // if lookup_value != NULL
+    } // if lookup_value != NULL
     else { // look for containers
         cont_lookup_value = hash_table_lookup(container_hash_table_g, &hash_key);
         if (cont_lookup_value != NULL) {
@@ -3011,21 +3011,21 @@ sqlite_get_kvtag_callback(void *data, int argc, char **argv, char **colName)
     for (int i = 0; i < argc; i++) {
         if (NULL != argv[i]) {
             if (0 == strcmp(colName[i], "value_int")) {
-                int *int_tmp = (int *)malloc(sizeof(int));
+                int *int_tmp = (int *)PDC_malloc(sizeof(int));
                 *int_tmp     = atoi(argv[i]);
                 out->value   = (void *)int_tmp;
                 out->size    = sizeof(int);
                 break;
             }
             else if (0 == strcmp(colName[i], "value_real")) {
-                float *float_tmp = (float *)malloc(sizeof(float));
+                float *float_tmp = (float *)PDC_malloc(sizeof(float));
                 *float_tmp       = (float)atof(argv[i]);
                 out->value       = (void *)float_tmp;
                 out->size        = sizeof(float);
                 break;
             }
             else if (0 == strcmp(colName[i], "value_double")) {
-                double *double_tmp = (double *)malloc(sizeof(double));
+                double *double_tmp = (double *)PDC_malloc(sizeof(double));
                 *double_tmp        = atof(argv[i]);
                 out->value         = (void *)double_tmp;
                 out->size          = sizeof(double);
@@ -3056,9 +3056,9 @@ PDC_Server_get_kvtag_rocksdb(metadata_get_kvtag_in_t *in, metadata_get_kvtag_out
     rocksdb_readoptions_t *readoptions              = rocksdb_readoptions_create();
     char                   rocksdb_key[TAG_LEN_MAX] = {0};
     sprintf(rocksdb_key, "%lu`%s", in->obj_id, in->key);
-    char * err = NULL;
+    char  *err = NULL;
     size_t len;
-    char * value = rocksdb_get(rocksdb_g, readoptions, rocksdb_key, strlen(rocksdb_key) + 1, &len, &err);
+    char  *value = rocksdb_get(rocksdb_g, readoptions, rocksdb_key, strlen(rocksdb_key) + 1, &len, &err);
     if (value == NULL) {
         LOG_ERROR("==PDC_SERVER[%d]: Error with rocksdb_get %s, [%s]!\n", pdc_server_rank_g, in->key, err);
         ret_value = FAIL;
@@ -3110,7 +3110,7 @@ PDC_Server_get_kvtag_someta(metadata_get_kvtag_in_t *in, metadata_get_kvtag_out_
     perr_t                       ret_value = SUCCEED;
     uint32_t                     hash_key;
     uint64_t                     obj_id;
-    pdc_hash_table_entry_head *  lookup_value;
+    pdc_hash_table_entry_head   *lookup_value;
     pdc_cont_hash_table_entry_t *cont_lookup_value;
 
     hash_key = in->hash_value;
@@ -3238,11 +3238,11 @@ PDC_del_kvtag_value_from_list(pdc_kvtag_list_t **list_head, char *key)
     DL_FOREACH(*list_head, elt)
     {
         if (strcmp(elt->kvtag->name, key) == 0) {
-            free(elt->kvtag->name);
-            free(elt->kvtag->value);
-            free(elt->kvtag);
+            elt->kvtag->name  = (char *)PDC_free(elt->kvtag->name);
+            elt->kvtag->value = (void *)PDC_free(elt->kvtag->value);
+            elt->kvtag        = (pdc_kvtag_t *)PDC_free(elt->kvtag);
             DL_DELETE(*list_head, elt);
-            free(elt);
+            elt = (pdc_kvtag_list_t *)PDC_free(elt);
             break;
         }
     }
@@ -3257,7 +3257,7 @@ PDC_Server_del_kvtag_rocksdb(metadata_get_kvtag_in_t *in, metadata_add_tag_out_t
 {
     perr_t ret_value = SUCCEED;
 #ifdef ENABLE_ROCKSDB
-    char *                  err                      = NULL;
+    char                   *err                      = NULL;
     char                    rocksdb_key[TAG_LEN_MAX] = {0};
     rocksdb_writeoptions_t *writeoptions             = rocksdb_writeoptions_create();
 
@@ -3309,7 +3309,7 @@ PDC_Server_del_kvtag_someta(metadata_get_kvtag_in_t *in, metadata_add_tag_out_t 
     perr_t                       ret_value = SUCCEED;
     uint32_t                     hash_key;
     uint64_t                     obj_id;
-    pdc_hash_table_entry_head *  lookup_value;
+    pdc_hash_table_entry_head   *lookup_value;
     pdc_cont_hash_table_entry_t *cont_lookup_value;
 
     hash_key = in->hash_value;

--- a/src/server/pdc_server_metadata_index.c
+++ b/src/server/pdc_server_metadata_index.c
@@ -48,8 +48,8 @@ PDC_Server_dart_perform_one_server(dart_perform_one_server_in_t *in, dart_perfor
     perr_t                 result     = SUCCEED;
     dart_op_type_t         op_type    = in->op_type;
     dart_hash_algo_t       hash_algo  = in->hash_algo;
-    char                  *attr_key   = (char *)in->attr_key;
-    void                  *attr_val   = in->attr_val;
+    char *                 attr_key   = (char *)in->attr_key;
+    void *                 attr_val   = in->attr_val;
     uint32_t               attr_vsize = in->attr_vsize;
     pdc_c_var_type_t       attr_dtype = in->attr_vtype;
     dart_object_ref_type_t ref_type   = in->obj_ref_type;

--- a/src/server/pdc_server_metadata_index.c
+++ b/src/server/pdc_server_metadata_index.c
@@ -48,19 +48,20 @@ PDC_Server_dart_perform_one_server(dart_perform_one_server_in_t *in, dart_perfor
     perr_t                 result     = SUCCEED;
     dart_op_type_t         op_type    = in->op_type;
     dart_hash_algo_t       hash_algo  = in->hash_algo;
-    char *                 attr_key   = (char *)in->attr_key;
-    void *                 attr_val   = in->attr_val;
+    char                  *attr_key   = (char *)in->attr_key;
+    void                  *attr_val   = in->attr_val;
     uint32_t               attr_vsize = in->attr_vsize;
     pdc_c_var_type_t       attr_dtype = in->attr_vtype;
     dart_object_ref_type_t ref_type   = in->obj_ref_type;
 
-    IDIOMS_md_idx_record_t *idx_record = (IDIOMS_md_idx_record_t *)calloc(1, sizeof(IDIOMS_md_idx_record_t));
-    idx_record->key                    = attr_key;
-    idx_record->value                  = attr_val;
-    idx_record->virtual_node_id        = in->vnode_id;
-    idx_record->type                   = in->attr_vtype;
-    idx_record->value_len              = in->attr_vsize;
-    idx_record->src_client_id          = in->src_client_id;
+    IDIOMS_md_idx_record_t *idx_record =
+        (IDIOMS_md_idx_record_t *)PDC_calloc(1, sizeof(IDIOMS_md_idx_record_t));
+    idx_record->key             = attr_key;
+    idx_record->value           = attr_val;
+    idx_record->virtual_node_id = in->vnode_id;
+    idx_record->type            = in->attr_vtype;
+    idx_record->value_len       = in->attr_vsize;
+    idx_record->src_client_id   = in->src_client_id;
 
     uint64_t obj_locator = in->obj_primary_ref;
     if (ref_type == REF_PRIMARY_ID) {
@@ -73,7 +74,7 @@ PDC_Server_dart_perform_one_server(dart_perform_one_server_in_t *in, dart_perfor
         obj_locator = in->obj_server_ref;
     }
 
-    idx_record->obj_ids     = (uint64_t *)calloc(1, sizeof(uint64_t));
+    idx_record->obj_ids     = (uint64_t *)PDC_calloc(1, sizeof(uint64_t));
     idx_record->obj_ids[0]  = obj_locator;
     idx_record->num_obj_ids = 1;
 

--- a/src/server/pdc_server_metadata_index_test.c
+++ b/src/server/pdc_server_metadata_index_test.c
@@ -9,8 +9,8 @@
 void
 delete_kv_from_index(char *kv, uint64_t obj_id)
 {
-    char  *key      = NULL;
-    char  *value    = NULL;
+    char * key      = NULL;
+    char * value    = NULL;
     int8_t kv_dtype = PDC_STRING;
 
     dart_perform_one_server_in_t  input;
@@ -75,8 +75,8 @@ void
 insert_kv_to_index(char *kv, uint64_t obj_id)
 {
 
-    char  *key      = NULL;
-    void  *value    = NULL;
+    char * key      = NULL;
+    void * value    = NULL;
     int8_t kv_dtype = PDC_STRING;
 
     dart_perform_one_server_in_t  input;

--- a/src/server/pdc_server_metadata_index_test.c
+++ b/src/server/pdc_server_metadata_index_test.c
@@ -9,8 +9,8 @@
 void
 delete_kv_from_index(char *kv, uint64_t obj_id)
 {
-    char * key      = NULL;
-    char * value    = NULL;
+    char  *key      = NULL;
+    char  *value    = NULL;
     int8_t kv_dtype = PDC_STRING;
 
     dart_perform_one_server_in_t  input;
@@ -75,8 +75,8 @@ void
 insert_kv_to_index(char *kv, uint64_t obj_id)
 {
 
-    char * key      = NULL;
-    void * value    = NULL;
+    char  *key      = NULL;
+    void  *value    = NULL;
     int8_t kv_dtype = PDC_STRING;
 
     dart_perform_one_server_in_t  input;
@@ -144,9 +144,9 @@ void
 query_result_from_kvtag(char *key_value_query, int8_t op_type)
 {
     dart_perform_one_server_in_t *input =
-        (dart_perform_one_server_in_t *)calloc(1, sizeof(dart_perform_one_server_in_t));
+        (dart_perform_one_server_in_t *)PDC_calloc(1, sizeof(dart_perform_one_server_in_t));
     dart_perform_one_server_out_t *output =
-        (dart_perform_one_server_out_t *)calloc(1, sizeof(dart_perform_one_server_out_t));
+        (dart_perform_one_server_out_t *)PDC_calloc(1, sizeof(dart_perform_one_server_out_t));
     uint64_t  n_obj_ids = 0;
     uint64_t *buf_ptr   = NULL;
     input->op_type      = op_type;
@@ -165,8 +165,8 @@ test_PDC_Server_dart_perform_one_server()
 
     PDC_Server_metadata_index_init(1, 0);
 
-    char *kv    = (char *)calloc(20, sizeof(char));
-    char *numkv = (char *)calloc(20, sizeof(char));
+    char *kv    = (char *)PDC_calloc(20, sizeof(char));
+    char *numkv = (char *)PDC_calloc(20, sizeof(char));
 
     for (int i = 0; i < 1000; i++) {
         sprintf(kv, "key%03dkey=\"val%03dval\"", i, i);

--- a/src/server/pdc_server_region/pdc_server_data.c
+++ b/src/server/pdc_server_region/pdc_server_data.c
@@ -62,7 +62,7 @@
 #include "pdc_logger.h"
 
 // Global object region info list in local data server
-data_server_region_t *      dataserver_region_g     = NULL;
+data_server_region_t       *dataserver_region_g     = NULL;
 data_server_region_unmap_t *dataserver_region_unmap = NULL;
 
 int pdc_buffered_bulk_update_total_g = 0;
@@ -79,10 +79,10 @@ uint64_t max_mem_cache_size_mb_g       = 0;
 int      cache_percentage_g            = 0;
 int      current_read_from_cache_cnt_g = 0;
 int      total_read_from_cache_cnt_g   = 0;
-FILE *   pdc_cache_file_ptr_g          = NULL;
+FILE    *pdc_cache_file_ptr_g          = NULL;
 char     pdc_cache_file_path_g[ADDR_MAX];
 
-query_task_t *          query_task_list_head_g      = NULL;
+query_task_t           *query_task_list_head_g      = NULL;
 cache_storage_region_t *cache_storage_region_head_g = NULL;
 
 static int
@@ -263,13 +263,13 @@ PDC_Server_local_region_lock_status(PDC_mapping_info_t *mapped_region, int *lock
 {
     perr_t          ret_value = SUCCEED;
     pdc_metadata_t *res_meta;
-    region_list_t * elt, *request_region;
+    region_list_t  *elt, *request_region;
 
     FUNC_ENTER(NULL);
 
     // Check if the region lock info is on current server
     *lock_status   = 0;
-    request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&(mapped_region->remote_region), request_region);
     res_meta = find_metadata_by_id(mapped_region->remote_obj_id);
     if (res_meta == NULL || res_meta->region_lock_head == NULL) {
@@ -295,7 +295,7 @@ PDC_Server_local_region_lock_status(PDC_mapping_info_t *mapped_region, int *lock
             elt->client_id   = mapped_region->remote_client_id;
         }
     }
-    free(request_region);
+    request_region = (region_list_t *)PDC_free(request_region);
 
 done:
     FUNC_LEAVE(ret_value);
@@ -309,7 +309,7 @@ PDC_Server_region_lock_status(PDC_mapping_info_t *mapped_region, int *lock_statu
     uint32_t       server_id = 0;
 
     *lock_status   = 0;
-    request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_region_transfer_t_to_list_t(&(mapped_region->remote_region), request_region);
 
     server_id = PDC_get_server_by_obj_id(mapped_region->remote_obj_id, pdc_server_size_g);
@@ -364,7 +364,7 @@ PDC_Server_clear_obj_region()
 {
     perr_t                ret_value = SUCCEED;
     data_server_region_t *elt, *tmp;
-    region_list_t *       elt2, *tmp2;
+    region_list_t        *elt2, *tmp2;
 
     FUNC_ENTER(NULL);
     if (dataserver_region_g != NULL) {
@@ -372,11 +372,10 @@ PDC_Server_clear_obj_region()
         {
             DL_FOREACH_SAFE(elt->region_storage_head, elt2, tmp2)
             {
-                // DL_DELETE(elt->region_storage_head, elt2);
-                free(elt2);
+                elt2 = (region_list_t *)PDC_free(elt2);
             }
-            free(elt->storage_location);
-            free(elt);
+            elt->storage_location = (char *)PDC_free(elt->storage_location);
+            elt                   = (data_server_region_t *)PDC_free(elt);
         }
     }
     FUNC_LEAVE(ret_value);
@@ -392,7 +391,7 @@ PDC_Server_register_obj_region_by_pointer(data_server_region_t **new_obj_reg_ptr
     FUNC_ENTER(NULL);
 
     if (new_obj_reg == NULL) {
-        new_obj_reg = (data_server_region_t *)malloc(sizeof(struct data_server_region_t));
+        new_obj_reg = (data_server_region_t *)PDC_malloc(sizeof(struct data_server_region_t));
         if (new_obj_reg == NULL) {
             ret_value = FAIL;
         }
@@ -402,7 +401,7 @@ PDC_Server_register_obj_region_by_pointer(data_server_region_t **new_obj_reg_ptr
         new_obj_reg->region_lock_request_head = NULL;
         new_obj_reg->region_storage_head      = NULL;
         new_obj_reg->close_flag               = close_flag;
-        new_obj_reg->storage_location         = (char *)malloc(sizeof(char) * ADDR_MAX);
+        new_obj_reg->storage_location         = (char *)PDC_malloc(sizeof(char) * ADDR_MAX);
 
         new_obj_reg->fd = server_open_storage(new_obj_reg->storage_location, obj_id);
         if (new_obj_reg->fd < 0) {
@@ -473,10 +472,10 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
 {
     perr_t                ret_value = SUCCEED;
     int                   ndim;
-    region_list_t *       request_region;
+    region_list_t        *request_region;
     data_server_region_t *new_obj_reg;
-    region_list_t *       elt1, *tmp;
-    region_buf_map_t *    eltt;
+    region_list_t        *elt1, *tmp;
+    region_buf_map_t     *eltt;
     int                   error      = 0;
     int                   found_lock = 0;
     // time_t                t;
@@ -487,7 +486,7 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
     ndim = in->region.ndim;
 
     // Convert transferred lock region to structure
-    request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_init_region_list(request_region);
     request_region->ndim = ndim;
 
@@ -499,7 +498,7 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
 #endif
     new_obj_reg = PDC_Server_get_obj_region(in->obj_id);
     if (new_obj_reg == NULL) {
-        new_obj_reg = (data_server_region_t *)malloc(sizeof(struct data_server_region_t));
+        new_obj_reg = (data_server_region_t *)PDC_malloc(sizeof(struct data_server_region_t));
         if (new_obj_reg == NULL) {
             error = 1;
             PGOTO_ERROR(FAIL, "PDC_SERVER: PDC_Server_region_lock() allocates new object failed");
@@ -538,7 +537,7 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
 
     if (found_lock == 0) {
         // check if the lock region is used in buf map function
-        tmp = (region_list_t *)malloc(sizeof(region_list_t));
+        tmp = (region_list_t *)PDC_malloc(sizeof(region_list_t));
         DL_FOREACH(new_obj_reg->region_buf_map_head, eltt)
         {
             PDC_region_transfer_t_to_list_t(&(eltt->remote_region_unit), tmp);
@@ -547,7 +546,7 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
                 hg_atomic_incr32(&(request_region->buf_map_refcount));
             }
         }
-        free(tmp);
+        tmp = (region_list_t *)PDC_free(tmp);
 
 #ifdef ENABLE_MULTITHREAD
         hg_thread_mutex_lock(&lock_list_mutex_g);
@@ -577,14 +576,14 @@ perr_t
 PDC_Server_release_lock_request(uint64_t obj_id, struct pdc_region_info *region)
 {
     perr_t                ret_value = SUCCEED;
-    region_list_t *       request_region;
-    region_list_t *       elt, *tmp;
+    region_list_t        *request_region;
+    region_list_t        *elt, *tmp;
     data_server_region_t *new_obj_reg;
     region_lock_out_t     out;
 
     FUNC_ENTER(NULL);
 
-    request_region = (region_list_t *)malloc(sizeof(region_list_t));
+    request_region = (region_list_t *)PDC_malloc(sizeof(region_list_t));
     PDC_init_region_list(request_region);
     PDC_region_info_to_list_t(region, request_region);
 
@@ -602,13 +601,13 @@ PDC_Server_release_lock_request(uint64_t obj_id, struct pdc_region_info *region)
             HG_Respond(elt->lock_handle, NULL, NULL, &out);
             HG_Destroy(elt->lock_handle);
             DL_DELETE(new_obj_reg->region_lock_request_head, elt);
-            free(elt);
+            elt = (region_list_t *)PDC_free(elt);
         }
     }
 #ifdef ENABLE_MULTITHREAD
     hg_thread_mutex_unlock(&lock_request_mutex_g);
 #endif
-    free(request_region);
+    request_region = (region_list_t *)PDC_free(request_region);
 
 done:
     fflush(stdout);
@@ -620,7 +619,7 @@ PDC_Data_Server_region_release(region_lock_in_t *in, region_lock_out_t *out)
 {
     perr_t                ret_value = SUCCEED;
     int                   ndim;
-    region_list_t *       tmp1, *tmp2;
+    region_list_t        *tmp1, *tmp2;
     region_list_t         request_region;
     int                   found   = 0;
     data_server_region_t *obj_reg = NULL;
@@ -657,7 +656,7 @@ PDC_Data_Server_region_release(region_lock_in_t *in, region_lock_out_t *out)
             // Found the requested region lock, remove from the linked list
             found = 1;
             DL_DELETE(obj_reg->region_lock_head, tmp1);
-            free(tmp1);
+            tmp1 = (region_list_t *)PDC_free(tmp1);
             tmp1 = NULL;
             break;
         }
@@ -759,7 +758,7 @@ PDC_Data_Server_buf_unmap(const struct hg_info *info, buf_unmap_in_t *in)
 {
     perr_t                ret_value = SUCCEED;
     int                   ret       = HG_UTIL_SUCCESS;
-    region_buf_map_t *    tmp, *elt;
+    region_buf_map_t     *tmp, *elt;
     data_server_region_t *target_obj;
 
     FUNC_ENTER(NULL);
@@ -796,7 +795,7 @@ PDC_Data_Server_buf_unmap(const struct hg_info *info, buf_unmap_in_t *in)
 #endif
             if (ret == HG_UTIL_SUCCESS) {
                 if (elt->remote_data_ptr) {
-                    free(elt->remote_data_ptr);
+                    elt->remote_data_ptr = (void *)PDC_free(elt->remote_data_ptr);
                     elt->remote_data_ptr = NULL;
                 }
                 HG_Addr_free(info->hg_class, elt->local_addr);
@@ -807,14 +806,14 @@ PDC_Data_Server_buf_unmap(const struct hg_info *info, buf_unmap_in_t *in)
                 free(elt->bulk_args);
 #endif
                 DL_DELETE(target_obj->region_buf_map_head, elt);
-                free(elt);
+                elt = (region_buf_map_t *)PDC_free(elt);
             }
 #ifndef ENABLE_WAIT_DATA
             // timeout, append the global list for unmap
 
             else {
                 data_server_region_unmap_t *region = NULL;
-                region = (data_server_region_unmap_t *)malloc(sizeof(struct data_server_region_unmap_t));
+                region = (data_server_region_unmap_t *)PDC_malloc(sizeof(struct data_server_region_unmap_t));
                 if (region == NULL)
                     PGOTO_ERROR(FAIL,
                                 "===PDC_DATA_SERVER: PDC_Data_Server_buf_unmap() - cannot allocate region");
@@ -853,9 +852,9 @@ PDC_Data_Server_check_unmap()
     perr_t                      ret_value = SUCCEED;
     int                         ret       = HG_UTIL_SUCCESS;
     pdcid_t                     remote_obj_id;
-    region_buf_map_t *          tmp, *elt;
+    region_buf_map_t           *tmp, *elt;
     data_server_region_unmap_t *tmp1, *elt1;
-    data_server_region_t *      target_obj;
+    data_server_region_t       *target_obj;
     int                         completed = 0;
 
     FUNC_ENTER(NULL);
@@ -941,7 +940,7 @@ done:
     HG_Destroy(tranx_args->handle);
     HG_Free_output(handle, &out);
     HG_Destroy(handle);
-    free(tranx_args);
+    tranx_args = (struct transfer_buf_unmap *)PDC_free(tranx_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -954,7 +953,7 @@ buf_unmap_lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     struct buf_unmap_server_lookup_args_t *lookup_args;
     hg_handle_t                            server_send_buf_unmap_handle;
     hg_handle_t                            handle;
-    struct transfer_buf_unmap *            tranx_args;
+    struct transfer_buf_unmap             *tranx_args;
     int                                    error = 0;
 
     FUNC_ENTER(NULL);
@@ -1014,11 +1013,11 @@ PDC_Server_buf_unmap_lookup_server_id(int remote_server_id, struct transfer_buf_
 
     handle = transfer_args->handle;
     lookup_args =
-        (struct buf_unmap_server_lookup_args_t *)malloc(sizeof(struct buf_unmap_server_lookup_args_t));
+        (struct buf_unmap_server_lookup_args_t *)PDC_malloc(sizeof(struct buf_unmap_server_lookup_args_t));
     lookup_args->server_id      = remote_server_id;
     lookup_args->buf_unmap_args = transfer_args;
     hg_ret                      = HG_Addr_lookup(hg_context_g, buf_unmap_lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                                 pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         error = 1;
         PGOTO_ERROR(
@@ -1066,7 +1065,7 @@ done:
     HG_Destroy(tranx_args->handle);
     HG_Free_output(handle, &output);
     HG_Destroy(handle);
-    free(tranx_args);
+    tranx_args = (struct transfer_buf_unmap_args *)PDC_free(tranx_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -1078,9 +1077,9 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
     hg_return_t                     hg_ret    = HG_SUCCESS;
     hg_handle_t                     server_send_buf_unmap_handle;
     struct transfer_buf_unmap_args *buf_unmap_args;
-    struct transfer_buf_unmap *     addr_args;
-    pdc_metadata_t *                target_meta = NULL;
-    region_buf_map_t *              tmp, *elt;
+    struct transfer_buf_unmap      *addr_args;
+    pdc_metadata_t                 *target_meta = NULL;
+    region_buf_map_t               *tmp, *elt;
     int                             error = 0;
 
     FUNC_ENTER(NULL);
@@ -1114,7 +1113,7 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
         hg_thread_mutex_lock(&addr_valid_mutex_g);
 #endif
         if (pdc_remote_server_info_g[in->meta_server_id].addr_valid != 1) {
-            addr_args         = (struct transfer_buf_unmap *)malloc(sizeof(struct transfer_buf_unmap));
+            addr_args         = (struct transfer_buf_unmap *)PDC_malloc(sizeof(struct transfer_buf_unmap));
             addr_args->handle = *handle;
             addr_args->in     = *in;
 
@@ -1124,7 +1123,8 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
             HG_Create(hg_context_g, pdc_remote_server_info_g[in->meta_server_id].addr,
                       buf_unmap_server_register_id_g, &server_send_buf_unmap_handle);
 
-            buf_unmap_args = (struct transfer_buf_unmap_args *)malloc(sizeof(struct transfer_buf_unmap_args));
+            buf_unmap_args =
+                (struct transfer_buf_unmap_args *)PDC_malloc(sizeof(struct transfer_buf_unmap_args));
             buf_unmap_args->handle = *handle;
             buf_unmap_args->in     = *in;
             hg_ret =
@@ -1154,14 +1154,14 @@ region_buf_map_t *
 PDC_Data_Server_buf_map(const struct hg_info *info, buf_map_in_t *in, region_list_t *request_region,
                         void *data_ptr)
 {
-    region_buf_map_t *    ret_value   = NULL;
+    region_buf_map_t     *ret_value   = NULL;
     data_server_region_t *new_obj_reg = NULL;
-    region_list_t *       elt_reg;
-    region_buf_map_t *    buf_map_ptr = NULL;
-    region_buf_map_t *    tmp;
+    region_list_t        *elt_reg;
+    region_buf_map_t     *buf_map_ptr = NULL;
+    region_buf_map_t     *tmp;
     int                   dup                      = 0;
-    char *                data_path                = NULL;
-    char *                user_specified_data_path = NULL;
+    char                 *data_path                = NULL;
+    char                 *user_specified_data_path = NULL;
     char                  storage_location[ADDR_MAX];
 #ifdef ENABLE_LUSTRE
     int stripe_count, stripe_size;
@@ -1174,7 +1174,7 @@ PDC_Data_Server_buf_map(const struct hg_info *info, buf_map_in_t *in, region_lis
 #endif
     new_obj_reg = PDC_Server_get_obj_region(in->remote_obj_id);
     if (new_obj_reg == NULL) {
-        new_obj_reg = (data_server_region_t *)malloc(sizeof(struct data_server_region_t));
+        new_obj_reg = (data_server_region_t *)PDC_malloc(sizeof(struct data_server_region_t));
         if (new_obj_reg == NULL)
             PGOTO_ERROR(NULL, "PDC_SERVER: PDC_Server_insert_buf_map_region() allocates new object failed");
         new_obj_reg->obj_id                   = in->remote_obj_id;
@@ -1234,7 +1234,7 @@ PDC_Data_Server_buf_map(const struct hg_info *info, buf_map_in_t *in, region_lis
         }
     }
     if (dup == 0) {
-        buf_map_ptr = (region_buf_map_t *)malloc(sizeof(region_buf_map_t));
+        buf_map_ptr = (region_buf_map_t *)PDC_malloc(sizeof(region_buf_map_t));
         if (buf_map_ptr == NULL)
             PGOTO_ERROR(NULL,
                         "PDC_SERVER: PDC_Server_insert_buf_map_region() allocates region pointer failed");
@@ -1277,9 +1277,9 @@ done:
 void *
 PDC_Server_maybe_allocate_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t region, size_t type_size)
 {
-    void *                ret_value  = NULL;
+    void                 *ret_value  = NULL;
     data_server_region_t *target_obj = NULL, *elt = NULL;
-    region_buf_map_t *    tmp;
+    region_buf_map_t     *tmp;
 
     FUNC_ENTER(NULL);
 
@@ -1310,7 +1310,7 @@ PDC_Server_maybe_allocate_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t 
 
         ret_value = malloc(region_size);
 
-        buf_map_ptr                       = (region_buf_map_t *)malloc(sizeof(region_buf_map_t));
+        buf_map_ptr                       = (region_buf_map_t *)PDC_malloc(sizeof(region_buf_map_t));
         buf_map_ptr->remote_obj_id        = obj_id;
         buf_map_ptr->remote_ndim          = region.ndim;
         buf_map_ptr->remote_data_ptr      = ret_value;
@@ -1331,9 +1331,9 @@ done:
 void *
 PDC_Server_get_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t region)
 {
-    void *                ret_value  = NULL;
+    void                 *ret_value  = NULL;
     data_server_region_t *target_obj = NULL, *elt = NULL;
-    region_buf_map_t *    tmp;
+    region_buf_map_t     *tmp;
 
     FUNC_ENTER(NULL);
 
@@ -1399,7 +1399,7 @@ buf_map_lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     struct buf_map_server_lookup_args_t *lookup_args;
     hg_handle_t                          server_send_buf_map_handle;
     hg_handle_t                          handle;
-    struct transfer_buf_map *            tranx_args;
+    struct transfer_buf_map             *tranx_args;
     int                                  error = 0;
 
     FUNC_ENTER(NULL);
@@ -1458,12 +1458,13 @@ PDC_Server_buf_map_lookup_server_id(int remote_server_id, struct transfer_buf_ma
 
     FUNC_ENTER(NULL);
 
-    handle      = transfer_args->handle;
-    lookup_args = (struct buf_map_server_lookup_args_t *)malloc(sizeof(struct buf_map_server_lookup_args_t));
+    handle = transfer_args->handle;
+    lookup_args =
+        (struct buf_map_server_lookup_args_t *)PDC_malloc(sizeof(struct buf_map_server_lookup_args_t));
     lookup_args->server_id    = remote_server_id;
     lookup_args->buf_map_args = transfer_args;
     hg_ret                    = HG_Addr_lookup(hg_context_g, buf_map_lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                               pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         error = 1;
         PGOTO_ERROR(
@@ -1519,9 +1520,9 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
     hg_return_t                   hg_ret    = HG_SUCCESS;
     hg_handle_t                   server_send_buf_map_handle;
     struct transfer_buf_map_args *tranx_args = NULL;
-    struct transfer_buf_map *     addr_args;
-    pdc_metadata_t *              target_meta = NULL;
-    region_buf_map_t *            buf_map_ptr;
+    struct transfer_buf_map      *addr_args;
+    pdc_metadata_t               *target_meta = NULL;
+    region_buf_map_t             *buf_map_ptr;
     int                           error = 0;
 
     FUNC_ENTER(NULL);
@@ -1534,7 +1535,7 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
             PGOTO_ERROR(FAIL, "PDC_SERVER: PDC_Meta_Server_buf_map() find_metadata_by_id FAILED!");
         }
 
-        buf_map_ptr = (region_buf_map_t *)malloc(sizeof(region_buf_map_t));
+        buf_map_ptr = (region_buf_map_t *)PDC_malloc(sizeof(region_buf_map_t));
         if (buf_map_ptr == NULL) {
             error = 1;
             PGOTO_ERROR(FAIL,
@@ -1570,7 +1571,7 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
         hg_thread_mutex_lock(&addr_valid_mutex_g);
 #endif
         if (pdc_remote_server_info_g[in->meta_server_id].addr_valid != 1) {
-            addr_args         = (struct transfer_buf_map *)malloc(sizeof(struct transfer_buf_map));
+            addr_args         = (struct transfer_buf_map *)PDC_malloc(sizeof(struct transfer_buf_map));
             addr_args->handle = *handle;
             addr_args->in     = *in;
 
@@ -1580,7 +1581,7 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
             HG_Create(hg_context_g, pdc_remote_server_info_g[in->meta_server_id].addr,
                       buf_map_server_register_id_g, &server_send_buf_map_handle);
 
-            tranx_args         = (struct transfer_buf_map_args *)malloc(sizeof(struct transfer_buf_map_args));
+            tranx_args = (struct transfer_buf_map_args *)PDC_malloc(sizeof(struct transfer_buf_map_args));
             tranx_args->handle = *handle;
             tranx_args->in     = *in;
             hg_ret = HG_Forward(server_send_buf_map_handle, server_send_buf_map_rpc_cb, tranx_args, in);
@@ -1794,11 +1795,11 @@ PDC_Server_notify_client_multi_io_complete(uint32_t client_id, int client_seq_id
     hg_return_t             hg_ret    = HG_SUCCESS;
     hg_handle_t             rpc_handle;
     hg_bulk_t               bulk_handle;
-    void **                 buf_ptrs;
-    hg_size_t *             buf_sizes;
+    void                  **buf_ptrs;
+    hg_size_t              *buf_sizes;
     bulk_rpc_in_t           bulk_rpc_in;
     int                     i;
-    region_list_t *         region_elt;
+    region_list_t          *region_elt;
     notify_multi_io_args_t *bulk_args;
 
     FUNC_ENTER(NULL);
@@ -2005,7 +2006,7 @@ PDC_Server_read_check(data_server_read_check_in_t *in, server_read_check_out_t *
 {
     perr_t                     ret_value = SUCCEED;
     pdc_data_server_io_list_t *io_elt = NULL, *io_target = NULL;
-    region_list_t *            region_elt = NULL;
+    region_list_t             *region_elt = NULL;
     region_list_t              r_target;
     /* uint32_t i; */
 
@@ -2091,7 +2092,7 @@ PDC_Server_write_check(data_server_write_check_in_t *in, data_server_write_check
 {
     perr_t                     ret_value = FAIL;
     pdc_data_server_io_list_t *io_elt = NULL, *io_target = NULL;
-    region_list_t *            region_elt = NULL, *region_tmp = NULL;
+    region_list_t             *region_elt = NULL, *region_tmp = NULL;
     int                        found_region = 0;
 
     FUNC_ENTER(NULL);
@@ -2199,7 +2200,7 @@ PDC_Server_get_local_storage_location_of_region(uint64_t obj_id, region_list_t *
 {
     perr_t          ret_value   = SUCCEED;
     pdc_metadata_t *target_meta = NULL;
-    region_list_t * region_elt  = NULL;
+    region_list_t  *region_elt  = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -2326,7 +2327,7 @@ PDC_Server_count_write_check_update_storage_meta_cb(const struct hg_cb_info *cal
             }
 
         } // end of if
-    }     // end of if (write_ret->ret == 1)
+    } // end of if (write_ret->ret == 1)
 
 done:
 
@@ -2358,17 +2359,17 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
     perr_t                             ret_value = SUCCEED;
     uint32_t                           server_id = 0;
     uint32_t                           i, j;
-    pdc_metadata_t *                   region_meta = NULL, *region_meta_prev = NULL;
-    region_list_t *                    region_elt, req_region, **overlap_regions_2d = NULL;
+    pdc_metadata_t                    *region_meta = NULL, *region_meta_prev = NULL;
+    region_list_t                     *region_elt, req_region, **overlap_regions_2d = NULL;
     region_info_transfer_t             local_region_transfer[PDC_SERVER_MAX_PROC_PER_NODE];
-    region_info_transfer_t *           all_requests        = NULL;
+    region_info_transfer_t            *all_requests        = NULL;
     update_region_storage_meta_bulk_t *send_buf            = NULL;
     update_region_storage_meta_bulk_t *result_storage_meta = NULL;
     uint32_t                           total_request_cnt;
     int                                data_size           = sizeof(region_info_transfer_t);
-    int *                              send_bytes          = NULL;
-    int *                              displs              = NULL;
-    int *                              request_overlap_cnt = NULL;
+    int                               *send_bytes          = NULL;
+    int                               *displs              = NULL;
+    int                               *request_overlap_cnt = NULL;
     int                                nrequest_per_server = 0;
 
     FUNC_ENTER(NULL);
@@ -2551,14 +2552,14 @@ done:
 #ifdef ENABLE_MPI
     if (server_id == (uint32_t)pdc_server_rank_g) {
         if (all_requests)
-            free(all_requests);
+            all_requests = (region_info_transfer_t *)PDC_free(all_requests);
         if (overlap_regions_2d)
-            free(overlap_regions_2d);
+            overlap_regions_2d = (region_list_t **)PDC_free(overlap_regions_2d);
         if (send_buf)
-            free(send_buf);
+            send_buf = (update_region_storage_meta_bulk_t *)PDC_free(send_buf);
     }
     if (result_storage_meta)
-        free(result_storage_meta);
+        result_storage_meta = (update_region_storage_meta_bulk_t *)PDC_free(result_storage_meta);
 #else
     if (overlap_regions_2d)
         free(overlap_regions_2d);
@@ -2696,7 +2697,7 @@ PDC_Server_data_io_via_shm(const struct hg_cb_info *callback_info)
     perr_t ret_value = SUCCEED;
 
     pdc_data_server_io_list_t *io_list_elt, *io_list = NULL, *io_list_target = NULL;
-    region_list_t *            region_elt  = NULL, *region_tmp;
+    region_list_t             *region_elt  = NULL, *region_tmp;
     int                        real_bb_cnt = 0, real_lustre_cnt = 0;
     int                        write_to_bb_cnt = 0;
     int                        count;
@@ -3098,7 +3099,7 @@ PDC_Server_update_region_storagelocation_offset(region_list_t *region, int type)
     hg_return_t            hg_ret;
     perr_t                 ret_value   = SUCCEED;
     uint32_t               server_id   = 0;
-    pdc_metadata_t *       region_meta = NULL;
+    pdc_metadata_t        *region_meta = NULL;
     hg_handle_t            update_region_loc_handle;
     update_region_loc_in_t in;
     server_lookup_args_t   lookup_args;
@@ -3200,7 +3201,7 @@ PDC_Server_add_region_storage_meta_to_bulk_buf(region_list_t *region, bulk_xfer_
     int                                i;
     uint64_t                           obj_id = 0;
     update_region_storage_meta_bulk_t *curr_buf_ptr;
-    uint64_t *                         obj_id_ptr;
+    uint64_t                          *obj_id_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -3290,8 +3291,8 @@ PDC_Server_update_region_storage_meta_bulk_local(update_region_storage_meta_bulk
 {
     perr_t                             ret_value = SUCCEED;
     int                                i;
-    pdc_metadata_t *                   target_meta = NULL;
-    region_list_t *                    region_elt = NULL, *new_region = NULL;
+    pdc_metadata_t                    *target_meta = NULL;
+    region_list_t                     *region_elt = NULL, *new_region = NULL;
     update_region_storage_meta_bulk_t *bulk_ptr;
     int                                update_success = 0, express_insert = 0;
     uint64_t                           obj_id;
@@ -3414,7 +3415,7 @@ PDC_Server_update_region_storage_meta_bulk_mpi(bulk_xfer_data_t *bulk_data)
     int                                i;
     uint32_t                           server_id = 0;
     update_region_storage_meta_bulk_t *recv_buf  = NULL;
-    void **                            all_meta  = NULL;
+    void                             **all_meta  = NULL;
 #endif
 
     FUNC_ENTER(NULL);
@@ -3467,9 +3468,9 @@ done:
 }
 
 perr_t
-PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t *          bulk_data, perr_t (*cb)(),
+PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t           *bulk_data, perr_t (*cb)(),
                                                    update_storage_meta_list_t *meta_list_target,
-                                                   int *                       n_updated)
+                                                   int                        *n_updated)
 {
     hg_return_t hg_ret;
     perr_t      ret_value = SUCCEED;
@@ -3710,7 +3711,7 @@ all_select:
                 }
                 *total_read_bytes += read_bytes;
             } // for each row
-        }     // ndim=2
+        } // ndim=2
         else if (ndim == 3) {
             uint64_t buf_serialize_offset;
             /* fseek (fp, storage_offset, SEEK_SET); */
@@ -3793,8 +3794,8 @@ PDC_Server_read_one_region(region_list_t *read_region)
     size_t         total_read_bytes  = 0;
     uint32_t       n_storage_regions = 0;
     region_list_t *region_elt;
-    FILE *         fp_read        = NULL;
-    char *         prev_path      = NULL;
+    FILE          *fp_read        = NULL;
+    char          *prev_path      = NULL;
     int            is_shm_created = 0, is_read_succeed = 0;
 #ifdef ENABLE_TIMING
     double fopen_time;
@@ -3937,8 +3938,8 @@ PDC_Server_posix_one_file_io(region_list_t *region_list_head)
     uint64_t       offset           = 0;
     uint32_t       i                = 0;
     region_list_t *region_elt = NULL, *previous_region = NULL;
-    FILE *         fp_read = NULL, *fp_write = NULL;
-    char *         prev_path = NULL;
+    FILE          *fp_read = NULL, *fp_write = NULL;
+    char          *prev_path = NULL;
 #ifdef ENABLE_LUSTRE
     int stripe_count, stripe_size;
 #endif
@@ -4398,11 +4399,11 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 {
     perr_t                ret_value      = SUCCEED;
     data_server_region_t *region         = NULL;
-    region_list_t *       overlap_region = NULL;
+    region_list_t        *overlap_region = NULL;
     int                   is_contained   = 0;
     uint64_t              i, j, pos;
-    uint64_t *            overlap_offset, *overlap_size;
-    char *                tmp_buf;
+    uint64_t             *overlap_offset, *overlap_size;
+    char                 *tmp_buf;
 #if 0
     size_t                total_write_size = 0, local_write_size;
     int is_overlap;
@@ -4492,7 +4493,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
                 // data_sieving_g = 1 by default, export PDC_DATA_SIEVING=0 to change
                 if (data_sieving_g) {
                     // Create a buffer for loading the entire region.
-                    tmp_buf = (char *)malloc(overlap_region->data_size);
+                    tmp_buf = (char *)PDC_malloc(overlap_region->data_size);
 #ifdef PDC_TIMING
                     start_posix = MPI_Wtime();
 #endif
@@ -4549,7 +4550,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 #endif
                             }
                             else {
-                                tmp_buf = (char *)malloc(overlap_size[0] * overlap_size[1] * unit);
+                                tmp_buf = (char *)PDC_malloc(overlap_size[0] * overlap_size[1] * unit);
                                 memcpy_overlap_subregion(region_info->ndim, unit, buf, region_info->offset,
                                                          region_info->size, tmp_buf, overlap_offset,
                                                          overlap_size, overlap_offset, overlap_size);
@@ -4628,8 +4629,8 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 #endif
                             }
                             else {
-                                tmp_buf = (char *)malloc(overlap_size[0] * overlap_size[1] * overlap_size[2] *
-                                                         unit);
+                                tmp_buf = (char *)PDC_malloc(overlap_size[0] * overlap_size[1] *
+                                                             overlap_size[2] * unit);
                                 memcpy_overlap_subregion(region_info->ndim, unit, buf, region_info->offset,
                                                          region_info->size, tmp_buf, overlap_offset,
                                                          overlap_size, overlap_offset, overlap_size);
@@ -4685,11 +4686,11 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
     if (is_contained == 0) {
         request_region->offset = lseek(region->fd, 0, SEEK_END);
 #ifdef ENABLE_ZFP
-        zfp_field * field;
+        zfp_field  *field;
         zfp_stream *zfp;
         size_t      bufsize;
-        void *      buffer;
-        bitstream * stream;
+        void       *buffer;
+        bitstream  *stream;
 
         field = _setup_zfp(region_info, &zfp);
         if (field == NULL)
@@ -4763,10 +4764,10 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
     perr_t                ret_value     = SUCCEED;
     ssize_t               request_bytes = unit;
     data_server_region_t *region        = NULL;
-    region_list_t *       elt;
+    region_list_t        *elt;
     uint64_t              i, j, pos;
-    uint64_t *            overlap_offset, *overlap_size;
-    char *                tmp_buf;
+    uint64_t             *overlap_offset, *overlap_size;
+    char                 *tmp_buf;
 
     FUNC_ENTER(NULL);
 #ifdef PDC_TIMING
@@ -4827,7 +4828,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
             else {
                 // data_sieving_g = 1 by default, export PDC_DATA_SIEVING=0 to change
                 if (data_sieving_g) {
-                    tmp_buf = (char *)malloc(overlap_region->data_size);
+                    tmp_buf = (char *)PDC_malloc(overlap_region->data_size);
 #ifdef PDC_TIMING
                     start_posix = MPI_Wtime();
 #endif
@@ -4864,10 +4865,10 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
 
 #ifdef ENABLE_ZFP
                     // Uncompress the data
-                    zfp_field * field;
+                    zfp_field  *field;
                     zfp_stream *zfp;
                     size_t      bufsize, decompress_size;
-                    bitstream * stream;
+                    bitstream  *stream;
 
                     field = _setup_zfp(region_info, &zfp);
                     if (field == NULL)
@@ -4936,7 +4937,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
 #endif
                             }
                             else {
-                                tmp_buf = (char *)malloc(overlap_size[0] * overlap_size[1] * unit);
+                                tmp_buf = (char *)PDC_malloc(overlap_size[0] * overlap_size[1] * unit);
 #ifdef PDC_TIMING
                                 start_posix = MPI_Wtime();
 #endif
@@ -5008,8 +5009,8 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
 #endif
                             }
                             else {
-                                tmp_buf = (char *)malloc(overlap_size[0] * overlap_size[1] * overlap_size[2] *
-                                                         unit);
+                                tmp_buf = (char *)PDC_malloc(overlap_size[0] * overlap_size[1] *
+                                                             overlap_size[2] * unit);
 #ifdef PDC_TIMING
                                 start_posix = MPI_Wtime();
 #endif
@@ -5128,7 +5129,7 @@ PDC_Server_get_local_storage_meta_with_one_name(storage_meta_query_one_name_args
 {
     perr_t          ret_value  = SUCCEED;
     pdc_metadata_t *meta       = NULL;
-    region_list_t * region_elt = NULL, *region_head = NULL, *res_region_list = NULL;
+    region_list_t  *region_elt = NULL, *region_head = NULL, *res_region_list = NULL;
     int             region_count = 0, i = 0;
 
     FUNC_ENTER(NULL);
@@ -5260,7 +5261,7 @@ PDC_Server_accumulate_storage_meta_then_read(storage_meta_query_one_name_args_t 
 {
     perr_t                     ret_value = SUCCEED;
     accumulate_storage_meta_t *accu_meta;
-    region_list_t *            req_region = NULL, *region_elt = NULL, *read_list_head = NULL;
+    region_list_t             *req_region = NULL, *region_elt = NULL, *read_list_head = NULL;
     int                        i, is_sort_read;
     size_t                     j;
 
@@ -5428,16 +5429,16 @@ PDC_Server_storage_meta_name_query_bulk_respond(const struct hg_cb_info *callbac
 {
     hg_return_t                         hg_ret = HG_SUCCESS;
     perr_t                              ret_value;
-    storage_meta_name_query_in_t *      args;
+    storage_meta_name_query_in_t       *args;
     storage_meta_query_one_name_args_t *query_args;
     hg_handle_t                         rpc_handle;
     hg_bulk_t                           bulk_handle;
     bulk_rpc_in_t                       bulk_rpc_in;
-    void **                             buf_ptrs;
-    hg_size_t *                         buf_sizes;
+    void                              **buf_ptrs;
+    hg_size_t                          *buf_sizes;
     uint32_t                            server_id;
-    region_info_transfer_t **           region_infos;
-    region_list_t *                     region_elt;
+    region_info_transfer_t            **region_infos;
+    region_list_t                      *region_elt;
     int                                 i, j;
     FUNC_ENTER(NULL);
 
@@ -5580,9 +5581,9 @@ PDC_Server_add_client_shm_to_cache(int cnt, void *buf_cp)
 {
     perr_t                     ret_value = SUCCEED;
     int                        i, j;
-    region_storage_meta_t *    storage_metas = (region_storage_meta_t *)buf_cp;
+    region_storage_meta_t     *storage_metas = (region_storage_meta_t *)buf_cp;
     pdc_data_server_io_list_t *io_list_elt, *io_list_target;
-    region_list_t *            new_region;
+    region_list_t             *new_region;
 
     FUNC_ENTER(NULL);
 
@@ -5694,7 +5695,7 @@ PDC_Server_data_read_to_buf_1_region(region_list_t *region)
 {
     perr_t   ret_value = SUCCEED;
     uint64_t offset, read_bytes;
-    FILE *   fp_read = NULL;
+    FILE    *fp_read = NULL;
 
     if (region->is_data_ready == 1)
         return SUCCEED;
@@ -5743,9 +5744,9 @@ PDC_Server_data_read_to_buf(region_list_t *region_list_head)
 {
     perr_t         ret_value = SUCCEED;
     region_list_t *region_elt;
-    char *         prev_path = NULL;
+    char          *prev_path = NULL;
     uint64_t       offset, read_bytes;
-    FILE *         fp_read = NULL;
+    FILE          *fp_read = NULL;
 
     int read_count = 0;
 
@@ -5884,8 +5885,8 @@ static perr_t
 PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_combine_op_t combine_op)
 {
     perr_t                     ret_value  = SUCCEED;
-    region_list_t *            req_region = NULL, *region_tmp = NULL;
-    region_list_t *            storage_region_list_head = NULL;
+    region_list_t             *req_region = NULL, *region_tmp = NULL;
+    region_list_t             *storage_region_list_head = NULL;
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
     uint64_t                   obj_id;
     int                        iter, count, is_same_region, i, can_skip;
@@ -6157,7 +6158,7 @@ compare_coords_3d(const void *a, const void *b)
     ({                                                                                                       \
         uint64_t idx, iii, jjj, ttt, cur_count = 0, istart, has_dup;                                         \
         int      is_good, _ndim;                                                                             \
-        TYPE *   edata = (TYPE *)(_data);                                                                    \
+        TYPE    *edata = (TYPE *)(_data);                                                                    \
         _ndim          = (_region)->ndim;                                                                    \
         istart         = (_sel)->nhits * _ndim;                                                              \
         if (_ndim > 3) {                                                                                     \
@@ -6302,7 +6303,7 @@ compare_coords_3d(const void *a, const void *b)
     ({                                                                                                       \
         uint64_t idx, iii, jjj, ttt, cur_count = 0, istart, has_dup;                                         \
         int      is_good, _ndim;                                                                             \
-        TYPE *   edata = (TYPE *)(_data);                                                                    \
+        TYPE    *edata = (TYPE *)(_data);                                                                    \
         _ndim          = (_region)->ndim;                                                                    \
         istart         = (_sel)->nhits * _ndim;                                                              \
         if (_ndim > 3) {                                                                                     \
@@ -6463,11 +6464,11 @@ generate_write_fastbit_idx(uint64_t obj_id, void *data, uint64_t dataCount, Fast
     char      keyName[128];
     char      offName[128];
     char      out_name[256];
-    double *  keys    = NULL;
-    int64_t * offsets = NULL;
+    double   *keys    = NULL;
+    int64_t  *offsets = NULL;
     uint32_t *bms     = NULL;
     uint64_t  nk = 0, no = 0, nb = 0;
-    FILE *    fp;
+    FILE     *fp;
 
     FUNC_ENTER(NULL);
 
@@ -6565,7 +6566,7 @@ int
 queryData(const char *name)
 {
     uint64_t               nhits, i;
-    uint64_t *             buf;
+    uint64_t              *buf;
     double                 val1 = 0.0, val2 = 10.0;
     FastBitSelectionHandle sel1 = fastbit_selection_osr(name, FastBitCompareGreater, val1);
     FastBitSelectionHandle sel2 = fastbit_selection_osr(name, FastBitCompareLess, val2);
@@ -6600,7 +6601,7 @@ PDC_load_fastbit_index(char *idx_name, uint64_t obj_id, FastBitDataType dtype, i
     char     offName[128];
     char     out_name[256];
     uint64_t nk = 0, no = 0, nb = 0, size;
-    FILE *   fp;
+    FILE    *fp;
 
     PDC_gen_fastbit_idx_name(bmsName, "bms", obj_id, timestep, ndim, start, count);
     PDC_gen_fastbit_idx_name(keyName, "key", obj_id, timestep, ndim, start, count);
@@ -6676,9 +6677,9 @@ PDC_query_fastbit_idx(region_list_t *region, pdc_query_constraint_t *constraint,
     perr_t          ret_value = SUCCEED;
     FastBitDataType ft        = 0;
     uint64_t        type_size;
-    uint32_t *      bms     = NULL;
-    double *        keys    = NULL;
-    int64_t *       offsets = NULL;
+    uint32_t       *bms     = NULL;
+    double         *keys    = NULL;
+    int64_t        *offsets = NULL;
     int             timestep;
     double          v1, v2;
     size_t          i;
@@ -6854,7 +6855,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
                                     pdc_query_combine_op_t combine_op)
 {
     perr_t           ret_value = SUCCEED;
-    region_list_t *  region_elt, *region_list_head, *cache_region, tmp_region, *region_constraint = NULL;
+    region_list_t   *region_elt, *region_list_head, *cache_region, tmp_region, *region_constraint = NULL;
     pdc_selection_t *sel = query->sel;
     uint64_t         nelem;
     size_t           i, j, unit_size;
@@ -6868,7 +6869,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
     uint32_t ulo = 0, uhi = 0;
     int64_t  i64lo = 0, i64hi = 0;
     uint64_t ui64lo = 0, ui64hi = 0;
-    void *   value = NULL, *buf = NULL;
+    void    *value = NULL, *buf = NULL;
     int      n_eval_region = 0, can_skip, region_iter = 0;
 
     LOG_INFO("==PDC_SERVER[%d]: start query evaluation!\n", pdc_server_rank_g);
@@ -7209,12 +7210,12 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
 
             n_eval_region++;
         } // End DL_FOREACH
-    }     // End not use fastbit
+    } // End not use fastbit
 
     if (n_eval_region == 0 && combine_op == PDC_QUERY_AND) {
         if (sel->nhits > 0) {
-            sel->nhits = 0;
-            free(sel->coords);
+            sel->nhits        = 0;
+            sel->coords       = (uint64_t *)PDC_free(sel->coords);
             sel->coords_alloc = 0;
             sel->coords       = NULL;
         }
@@ -7523,7 +7524,7 @@ PDC_recv_nhits(const struct hg_cb_info *callback_info)
     if (task_elt && task_elt->n_recv >= task_elt->n_sent_server)
         PDC_Server_send_nhits_to_client(task_elt);
 
-    free(in);
+    in = (send_nhits_t *)PDC_free(in);
 
     return ret;
 }
@@ -7537,7 +7538,7 @@ PDC_Server_send_coords_to_client(query_task_t *task)
     hg_bulk_t     bulk_handle;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void *        buf;
+    void         *buf;
     int           client_id;
 
     FUNC_ENTER(NULL);
@@ -7619,7 +7620,7 @@ PDC_Server_send_coords_to_server(query_task_t *task)
     hg_bulk_t     bulk_handle = NULL;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void *        buf;
+    void         *buf;
     int           server_id;
 
     FUNC_ENTER(NULL);
@@ -7826,9 +7827,9 @@ hg_return_t
 PDC_Server_read_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret  = HG_SUCCESS;
-    query_task_t *          task = (query_task_t *)callback_info->arg;
+    query_task_t           *task = (query_task_t *)callback_info->arg;
     pdc_query_constraint_t *constraint;
-    region_list_t *         storage_region_head, *region_elt, *cache_region;
+    region_list_t          *storage_region_head, *region_elt, *cache_region;
     size_t                  ndim, unit_size;
     uint64_t                i, *coord, data_off, buf_off, my_size;
 
@@ -7894,11 +7895,11 @@ PDC_recv_read_coords(const struct hg_cb_info *callback_info)
     hg_return_t         ret               = HG_SUCCESS;
     hg_bulk_t           local_bulk_handle = callback_info->info.bulk.local_handle;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    query_task_t *      task_elt          = NULL;
+    query_task_t       *task_elt          = NULL;
     uint64_t            nhits, obj_id;
     uint32_t            ndim;
     int                 query_id, origin;
-    void *              buf;
+    void               *buf;
 
     pdc_int_ret_t out;
     out.ret = 1;
@@ -7933,7 +7934,7 @@ PDC_recv_read_coords(const struct hg_cb_info *callback_info)
         {
             if (task_elt->query_id == query_id) {
 
-                task_elt->my_read_coords = (uint64_t *)malloc(bulk_args->nbytes);
+                task_elt->my_read_coords = (uint64_t *)PDC_malloc(bulk_args->nbytes);
                 memcpy(task_elt->my_read_coords, buf, bulk_args->nbytes);
 
                 task_elt->my_read_obj_id  = obj_id;
@@ -7966,7 +7967,7 @@ done:
     if (ret != HG_SUCCESS)
         LOG_ERROR("Could not destroy handle\n");
 
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
     return ret;
 }
 
@@ -7977,7 +7978,7 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
     hg_return_t         ret               = HG_SUCCESS;
     hg_bulk_t           local_bulk_handle = callback_info->info.bulk.local_handle;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    query_task_t *      task_elt;
+    query_task_t       *task_elt;
     uint64_t            nhits = 0, total_hits;
     size_t              ndim, unit_size;
     int                 i, query_id, origin, found_task;
@@ -8032,7 +8033,7 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
             task_elt->n_hits_from_server = (uint64_t *)calloc(pdc_server_size_g, sizeof(uint64_t));
 
         if (nhits > 0) {
-            task_elt->coords_arr[origin] = (uint64_t *)malloc(bulk_args->nbytes);
+            task_elt->coords_arr[origin] = (uint64_t *)PDC_malloc(bulk_args->nbytes);
             memcpy(task_elt->coords_arr[origin], buf, bulk_args->nbytes);
             task_elt->n_hits_from_server[origin] = nhits;
         }
@@ -8046,18 +8047,18 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
                 total_hits += task_elt->n_hits_from_server[i];
 
             if (total_hits > 0) {
-                task_elt->coords = (uint64_t *)malloc(total_hits * unit_size);
+                task_elt->coords = (uint64_t *)PDC_malloc(total_hits * unit_size);
                 uint64_t off     = 0, size;
                 for (i = 0; i < pdc_server_size_g; i++) {
                     if (task_elt->coords_arr[i] != NULL) {
                         size = task_elt->n_hits_from_server[i] * unit_size;
                         memcpy(task_elt->coords + off, task_elt->coords_arr[i], size);
-                        free(task_elt->coords_arr[i]);
+                        task_elt->coords_arr[i] = (uint64_t *)PDC_free(task_elt->coords_arr[i]);
                         task_elt->coords_arr[i] = NULL;
                         off += task_elt->n_hits_from_server[i];
                     }
                 }
-                free(task_elt->coords_arr);
+                task_elt->coords_arr = (uint64_t **)PDC_free(task_elt->coords_arr);
                 task_elt->coords_arr = NULL;
             }
 
@@ -8085,7 +8086,7 @@ done:
     if (ret != HG_SUCCESS)
         LOG_ERROR("Could not destroy handle\n");
 
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
 
     return ret;
 }
@@ -8173,7 +8174,7 @@ PDC_Server_do_query(query_task_t *task)
     if (task->get_op == PDC_QUERY_GET_NHITS) {
         if (task->query && task->query->sel && task->query->sel->coords_alloc > 0 &&
             task->query->sel->coords) {
-            free(task->query->sel->coords);
+            task->query->sel->coords       = (uint64_t *)PDC_free(task->query->sel->coords);
             task->query->sel->coords       = 0;
             task->query->sel->coords_alloc = 0;
         }
@@ -8195,7 +8196,7 @@ perr_t
 add_storage_region_to_buf(void **in_buf, uint64_t *buf_alloc, uint64_t *buf_off, const region_list_t *region)
 {
     perr_t   ret_value = SUCCEED;
-    void *   buf       = *in_buf;
+    void    *buf       = *in_buf;
     uint64_t my_size, tmp_size;
 
     if (in_buf == NULL || *in_buf == NULL || region == NULL || buf_alloc == NULL || buf_off == NULL ||
@@ -8391,8 +8392,8 @@ PDC_Server_distribute_query_storage_info(query_task_t *task, uint64_t obj_id, in
 {
     pdc_metadata_t *meta = NULL;
     int             i, server_id, count, avg_count, nsent, nsent_server;
-    region_list_t * elt, *new_region = NULL;
-    void *          region_bulk_buf;
+    region_list_t  *elt, *new_region = NULL;
+    void           *region_bulk_buf;
     uint64_t        buf_alloc = 0, buf_off = 0;
     bulk_rpc_in_t   header;
 
@@ -8532,16 +8533,16 @@ PDC_recv_query_metadata_bulk(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret               = HG_SUCCESS;
     hg_bulk_t               local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *    bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    void *                  buf;
-    region_list_t *         regions = NULL;
+    struct bulk_args_t     *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    void                   *buf;
+    region_list_t          *regions = NULL;
     int                     i, nregion, *loc_len_ptr, *has_hist_ptr, found_task;
     uint64_t                buf_off, *offset_ptr = NULL, *size_ptr = NULL;
-    char *                  loc_ptr         = NULL;
+    char                   *loc_ptr         = NULL;
     region_info_transfer_t *region_info_ptr = NULL;
-    pdc_histogram_t *       hist_ptr        = NULL;
-    query_task_t *          task_elt        = NULL;
-    pdc_query_t *           query           = NULL;
+    pdc_histogram_t        *hist_ptr        = NULL;
+    query_task_t           *task_elt        = NULL;
+    pdc_query_t            *query           = NULL;
 
     pdc_int_ret_t out;
     out.ret = 1;
@@ -8687,7 +8688,7 @@ done:
         uint64_t *obj_ids = (uint64_t *)calloc(pdc_server_size_g, sizeof(uint64_t));
         int       obj_idx = 0;
         PDC_Server_distribute_query_workload(task_elt, query, &obj_idx, obj_ids, PDC_RECV_REGION_DO_QUERY);
-        free(obj_ids);
+        obj_ids = (uint64_t *)PDC_free(obj_ids);
     }
 
     int has_more = 0;
@@ -8700,7 +8701,7 @@ done:
         PDC_Server_send_query_result_to_manager(task_elt);
     }
 
-    free(bulk_args);
+    bulk_args = (struct bulk_args_t *)PDC_free(bulk_args);
     return ret;
 }
 
@@ -8710,10 +8711,10 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
     hg_return_t       ret        = HG_SUCCESS;
     pdc_query_xfer_t *query_xfer = (pdc_query_xfer_t *)callback_info->arg;
     int               obj_idx    = 0;
-    uint64_t *        obj_ids;
-    query_task_t *    new_task       = NULL, *task_elt;
+    uint64_t         *obj_ids;
+    query_task_t     *new_task       = NULL, *task_elt;
     int               query_id_exist = 0;
-    pdc_query_t *     query;
+    pdc_query_t      *query;
 
     query = PDC_deserialize_query(query_xfer);
     if (NULL == query) {
@@ -8786,7 +8787,7 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
             obj_idx = 0;
             PDC_Server_distribute_query_workload(new_task, query, &obj_idx, obj_ids,
                                                  PDC_RECV_REGION_DO_QUERY);
-            free(obj_ids);
+            obj_ids = (uint64_t *)PDC_free(obj_ids);
             goto done;
         }
 
@@ -8819,7 +8820,7 @@ PDC_Server_send_read_coords_to_server(int server_id, uint64_t *coord, uint64_t n
     hg_bulk_t     bulk_handle = NULL;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void *        buf;
+    void         *buf;
 
     FUNC_ENTER(NULL);
 
@@ -8930,12 +8931,12 @@ hg_return_t
 PDC_Server_recv_read_sel_obj_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret = HG_SUCCESS;
-    get_sel_data_rpc_in_t * in  = (get_sel_data_rpc_in_t *)callback_info->arg;
-    query_task_t *          task_elt, *task = NULL;
+    get_sel_data_rpc_in_t  *in  = (get_sel_data_rpc_in_t *)callback_info->arg;
+    query_task_t           *task_elt, *task = NULL;
     uint64_t                nhits, *coord, *coords = NULL, obj_id, buf_off, my_size, data_off, i;
     size_t                  ndim, unit_size;
     cache_storage_region_t *cache_region_elt;
-    region_list_t *         storage_region_head = NULL, *cache_region, *region_elt;
+    region_list_t          *storage_region_head = NULL, *cache_region, *region_elt;
     pdc_var_type_t          data_type;
 
     // find task
@@ -9023,8 +9024,8 @@ PDC_Server_recv_get_sel_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t            ret = HG_SUCCESS;
     get_sel_data_rpc_in_t *in  = (get_sel_data_rpc_in_t *)callback_info->arg;
-    query_task_t *         task_elt, *task = NULL;
-    pdc_metadata_t *       meta;
+    query_task_t          *task_elt, *task = NULL;
+    pdc_metadata_t        *meta;
     struct hg_cb_info      fake_callback_info = {0};
 
     DL_FOREACH(query_task_list_head_g, task_elt)
@@ -9056,7 +9057,7 @@ PDC_Server_recv_get_sel_data(const struct hg_cb_info *callback_info)
             int       obj_idx = 0;
             PDC_Server_distribute_query_storage_info(task, in->obj_id, &obj_idx, obj_ids,
                                                      PDC_RECV_REGION_DO_READ);
-            free(obj_ids);
+            obj_ids = (uint64_t *)PDC_free(obj_ids);
         }
         // Send query id and obj_id to other servers, as they have cached the corresponding coords
         PDC_Server_send_query_obj_read_to_all_server(task, in->obj_id);
@@ -9075,6 +9076,6 @@ PDC_Server_recv_get_sel_data(const struct hg_cb_info *callback_info)
 
 done:
     if (in)
-        free(in);
+        in = (get_sel_data_rpc_in_t *)PDC_free(in);
     return ret;
 }

--- a/src/server/pdc_server_region/pdc_server_data.c
+++ b/src/server/pdc_server_region/pdc_server_data.c
@@ -62,7 +62,7 @@
 #include "pdc_logger.h"
 
 // Global object region info list in local data server
-data_server_region_t       *dataserver_region_g     = NULL;
+data_server_region_t *      dataserver_region_g     = NULL;
 data_server_region_unmap_t *dataserver_region_unmap = NULL;
 
 int pdc_buffered_bulk_update_total_g = 0;
@@ -79,10 +79,10 @@ uint64_t max_mem_cache_size_mb_g       = 0;
 int      cache_percentage_g            = 0;
 int      current_read_from_cache_cnt_g = 0;
 int      total_read_from_cache_cnt_g   = 0;
-FILE    *pdc_cache_file_ptr_g          = NULL;
+FILE *   pdc_cache_file_ptr_g          = NULL;
 char     pdc_cache_file_path_g[ADDR_MAX];
 
-query_task_t           *query_task_list_head_g      = NULL;
+query_task_t *          query_task_list_head_g      = NULL;
 cache_storage_region_t *cache_storage_region_head_g = NULL;
 
 static int
@@ -263,7 +263,7 @@ PDC_Server_local_region_lock_status(PDC_mapping_info_t *mapped_region, int *lock
 {
     perr_t          ret_value = SUCCEED;
     pdc_metadata_t *res_meta;
-    region_list_t  *elt, *request_region;
+    region_list_t * elt, *request_region;
 
     FUNC_ENTER(NULL);
 
@@ -364,7 +364,7 @@ PDC_Server_clear_obj_region()
 {
     perr_t                ret_value = SUCCEED;
     data_server_region_t *elt, *tmp;
-    region_list_t        *elt2, *tmp2;
+    region_list_t *       elt2, *tmp2;
 
     FUNC_ENTER(NULL);
     if (dataserver_region_g != NULL) {
@@ -472,10 +472,10 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
 {
     perr_t                ret_value = SUCCEED;
     int                   ndim;
-    region_list_t        *request_region;
+    region_list_t *       request_region;
     data_server_region_t *new_obj_reg;
-    region_list_t        *elt1, *tmp;
-    region_buf_map_t     *eltt;
+    region_list_t *       elt1, *tmp;
+    region_buf_map_t *    eltt;
     int                   error      = 0;
     int                   found_lock = 0;
     // time_t                t;
@@ -576,8 +576,8 @@ perr_t
 PDC_Server_release_lock_request(uint64_t obj_id, struct pdc_region_info *region)
 {
     perr_t                ret_value = SUCCEED;
-    region_list_t        *request_region;
-    region_list_t        *elt, *tmp;
+    region_list_t *       request_region;
+    region_list_t *       elt, *tmp;
     data_server_region_t *new_obj_reg;
     region_lock_out_t     out;
 
@@ -619,7 +619,7 @@ PDC_Data_Server_region_release(region_lock_in_t *in, region_lock_out_t *out)
 {
     perr_t                ret_value = SUCCEED;
     int                   ndim;
-    region_list_t        *tmp1, *tmp2;
+    region_list_t *       tmp1, *tmp2;
     region_list_t         request_region;
     int                   found   = 0;
     data_server_region_t *obj_reg = NULL;
@@ -758,7 +758,7 @@ PDC_Data_Server_buf_unmap(const struct hg_info *info, buf_unmap_in_t *in)
 {
     perr_t                ret_value = SUCCEED;
     int                   ret       = HG_UTIL_SUCCESS;
-    region_buf_map_t     *tmp, *elt;
+    region_buf_map_t *    tmp, *elt;
     data_server_region_t *target_obj;
 
     FUNC_ENTER(NULL);
@@ -852,9 +852,9 @@ PDC_Data_Server_check_unmap()
     perr_t                      ret_value = SUCCEED;
     int                         ret       = HG_UTIL_SUCCESS;
     pdcid_t                     remote_obj_id;
-    region_buf_map_t           *tmp, *elt;
+    region_buf_map_t *          tmp, *elt;
     data_server_region_unmap_t *tmp1, *elt1;
-    data_server_region_t       *target_obj;
+    data_server_region_t *      target_obj;
     int                         completed = 0;
 
     FUNC_ENTER(NULL);
@@ -953,7 +953,7 @@ buf_unmap_lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     struct buf_unmap_server_lookup_args_t *lookup_args;
     hg_handle_t                            server_send_buf_unmap_handle;
     hg_handle_t                            handle;
-    struct transfer_buf_unmap             *tranx_args;
+    struct transfer_buf_unmap *            tranx_args;
     int                                    error = 0;
 
     FUNC_ENTER(NULL);
@@ -1017,7 +1017,7 @@ PDC_Server_buf_unmap_lookup_server_id(int remote_server_id, struct transfer_buf_
     lookup_args->server_id      = remote_server_id;
     lookup_args->buf_unmap_args = transfer_args;
     hg_ret                      = HG_Addr_lookup(hg_context_g, buf_unmap_lookup_remote_server_cb, lookup_args,
-                                                 pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         error = 1;
         PGOTO_ERROR(
@@ -1077,9 +1077,9 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
     hg_return_t                     hg_ret    = HG_SUCCESS;
     hg_handle_t                     server_send_buf_unmap_handle;
     struct transfer_buf_unmap_args *buf_unmap_args;
-    struct transfer_buf_unmap      *addr_args;
-    pdc_metadata_t                 *target_meta = NULL;
-    region_buf_map_t               *tmp, *elt;
+    struct transfer_buf_unmap *     addr_args;
+    pdc_metadata_t *                target_meta = NULL;
+    region_buf_map_t *              tmp, *elt;
     int                             error = 0;
 
     FUNC_ENTER(NULL);
@@ -1154,14 +1154,14 @@ region_buf_map_t *
 PDC_Data_Server_buf_map(const struct hg_info *info, buf_map_in_t *in, region_list_t *request_region,
                         void *data_ptr)
 {
-    region_buf_map_t     *ret_value   = NULL;
+    region_buf_map_t *    ret_value   = NULL;
     data_server_region_t *new_obj_reg = NULL;
-    region_list_t        *elt_reg;
-    region_buf_map_t     *buf_map_ptr = NULL;
-    region_buf_map_t     *tmp;
+    region_list_t *       elt_reg;
+    region_buf_map_t *    buf_map_ptr = NULL;
+    region_buf_map_t *    tmp;
     int                   dup                      = 0;
-    char                 *data_path                = NULL;
-    char                 *user_specified_data_path = NULL;
+    char *                data_path                = NULL;
+    char *                user_specified_data_path = NULL;
     char                  storage_location[ADDR_MAX];
 #ifdef ENABLE_LUSTRE
     int stripe_count, stripe_size;
@@ -1277,9 +1277,9 @@ done:
 void *
 PDC_Server_maybe_allocate_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t region, size_t type_size)
 {
-    void                 *ret_value  = NULL;
+    void *                ret_value  = NULL;
     data_server_region_t *target_obj = NULL, *elt = NULL;
-    region_buf_map_t     *tmp;
+    region_buf_map_t *    tmp;
 
     FUNC_ENTER(NULL);
 
@@ -1331,9 +1331,9 @@ done:
 void *
 PDC_Server_get_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t region)
 {
-    void                 *ret_value  = NULL;
+    void *                ret_value  = NULL;
     data_server_region_t *target_obj = NULL, *elt = NULL;
-    region_buf_map_t     *tmp;
+    region_buf_map_t *    tmp;
 
     FUNC_ENTER(NULL);
 
@@ -1399,7 +1399,7 @@ buf_map_lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     struct buf_map_server_lookup_args_t *lookup_args;
     hg_handle_t                          server_send_buf_map_handle;
     hg_handle_t                          handle;
-    struct transfer_buf_map             *tranx_args;
+    struct transfer_buf_map *            tranx_args;
     int                                  error = 0;
 
     FUNC_ENTER(NULL);
@@ -1464,7 +1464,7 @@ PDC_Server_buf_map_lookup_server_id(int remote_server_id, struct transfer_buf_ma
     lookup_args->server_id    = remote_server_id;
     lookup_args->buf_map_args = transfer_args;
     hg_ret                    = HG_Addr_lookup(hg_context_g, buf_map_lookup_remote_server_cb, lookup_args,
-                                               pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         error = 1;
         PGOTO_ERROR(
@@ -1520,9 +1520,9 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
     hg_return_t                   hg_ret    = HG_SUCCESS;
     hg_handle_t                   server_send_buf_map_handle;
     struct transfer_buf_map_args *tranx_args = NULL;
-    struct transfer_buf_map      *addr_args;
-    pdc_metadata_t               *target_meta = NULL;
-    region_buf_map_t             *buf_map_ptr;
+    struct transfer_buf_map *     addr_args;
+    pdc_metadata_t *              target_meta = NULL;
+    region_buf_map_t *            buf_map_ptr;
     int                           error = 0;
 
     FUNC_ENTER(NULL);
@@ -1794,11 +1794,11 @@ PDC_Server_notify_client_multi_io_complete(uint32_t client_id, int client_seq_id
     hg_return_t             hg_ret    = HG_SUCCESS;
     hg_handle_t             rpc_handle;
     hg_bulk_t               bulk_handle;
-    void                  **buf_ptrs;
-    hg_size_t              *buf_sizes;
+    void **                 buf_ptrs;
+    hg_size_t *             buf_sizes;
     bulk_rpc_in_t           bulk_rpc_in;
     int                     i;
-    region_list_t          *region_elt;
+    region_list_t *         region_elt;
     notify_multi_io_args_t *bulk_args;
 
     FUNC_ENTER(NULL);
@@ -2004,7 +2004,7 @@ PDC_Server_read_check(data_server_read_check_in_t *in, server_read_check_out_t *
 {
     perr_t                     ret_value = SUCCEED;
     pdc_data_server_io_list_t *io_elt = NULL, *io_target = NULL;
-    region_list_t             *region_elt = NULL;
+    region_list_t *            region_elt = NULL;
     region_list_t              r_target;
     /* uint32_t i; */
 
@@ -2090,7 +2090,7 @@ PDC_Server_write_check(data_server_write_check_in_t *in, data_server_write_check
 {
     perr_t                     ret_value = FAIL;
     pdc_data_server_io_list_t *io_elt = NULL, *io_target = NULL;
-    region_list_t             *region_elt = NULL, *region_tmp = NULL;
+    region_list_t *            region_elt = NULL, *region_tmp = NULL;
     int                        found_region = 0;
 
     FUNC_ENTER(NULL);
@@ -2198,7 +2198,7 @@ PDC_Server_get_local_storage_location_of_region(uint64_t obj_id, region_list_t *
 {
     perr_t          ret_value   = SUCCEED;
     pdc_metadata_t *target_meta = NULL;
-    region_list_t  *region_elt  = NULL;
+    region_list_t * region_elt  = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -2328,7 +2328,7 @@ PDC_Server_count_write_check_update_storage_meta_cb(const struct hg_cb_info *cal
             }
 
         } // end of if
-    } // end of if (write_ret->ret == 1)
+    }     // end of if (write_ret->ret == 1)
 
 done:
 
@@ -2360,17 +2360,17 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
     perr_t                             ret_value = SUCCEED;
     uint32_t                           server_id = 0;
     uint32_t                           i, j;
-    pdc_metadata_t                    *region_meta = NULL, *region_meta_prev = NULL;
-    region_list_t                     *region_elt, req_region, **overlap_regions_2d = NULL;
+    pdc_metadata_t *                   region_meta = NULL, *region_meta_prev = NULL;
+    region_list_t *                    region_elt, req_region, **overlap_regions_2d = NULL;
     region_info_transfer_t             local_region_transfer[PDC_SERVER_MAX_PROC_PER_NODE];
-    region_info_transfer_t            *all_requests        = NULL;
+    region_info_transfer_t *           all_requests        = NULL;
     update_region_storage_meta_bulk_t *send_buf            = NULL;
     update_region_storage_meta_bulk_t *result_storage_meta = NULL;
     uint32_t                           total_request_cnt;
     int                                data_size           = sizeof(region_info_transfer_t);
-    int                               *send_bytes          = NULL;
-    int                               *displs              = NULL;
-    int                               *request_overlap_cnt = NULL;
+    int *                              send_bytes          = NULL;
+    int *                              displs              = NULL;
+    int *                              request_overlap_cnt = NULL;
     int                                nrequest_per_server = 0;
 
     FUNC_ENTER(NULL);
@@ -2700,7 +2700,7 @@ PDC_Server_data_io_via_shm(const struct hg_cb_info *callback_info)
     perr_t ret_value = SUCCEED;
 
     pdc_data_server_io_list_t *io_list_elt, *io_list = NULL, *io_list_target = NULL;
-    region_list_t             *region_elt  = NULL, *region_tmp;
+    region_list_t *            region_elt  = NULL, *region_tmp;
     int                        real_bb_cnt = 0, real_lustre_cnt = 0;
     int                        write_to_bb_cnt = 0;
     int                        count;
@@ -3102,7 +3102,7 @@ PDC_Server_update_region_storagelocation_offset(region_list_t *region, int type)
     hg_return_t            hg_ret;
     perr_t                 ret_value   = SUCCEED;
     uint32_t               server_id   = 0;
-    pdc_metadata_t        *region_meta = NULL;
+    pdc_metadata_t *       region_meta = NULL;
     hg_handle_t            update_region_loc_handle;
     update_region_loc_in_t in;
     server_lookup_args_t   lookup_args;
@@ -3204,7 +3204,7 @@ PDC_Server_add_region_storage_meta_to_bulk_buf(region_list_t *region, bulk_xfer_
     int                                i;
     uint64_t                           obj_id = 0;
     update_region_storage_meta_bulk_t *curr_buf_ptr;
-    uint64_t                          *obj_id_ptr;
+    uint64_t *                         obj_id_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -3294,8 +3294,8 @@ PDC_Server_update_region_storage_meta_bulk_local(update_region_storage_meta_bulk
 {
     perr_t                             ret_value = SUCCEED;
     int                                i;
-    pdc_metadata_t                    *target_meta = NULL;
-    region_list_t                     *region_elt = NULL, *new_region = NULL;
+    pdc_metadata_t *                   target_meta = NULL;
+    region_list_t *                    region_elt = NULL, *new_region = NULL;
     update_region_storage_meta_bulk_t *bulk_ptr;
     int                                update_success = 0, express_insert = 0;
     uint64_t                           obj_id;
@@ -3418,7 +3418,7 @@ PDC_Server_update_region_storage_meta_bulk_mpi(bulk_xfer_data_t *bulk_data)
     int                                i;
     uint32_t                           server_id = 0;
     update_region_storage_meta_bulk_t *recv_buf  = NULL;
-    void                             **all_meta  = NULL;
+    void **                            all_meta  = NULL;
 #endif
 
     FUNC_ENTER(NULL);
@@ -3471,9 +3471,9 @@ done:
 }
 
 perr_t
-PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t           *bulk_data, perr_t (*cb)(),
+PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t *          bulk_data, perr_t (*cb)(),
                                                    update_storage_meta_list_t *meta_list_target,
-                                                   int                        *n_updated)
+                                                   int *                       n_updated)
 {
     hg_return_t hg_ret;
     perr_t      ret_value = SUCCEED;
@@ -3714,7 +3714,7 @@ all_select:
                 }
                 *total_read_bytes += read_bytes;
             } // for each row
-        } // ndim=2
+        }     // ndim=2
         else if (ndim == 3) {
             uint64_t buf_serialize_offset;
             /* fseek (fp, storage_offset, SEEK_SET); */
@@ -3797,8 +3797,8 @@ PDC_Server_read_one_region(region_list_t *read_region)
     size_t         total_read_bytes  = 0;
     uint32_t       n_storage_regions = 0;
     region_list_t *region_elt;
-    FILE          *fp_read        = NULL;
-    char          *prev_path      = NULL;
+    FILE *         fp_read        = NULL;
+    char *         prev_path      = NULL;
     int            is_shm_created = 0, is_read_succeed = 0;
 #ifdef ENABLE_TIMING
     double fopen_time;
@@ -3941,8 +3941,8 @@ PDC_Server_posix_one_file_io(region_list_t *region_list_head)
     uint64_t       offset           = 0;
     uint32_t       i                = 0;
     region_list_t *region_elt = NULL, *previous_region = NULL;
-    FILE          *fp_read = NULL, *fp_write = NULL;
-    char          *prev_path = NULL;
+    FILE *         fp_read = NULL, *fp_write = NULL;
+    char *         prev_path = NULL;
 #ifdef ENABLE_LUSTRE
     int stripe_count, stripe_size;
 #endif
@@ -4402,11 +4402,11 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 {
     perr_t                ret_value      = SUCCEED;
     data_server_region_t *region         = NULL;
-    region_list_t        *overlap_region = NULL;
+    region_list_t *       overlap_region = NULL;
     int                   is_contained   = 0;
     uint64_t              i, j, pos;
-    uint64_t             *overlap_offset, *overlap_size;
-    char                 *tmp_buf;
+    uint64_t *            overlap_offset, *overlap_size;
+    char *                tmp_buf;
 #if 0
     size_t                total_write_size = 0, local_write_size;
     int is_overlap;
@@ -4689,11 +4689,11 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
     if (is_contained == 0) {
         request_region->offset = lseek(region->fd, 0, SEEK_END);
 #ifdef ENABLE_ZFP
-        zfp_field  *field;
+        zfp_field * field;
         zfp_stream *zfp;
         size_t      bufsize;
-        void       *buffer;
-        bitstream  *stream;
+        void *      buffer;
+        bitstream * stream;
 
         field = _setup_zfp(region_info, &zfp);
         if (field == NULL)
@@ -4767,10 +4767,10 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
     perr_t                ret_value     = SUCCEED;
     ssize_t               request_bytes = unit;
     data_server_region_t *region        = NULL;
-    region_list_t        *elt;
+    region_list_t *       elt;
     uint64_t              i, j, pos;
-    uint64_t             *overlap_offset, *overlap_size;
-    char                 *tmp_buf;
+    uint64_t *            overlap_offset, *overlap_size;
+    char *                tmp_buf;
 
     FUNC_ENTER(NULL);
 #ifdef PDC_TIMING
@@ -4868,10 +4868,10 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
 
 #ifdef ENABLE_ZFP
                     //  Uncompress the data
-                    zfp_field  *field;
+                    zfp_field * field;
                     zfp_stream *zfp;
                     size_t      bufsize, decompress_size;
-                    bitstream  *stream;
+                    bitstream * stream;
 
                     field = _setup_zfp(region_info, &zfp);
                     if (field == NULL)
@@ -5132,7 +5132,7 @@ PDC_Server_get_local_storage_meta_with_one_name(storage_meta_query_one_name_args
 {
     perr_t          ret_value  = SUCCEED;
     pdc_metadata_t *meta       = NULL;
-    region_list_t  *region_elt = NULL, *region_head = NULL, *res_region_list = NULL;
+    region_list_t * region_elt = NULL, *region_head = NULL, *res_region_list = NULL;
     int             region_count = 0, i = 0;
 
     FUNC_ENTER(NULL);
@@ -5264,7 +5264,7 @@ PDC_Server_accumulate_storage_meta_then_read(storage_meta_query_one_name_args_t 
 {
     perr_t                     ret_value = SUCCEED;
     accumulate_storage_meta_t *accu_meta;
-    region_list_t             *req_region = NULL, *region_elt = NULL, *read_list_head = NULL;
+    region_list_t *            req_region = NULL, *region_elt = NULL, *read_list_head = NULL;
     int                        i, is_sort_read;
     size_t                     j;
 
@@ -5432,16 +5432,16 @@ PDC_Server_storage_meta_name_query_bulk_respond(const struct hg_cb_info *callbac
 {
     hg_return_t                         hg_ret = HG_SUCCESS;
     perr_t                              ret_value;
-    storage_meta_name_query_in_t       *args;
+    storage_meta_name_query_in_t *      args;
     storage_meta_query_one_name_args_t *query_args;
     hg_handle_t                         rpc_handle;
     hg_bulk_t                           bulk_handle;
     bulk_rpc_in_t                       bulk_rpc_in;
-    void                              **buf_ptrs;
-    hg_size_t                          *buf_sizes;
+    void **                             buf_ptrs;
+    hg_size_t *                         buf_sizes;
     uint32_t                            server_id;
-    region_info_transfer_t            **region_infos;
-    region_list_t                      *region_elt;
+    region_info_transfer_t **           region_infos;
+    region_list_t *                     region_elt;
     int                                 i, j;
     FUNC_ENTER(NULL);
 
@@ -5585,9 +5585,9 @@ PDC_Server_add_client_shm_to_cache(int cnt, void *buf_cp)
 {
     perr_t                     ret_value = SUCCEED;
     int                        i, j;
-    region_storage_meta_t     *storage_metas = (region_storage_meta_t *)buf_cp;
+    region_storage_meta_t *    storage_metas = (region_storage_meta_t *)buf_cp;
     pdc_data_server_io_list_t *io_list_elt, *io_list_target;
-    region_list_t             *new_region;
+    region_list_t *            new_region;
 
     FUNC_ENTER(NULL);
 
@@ -5699,7 +5699,7 @@ PDC_Server_data_read_to_buf_1_region(region_list_t *region)
 {
     perr_t   ret_value = SUCCEED;
     uint64_t offset, read_bytes;
-    FILE    *fp_read = NULL;
+    FILE *   fp_read = NULL;
 
     if (region->is_data_ready == 1)
         return SUCCEED;
@@ -5748,9 +5748,9 @@ PDC_Server_data_read_to_buf(region_list_t *region_list_head)
 {
     perr_t         ret_value = SUCCEED;
     region_list_t *region_elt;
-    char          *prev_path = NULL;
+    char *         prev_path = NULL;
     uint64_t       offset, read_bytes;
-    FILE          *fp_read = NULL;
+    FILE *         fp_read = NULL;
 
     int read_count = 0;
 
@@ -5889,8 +5889,8 @@ static perr_t
 PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_combine_op_t combine_op)
 {
     perr_t                     ret_value  = SUCCEED;
-    region_list_t             *req_region = NULL, *region_tmp = NULL;
-    region_list_t             *storage_region_list_head = NULL;
+    region_list_t *            req_region = NULL, *region_tmp = NULL;
+    region_list_t *            storage_region_list_head = NULL;
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
     uint64_t                   obj_id;
     int                        iter, count, is_same_region, i, can_skip;
@@ -6161,7 +6161,7 @@ compare_coords_3d(const void *a, const void *b)
     ({                                                                                                       \
         uint64_t idx, iii, jjj, ttt, cur_count = 0, istart, has_dup;                                         \
         int      is_good, _ndim;                                                                             \
-        TYPE    *edata = (TYPE *)(_data);                                                                    \
+        TYPE *   edata = (TYPE *)(_data);                                                                    \
         _ndim          = (_region)->ndim;                                                                    \
         istart         = (_sel)->nhits * _ndim;                                                              \
         if (_ndim > 3) {                                                                                     \
@@ -6306,7 +6306,7 @@ compare_coords_3d(const void *a, const void *b)
     ({                                                                                                       \
         uint64_t idx, iii, jjj, ttt, cur_count = 0, istart, has_dup;                                         \
         int      is_good, _ndim;                                                                             \
-        TYPE    *edata = (TYPE *)(_data);                                                                    \
+        TYPE *   edata = (TYPE *)(_data);                                                                    \
         _ndim          = (_region)->ndim;                                                                    \
         istart         = (_sel)->nhits * _ndim;                                                              \
         if (_ndim > 3) {                                                                                     \
@@ -6467,11 +6467,11 @@ generate_write_fastbit_idx(uint64_t obj_id, void *data, uint64_t dataCount, Fast
     char      keyName[128];
     char      offName[128];
     char      out_name[256];
-    double   *keys    = NULL;
-    int64_t  *offsets = NULL;
+    double *  keys    = NULL;
+    int64_t * offsets = NULL;
     uint32_t *bms     = NULL;
     uint64_t  nk = 0, no = 0, nb = 0;
-    FILE     *fp;
+    FILE *    fp;
 
     FUNC_ENTER(NULL);
 
@@ -6569,7 +6569,7 @@ int
 queryData(const char *name)
 {
     uint64_t               nhits, i;
-    uint64_t              *buf;
+    uint64_t *             buf;
     double                 val1 = 0.0, val2 = 10.0;
     FastBitSelectionHandle sel1 = fastbit_selection_osr(name, FastBitCompareGreater, val1);
     FastBitSelectionHandle sel2 = fastbit_selection_osr(name, FastBitCompareLess, val2);
@@ -6604,7 +6604,7 @@ PDC_load_fastbit_index(char *idx_name, uint64_t obj_id, FastBitDataType dtype, i
     char     offName[128];
     char     out_name[256];
     uint64_t nk = 0, no = 0, nb = 0, size;
-    FILE    *fp;
+    FILE *   fp;
 
     PDC_gen_fastbit_idx_name(bmsName, "bms", obj_id, timestep, ndim, start, count);
     PDC_gen_fastbit_idx_name(keyName, "key", obj_id, timestep, ndim, start, count);
@@ -6680,9 +6680,9 @@ PDC_query_fastbit_idx(region_list_t *region, pdc_query_constraint_t *constraint,
     perr_t          ret_value = SUCCEED;
     FastBitDataType ft        = 0;
     uint64_t        type_size;
-    uint32_t       *bms     = NULL;
-    double         *keys    = NULL;
-    int64_t        *offsets = NULL;
+    uint32_t *      bms     = NULL;
+    double *        keys    = NULL;
+    int64_t *       offsets = NULL;
     int             timestep;
     double          v1, v2;
     size_t          i;
@@ -6857,7 +6857,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
                                     pdc_query_combine_op_t combine_op)
 {
     perr_t           ret_value = SUCCEED;
-    region_list_t   *region_elt, *region_list_head, *cache_region, tmp_region, *region_constraint = NULL;
+    region_list_t *  region_elt, *region_list_head, *cache_region, tmp_region, *region_constraint = NULL;
     pdc_selection_t *sel = query->sel;
     uint64_t         nelem;
     size_t           i, j, unit_size;
@@ -6871,7 +6871,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
     uint32_t ulo = 0, uhi = 0;
     int64_t  i64lo = 0, i64hi = 0;
     uint64_t ui64lo = 0, ui64hi = 0;
-    void    *value = NULL, *buf = NULL;
+    void *   value = NULL, *buf = NULL;
     int      n_eval_region = 0, can_skip, region_iter = 0;
 
     LOG_INFO("==PDC_SERVER[%d]: start query evaluation!\n", pdc_server_rank_g);
@@ -7212,7 +7212,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
 
             n_eval_region++;
         } // End DL_FOREACH
-    } // End not use fastbit
+    }     // End not use fastbit
 
     if (n_eval_region == 0 && combine_op == PDC_QUERY_AND) {
         if (sel->nhits > 0) {
@@ -7540,7 +7540,7 @@ PDC_Server_send_coords_to_client(query_task_t *task)
     hg_bulk_t     bulk_handle;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void         *buf;
+    void *        buf;
     int           client_id;
 
     FUNC_ENTER(NULL);
@@ -7622,7 +7622,7 @@ PDC_Server_send_coords_to_server(query_task_t *task)
     hg_bulk_t     bulk_handle = NULL;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void         *buf;
+    void *        buf;
     int           server_id;
 
     FUNC_ENTER(NULL);
@@ -7829,9 +7829,9 @@ hg_return_t
 PDC_Server_read_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret  = HG_SUCCESS;
-    query_task_t           *task = (query_task_t *)callback_info->arg;
+    query_task_t *          task = (query_task_t *)callback_info->arg;
     pdc_query_constraint_t *constraint;
-    region_list_t          *storage_region_head, *region_elt, *cache_region;
+    region_list_t *         storage_region_head, *region_elt, *cache_region;
     size_t                  ndim, unit_size;
     uint64_t                i, *coord, data_off, buf_off, my_size;
 
@@ -7897,11 +7897,11 @@ PDC_recv_read_coords(const struct hg_cb_info *callback_info)
     hg_return_t         ret               = HG_SUCCESS;
     hg_bulk_t           local_bulk_handle = callback_info->info.bulk.local_handle;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    query_task_t       *task_elt          = NULL;
+    query_task_t *      task_elt          = NULL;
     uint64_t            nhits, obj_id;
     uint32_t            ndim;
     int                 query_id, origin;
-    void               *buf;
+    void *              buf;
 
     pdc_int_ret_t out;
     out.ret = 1;
@@ -7980,7 +7980,7 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
     hg_return_t         ret               = HG_SUCCESS;
     hg_bulk_t           local_bulk_handle = callback_info->info.bulk.local_handle;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    query_task_t       *task_elt;
+    query_task_t *      task_elt;
     uint64_t            nhits = 0, total_hits;
     size_t              ndim, unit_size;
     int                 i, query_id, origin, found_task;
@@ -8198,7 +8198,7 @@ perr_t
 add_storage_region_to_buf(void **in_buf, uint64_t *buf_alloc, uint64_t *buf_off, const region_list_t *region)
 {
     perr_t   ret_value = SUCCEED;
-    void    *buf       = *in_buf;
+    void *   buf       = *in_buf;
     uint64_t my_size, tmp_size;
 
     if (in_buf == NULL || *in_buf == NULL || region == NULL || buf_alloc == NULL || buf_off == NULL ||
@@ -8394,8 +8394,8 @@ PDC_Server_distribute_query_storage_info(query_task_t *task, uint64_t obj_id, in
 {
     pdc_metadata_t *meta = NULL;
     int             i, server_id, count, avg_count, nsent, nsent_server;
-    region_list_t  *elt, *new_region = NULL;
-    void           *region_bulk_buf;
+    region_list_t * elt, *new_region = NULL;
+    void *          region_bulk_buf;
     uint64_t        buf_alloc = 0, buf_off = 0;
     bulk_rpc_in_t   header;
 
@@ -8535,16 +8535,16 @@ PDC_recv_query_metadata_bulk(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret               = HG_SUCCESS;
     hg_bulk_t               local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t     *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    void                   *buf;
-    region_list_t          *regions = NULL;
+    struct bulk_args_t *    bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    void *                  buf;
+    region_list_t *         regions = NULL;
     int                     i, nregion, *loc_len_ptr, *has_hist_ptr, found_task;
     uint64_t                buf_off, *offset_ptr = NULL, *size_ptr = NULL;
-    char                   *loc_ptr         = NULL;
+    char *                  loc_ptr         = NULL;
     region_info_transfer_t *region_info_ptr = NULL;
-    pdc_histogram_t        *hist_ptr        = NULL;
-    query_task_t           *task_elt        = NULL;
-    pdc_query_t            *query           = NULL;
+    pdc_histogram_t *       hist_ptr        = NULL;
+    query_task_t *          task_elt        = NULL;
+    pdc_query_t *           query           = NULL;
 
     pdc_int_ret_t out;
     out.ret = 1;
@@ -8713,10 +8713,10 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
     hg_return_t       ret        = HG_SUCCESS;
     pdc_query_xfer_t *query_xfer = (pdc_query_xfer_t *)callback_info->arg;
     int               obj_idx    = 0;
-    uint64_t         *obj_ids;
-    query_task_t     *new_task       = NULL, *task_elt;
+    uint64_t *        obj_ids;
+    query_task_t *    new_task       = NULL, *task_elt;
     int               query_id_exist = 0;
-    pdc_query_t      *query;
+    pdc_query_t *     query;
 
     query = PDC_deserialize_query(query_xfer);
     if (NULL == query) {
@@ -8822,7 +8822,7 @@ PDC_Server_send_read_coords_to_server(int server_id, uint64_t *coord, uint64_t n
     hg_bulk_t     bulk_handle = NULL;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void         *buf;
+    void *        buf;
 
     FUNC_ENTER(NULL);
 
@@ -8933,12 +8933,12 @@ hg_return_t
 PDC_Server_recv_read_sel_obj_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret = HG_SUCCESS;
-    get_sel_data_rpc_in_t  *in  = (get_sel_data_rpc_in_t *)callback_info->arg;
-    query_task_t           *task_elt, *task = NULL;
+    get_sel_data_rpc_in_t * in  = (get_sel_data_rpc_in_t *)callback_info->arg;
+    query_task_t *          task_elt, *task = NULL;
     uint64_t                nhits, *coord, *coords = NULL, obj_id, buf_off, my_size, data_off, i;
     size_t                  ndim, unit_size;
     cache_storage_region_t *cache_region_elt;
-    region_list_t          *storage_region_head = NULL, *cache_region, *region_elt;
+    region_list_t *         storage_region_head = NULL, *cache_region, *region_elt;
     pdc_var_type_t          data_type;
 
     // find task
@@ -9026,8 +9026,8 @@ PDC_Server_recv_get_sel_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t            ret = HG_SUCCESS;
     get_sel_data_rpc_in_t *in  = (get_sel_data_rpc_in_t *)callback_info->arg;
-    query_task_t          *task_elt, *task = NULL;
-    pdc_metadata_t        *meta;
+    query_task_t *         task_elt, *task = NULL;
+    pdc_metadata_t *       meta;
     struct hg_cb_info      fake_callback_info = {0};
 
     DL_FOREACH(query_task_list_head_g, task_elt)

--- a/src/server/pdc_server_region/pdc_server_data.c
+++ b/src/server/pdc_server_region/pdc_server_data.c
@@ -62,7 +62,7 @@
 #include "pdc_logger.h"
 
 // Global object region info list in local data server
-data_server_region_t *      dataserver_region_g     = NULL;
+data_server_region_t       *dataserver_region_g     = NULL;
 data_server_region_unmap_t *dataserver_region_unmap = NULL;
 
 int pdc_buffered_bulk_update_total_g = 0;
@@ -79,10 +79,10 @@ uint64_t max_mem_cache_size_mb_g       = 0;
 int      cache_percentage_g            = 0;
 int      current_read_from_cache_cnt_g = 0;
 int      total_read_from_cache_cnt_g   = 0;
-FILE *   pdc_cache_file_ptr_g          = NULL;
+FILE    *pdc_cache_file_ptr_g          = NULL;
 char     pdc_cache_file_path_g[ADDR_MAX];
 
-query_task_t *          query_task_list_head_g      = NULL;
+query_task_t           *query_task_list_head_g      = NULL;
 cache_storage_region_t *cache_storage_region_head_g = NULL;
 
 static int
@@ -263,7 +263,7 @@ PDC_Server_local_region_lock_status(PDC_mapping_info_t *mapped_region, int *lock
 {
     perr_t          ret_value = SUCCEED;
     pdc_metadata_t *res_meta;
-    region_list_t * elt, *request_region;
+    region_list_t  *elt, *request_region;
 
     FUNC_ENTER(NULL);
 
@@ -364,7 +364,7 @@ PDC_Server_clear_obj_region()
 {
     perr_t                ret_value = SUCCEED;
     data_server_region_t *elt, *tmp;
-    region_list_t *       elt2, *tmp2;
+    region_list_t        *elt2, *tmp2;
 
     FUNC_ENTER(NULL);
     if (dataserver_region_g != NULL) {
@@ -472,10 +472,10 @@ PDC_Data_Server_region_lock(region_lock_in_t *in, region_lock_out_t *out, hg_han
 {
     perr_t                ret_value = SUCCEED;
     int                   ndim;
-    region_list_t *       request_region;
+    region_list_t        *request_region;
     data_server_region_t *new_obj_reg;
-    region_list_t *       elt1, *tmp;
-    region_buf_map_t *    eltt;
+    region_list_t        *elt1, *tmp;
+    region_buf_map_t     *eltt;
     int                   error      = 0;
     int                   found_lock = 0;
     // time_t                t;
@@ -576,8 +576,8 @@ perr_t
 PDC_Server_release_lock_request(uint64_t obj_id, struct pdc_region_info *region)
 {
     perr_t                ret_value = SUCCEED;
-    region_list_t *       request_region;
-    region_list_t *       elt, *tmp;
+    region_list_t        *request_region;
+    region_list_t        *elt, *tmp;
     data_server_region_t *new_obj_reg;
     region_lock_out_t     out;
 
@@ -619,7 +619,7 @@ PDC_Data_Server_region_release(region_lock_in_t *in, region_lock_out_t *out)
 {
     perr_t                ret_value = SUCCEED;
     int                   ndim;
-    region_list_t *       tmp1, *tmp2;
+    region_list_t        *tmp1, *tmp2;
     region_list_t         request_region;
     int                   found   = 0;
     data_server_region_t *obj_reg = NULL;
@@ -758,7 +758,7 @@ PDC_Data_Server_buf_unmap(const struct hg_info *info, buf_unmap_in_t *in)
 {
     perr_t                ret_value = SUCCEED;
     int                   ret       = HG_UTIL_SUCCESS;
-    region_buf_map_t *    tmp, *elt;
+    region_buf_map_t     *tmp, *elt;
     data_server_region_t *target_obj;
 
     FUNC_ENTER(NULL);
@@ -852,9 +852,9 @@ PDC_Data_Server_check_unmap()
     perr_t                      ret_value = SUCCEED;
     int                         ret       = HG_UTIL_SUCCESS;
     pdcid_t                     remote_obj_id;
-    region_buf_map_t *          tmp, *elt;
+    region_buf_map_t           *tmp, *elt;
     data_server_region_unmap_t *tmp1, *elt1;
-    data_server_region_t *      target_obj;
+    data_server_region_t       *target_obj;
     int                         completed = 0;
 
     FUNC_ENTER(NULL);
@@ -953,7 +953,7 @@ buf_unmap_lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     struct buf_unmap_server_lookup_args_t *lookup_args;
     hg_handle_t                            server_send_buf_unmap_handle;
     hg_handle_t                            handle;
-    struct transfer_buf_unmap *            tranx_args;
+    struct transfer_buf_unmap             *tranx_args;
     int                                    error = 0;
 
     FUNC_ENTER(NULL);
@@ -1017,7 +1017,7 @@ PDC_Server_buf_unmap_lookup_server_id(int remote_server_id, struct transfer_buf_
     lookup_args->server_id      = remote_server_id;
     lookup_args->buf_unmap_args = transfer_args;
     hg_ret                      = HG_Addr_lookup(hg_context_g, buf_unmap_lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                                 pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         error = 1;
         PGOTO_ERROR(
@@ -1077,9 +1077,9 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
     hg_return_t                     hg_ret    = HG_SUCCESS;
     hg_handle_t                     server_send_buf_unmap_handle;
     struct transfer_buf_unmap_args *buf_unmap_args;
-    struct transfer_buf_unmap *     addr_args;
-    pdc_metadata_t *                target_meta = NULL;
-    region_buf_map_t *              tmp, *elt;
+    struct transfer_buf_unmap      *addr_args;
+    pdc_metadata_t                 *target_meta = NULL;
+    region_buf_map_t               *tmp, *elt;
     int                             error = 0;
 
     FUNC_ENTER(NULL);
@@ -1154,14 +1154,14 @@ region_buf_map_t *
 PDC_Data_Server_buf_map(const struct hg_info *info, buf_map_in_t *in, region_list_t *request_region,
                         void *data_ptr)
 {
-    region_buf_map_t *    ret_value   = NULL;
+    region_buf_map_t     *ret_value   = NULL;
     data_server_region_t *new_obj_reg = NULL;
-    region_list_t *       elt_reg;
-    region_buf_map_t *    buf_map_ptr = NULL;
-    region_buf_map_t *    tmp;
+    region_list_t        *elt_reg;
+    region_buf_map_t     *buf_map_ptr = NULL;
+    region_buf_map_t     *tmp;
     int                   dup                      = 0;
-    char *                data_path                = NULL;
-    char *                user_specified_data_path = NULL;
+    char                 *data_path                = NULL;
+    char                 *user_specified_data_path = NULL;
     char                  storage_location[ADDR_MAX];
 #ifdef ENABLE_LUSTRE
     int stripe_count, stripe_size;
@@ -1277,9 +1277,9 @@ done:
 void *
 PDC_Server_maybe_allocate_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t region, size_t type_size)
 {
-    void *                ret_value  = NULL;
+    void                 *ret_value  = NULL;
     data_server_region_t *target_obj = NULL, *elt = NULL;
-    region_buf_map_t *    tmp;
+    region_buf_map_t     *tmp;
 
     FUNC_ENTER(NULL);
 
@@ -1308,7 +1308,7 @@ PDC_Server_maybe_allocate_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t 
             PDC_get_region_desc_size_bytes((uint64_t *)&(region.count), type_size, region.ndim) / type_size;
         region_buf_map_t *buf_map_ptr = NULL;
 
-        ret_value = malloc(region_size);
+        ret_value = PDC_malloc(region_size);
 
         buf_map_ptr                       = (region_buf_map_t *)PDC_malloc(sizeof(region_buf_map_t));
         buf_map_ptr->remote_obj_id        = obj_id;
@@ -1331,9 +1331,9 @@ done:
 void *
 PDC_Server_get_region_buf_ptr(pdcid_t obj_id, region_info_transfer_t region)
 {
-    void *                ret_value  = NULL;
+    void                 *ret_value  = NULL;
     data_server_region_t *target_obj = NULL, *elt = NULL;
-    region_buf_map_t *    tmp;
+    region_buf_map_t     *tmp;
 
     FUNC_ENTER(NULL);
 
@@ -1399,7 +1399,7 @@ buf_map_lookup_remote_server_cb(const struct hg_cb_info *callback_info)
     struct buf_map_server_lookup_args_t *lookup_args;
     hg_handle_t                          server_send_buf_map_handle;
     hg_handle_t                          handle;
-    struct transfer_buf_map *            tranx_args;
+    struct transfer_buf_map             *tranx_args;
     int                                  error = 0;
 
     FUNC_ENTER(NULL);
@@ -1464,7 +1464,7 @@ PDC_Server_buf_map_lookup_server_id(int remote_server_id, struct transfer_buf_ma
     lookup_args->server_id    = remote_server_id;
     lookup_args->buf_map_args = transfer_args;
     hg_ret                    = HG_Addr_lookup(hg_context_g, buf_map_lookup_remote_server_cb, lookup_args,
-                            pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
+                                               pdc_remote_server_info_g[remote_server_id].addr_string, HG_OP_ID_IGNORE);
     if (hg_ret != HG_SUCCESS) {
         error = 1;
         PGOTO_ERROR(
@@ -1520,9 +1520,9 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
     hg_return_t                   hg_ret    = HG_SUCCESS;
     hg_handle_t                   server_send_buf_map_handle;
     struct transfer_buf_map_args *tranx_args = NULL;
-    struct transfer_buf_map *     addr_args;
-    pdc_metadata_t *              target_meta = NULL;
-    region_buf_map_t *            buf_map_ptr;
+    struct transfer_buf_map      *addr_args;
+    pdc_metadata_t               *target_meta = NULL;
+    region_buf_map_t             *buf_map_ptr;
     int                           error = 0;
 
     FUNC_ENTER(NULL);
@@ -1794,11 +1794,11 @@ PDC_Server_notify_client_multi_io_complete(uint32_t client_id, int client_seq_id
     hg_return_t             hg_ret    = HG_SUCCESS;
     hg_handle_t             rpc_handle;
     hg_bulk_t               bulk_handle;
-    void **                 buf_ptrs;
-    hg_size_t *             buf_sizes;
+    void                  **buf_ptrs;
+    hg_size_t              *buf_sizes;
     bulk_rpc_in_t           bulk_rpc_in;
     int                     i;
-    region_list_t *         region_elt;
+    region_list_t          *region_elt;
     notify_multi_io_args_t *bulk_args;
 
     FUNC_ENTER(NULL);
@@ -2004,7 +2004,7 @@ PDC_Server_read_check(data_server_read_check_in_t *in, server_read_check_out_t *
 {
     perr_t                     ret_value = SUCCEED;
     pdc_data_server_io_list_t *io_elt = NULL, *io_target = NULL;
-    region_list_t *            region_elt = NULL;
+    region_list_t             *region_elt = NULL;
     region_list_t              r_target;
     /* uint32_t i; */
 
@@ -2090,7 +2090,7 @@ PDC_Server_write_check(data_server_write_check_in_t *in, data_server_write_check
 {
     perr_t                     ret_value = FAIL;
     pdc_data_server_io_list_t *io_elt = NULL, *io_target = NULL;
-    region_list_t *            region_elt = NULL, *region_tmp = NULL;
+    region_list_t             *region_elt = NULL, *region_tmp = NULL;
     int                        found_region = 0;
 
     FUNC_ENTER(NULL);
@@ -2198,7 +2198,7 @@ PDC_Server_get_local_storage_location_of_region(uint64_t obj_id, region_list_t *
 {
     perr_t          ret_value   = SUCCEED;
     pdc_metadata_t *target_meta = NULL;
-    region_list_t * region_elt  = NULL;
+    region_list_t  *region_elt  = NULL;
 
     FUNC_ENTER(NULL);
 
@@ -2328,7 +2328,7 @@ PDC_Server_count_write_check_update_storage_meta_cb(const struct hg_cb_info *cal
             }
 
         } // end of if
-    }     // end of if (write_ret->ret == 1)
+    } // end of if (write_ret->ret == 1)
 
 done:
 
@@ -2360,17 +2360,17 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
     perr_t                             ret_value = SUCCEED;
     uint32_t                           server_id = 0;
     uint32_t                           i, j;
-    pdc_metadata_t *                   region_meta = NULL, *region_meta_prev = NULL;
-    region_list_t *                    region_elt, req_region, **overlap_regions_2d = NULL;
+    pdc_metadata_t                    *region_meta = NULL, *region_meta_prev = NULL;
+    region_list_t                     *region_elt, req_region, **overlap_regions_2d = NULL;
     region_info_transfer_t             local_region_transfer[PDC_SERVER_MAX_PROC_PER_NODE];
-    region_info_transfer_t *           all_requests        = NULL;
+    region_info_transfer_t            *all_requests        = NULL;
     update_region_storage_meta_bulk_t *send_buf            = NULL;
     update_region_storage_meta_bulk_t *result_storage_meta = NULL;
     uint32_t                           total_request_cnt;
     int                                data_size           = sizeof(region_info_transfer_t);
-    int *                              send_bytes          = NULL;
-    int *                              displs              = NULL;
-    int *                              request_overlap_cnt = NULL;
+    int                               *send_bytes          = NULL;
+    int                               *displs              = NULL;
+    int                               *request_overlap_cnt = NULL;
     int                                nrequest_per_server = 0;
 
     FUNC_ENTER(NULL);
@@ -2700,7 +2700,7 @@ PDC_Server_data_io_via_shm(const struct hg_cb_info *callback_info)
     perr_t ret_value = SUCCEED;
 
     pdc_data_server_io_list_t *io_list_elt, *io_list = NULL, *io_list_target = NULL;
-    region_list_t *            region_elt  = NULL, *region_tmp;
+    region_list_t             *region_elt  = NULL, *region_tmp;
     int                        real_bb_cnt = 0, real_lustre_cnt = 0;
     int                        write_to_bb_cnt = 0;
     int                        count;
@@ -3102,7 +3102,7 @@ PDC_Server_update_region_storagelocation_offset(region_list_t *region, int type)
     hg_return_t            hg_ret;
     perr_t                 ret_value   = SUCCEED;
     uint32_t               server_id   = 0;
-    pdc_metadata_t *       region_meta = NULL;
+    pdc_metadata_t        *region_meta = NULL;
     hg_handle_t            update_region_loc_handle;
     update_region_loc_in_t in;
     server_lookup_args_t   lookup_args;
@@ -3204,7 +3204,7 @@ PDC_Server_add_region_storage_meta_to_bulk_buf(region_list_t *region, bulk_xfer_
     int                                i;
     uint64_t                           obj_id = 0;
     update_region_storage_meta_bulk_t *curr_buf_ptr;
-    uint64_t *                         obj_id_ptr;
+    uint64_t                          *obj_id_ptr;
 
     FUNC_ENTER(NULL);
 
@@ -3294,8 +3294,8 @@ PDC_Server_update_region_storage_meta_bulk_local(update_region_storage_meta_bulk
 {
     perr_t                             ret_value = SUCCEED;
     int                                i;
-    pdc_metadata_t *                   target_meta = NULL;
-    region_list_t *                    region_elt = NULL, *new_region = NULL;
+    pdc_metadata_t                    *target_meta = NULL;
+    region_list_t                     *region_elt = NULL, *new_region = NULL;
     update_region_storage_meta_bulk_t *bulk_ptr;
     int                                update_success = 0, express_insert = 0;
     uint64_t                           obj_id;
@@ -3418,7 +3418,7 @@ PDC_Server_update_region_storage_meta_bulk_mpi(bulk_xfer_data_t *bulk_data)
     int                                i;
     uint32_t                           server_id = 0;
     update_region_storage_meta_bulk_t *recv_buf  = NULL;
-    void **                            all_meta  = NULL;
+    void                             **all_meta  = NULL;
 #endif
 
     FUNC_ENTER(NULL);
@@ -3471,9 +3471,9 @@ done:
 }
 
 perr_t
-PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t *          bulk_data, perr_t (*cb)(),
+PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t           *bulk_data, perr_t (*cb)(),
                                                    update_storage_meta_list_t *meta_list_target,
-                                                   int *                       n_updated)
+                                                   int                        *n_updated)
 {
     hg_return_t hg_ret;
     perr_t      ret_value = SUCCEED;
@@ -3714,7 +3714,7 @@ all_select:
                 }
                 *total_read_bytes += read_bytes;
             } // for each row
-        }     // ndim=2
+        } // ndim=2
         else if (ndim == 3) {
             uint64_t buf_serialize_offset;
             /* fseek (fp, storage_offset, SEEK_SET); */
@@ -3797,8 +3797,8 @@ PDC_Server_read_one_region(region_list_t *read_region)
     size_t         total_read_bytes  = 0;
     uint32_t       n_storage_regions = 0;
     region_list_t *region_elt;
-    FILE *         fp_read        = NULL;
-    char *         prev_path      = NULL;
+    FILE          *fp_read        = NULL;
+    char          *prev_path      = NULL;
     int            is_shm_created = 0, is_read_succeed = 0;
 #ifdef ENABLE_TIMING
     double fopen_time;
@@ -3941,8 +3941,8 @@ PDC_Server_posix_one_file_io(region_list_t *region_list_head)
     uint64_t       offset           = 0;
     uint32_t       i                = 0;
     region_list_t *region_elt = NULL, *previous_region = NULL;
-    FILE *         fp_read = NULL, *fp_write = NULL;
-    char *         prev_path = NULL;
+    FILE          *fp_read = NULL, *fp_write = NULL;
+    char          *prev_path = NULL;
 #ifdef ENABLE_LUSTRE
     int stripe_count, stripe_size;
 #endif
@@ -4402,11 +4402,11 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 {
     perr_t                ret_value      = SUCCEED;
     data_server_region_t *region         = NULL;
-    region_list_t *       overlap_region = NULL;
+    region_list_t        *overlap_region = NULL;
     int                   is_contained   = 0;
     uint64_t              i, j, pos;
-    uint64_t *            overlap_offset, *overlap_size;
-    char *                tmp_buf;
+    uint64_t             *overlap_offset, *overlap_size;
+    char                 *tmp_buf;
 #if 0
     size_t                total_write_size = 0, local_write_size;
     int is_overlap;
@@ -4689,11 +4689,11 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
     if (is_contained == 0) {
         request_region->offset = lseek(region->fd, 0, SEEK_END);
 #ifdef ENABLE_ZFP
-        zfp_field * field;
+        zfp_field  *field;
         zfp_stream *zfp;
         size_t      bufsize;
-        void *      buffer;
-        bitstream * stream;
+        void       *buffer;
+        bitstream  *stream;
 
         field = _setup_zfp(region_info, &zfp);
         if (field == NULL)
@@ -4703,7 +4703,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
             bufsize = zfp_stream_maximum_size(zfp, field);
             if (bufsize == 0)
                 LOG_ERROR("==PDC_SERVER[%d]: zfp_stream_maximum_size returned 0!\n", pdc_server_rank_g);
-            buffer = malloc(bufsize);
+            buffer = PDC_malloc(bufsize);
             if (buffer == 0)
                 LOG_ERROR("==PDC_SERVER[%d]: malloc failed!\n", pdc_server_rank_g);
             else {
@@ -4767,10 +4767,10 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
     perr_t                ret_value     = SUCCEED;
     ssize_t               request_bytes = unit;
     data_server_region_t *region        = NULL;
-    region_list_t *       elt;
+    region_list_t        *elt;
     uint64_t              i, j, pos;
-    uint64_t *            overlap_offset, *overlap_size;
-    char *                tmp_buf;
+    uint64_t             *overlap_offset, *overlap_size;
+    char                 *tmp_buf;
 
     FUNC_ENTER(NULL);
 #ifdef PDC_TIMING
@@ -4868,10 +4868,10 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
 
 #ifdef ENABLE_ZFP
                     //  Uncompress the data
-                    zfp_field * field;
+                    zfp_field  *field;
                     zfp_stream *zfp;
                     size_t      bufsize, decompress_size;
-                    bitstream * stream;
+                    bitstream  *stream;
 
                     field = _setup_zfp(region_info, &zfp);
                     if (field == NULL)
@@ -4888,7 +4888,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
                             LOG_ERROR("==PDC_SERVER[%d]: zfp_stream_maximum_size returned 0!\n",
                                       pdc_server_rank_g);
 
-                        void *decompress_buffer = malloc(decompress_size);
+                        void *decompress_buffer = PDC_malloc(decompress_size);
                         if (decompress_buffer == 0)
                             LOG_ERROR("==PDC_SERVER[%d]: malloc failed!\n", pdc_server_rank_g);
                         else {
@@ -5132,7 +5132,7 @@ PDC_Server_get_local_storage_meta_with_one_name(storage_meta_query_one_name_args
 {
     perr_t          ret_value  = SUCCEED;
     pdc_metadata_t *meta       = NULL;
-    region_list_t * region_elt = NULL, *region_head = NULL, *res_region_list = NULL;
+    region_list_t  *region_elt = NULL, *region_head = NULL, *res_region_list = NULL;
     int             region_count = 0, i = 0;
 
     FUNC_ENTER(NULL);
@@ -5264,7 +5264,7 @@ PDC_Server_accumulate_storage_meta_then_read(storage_meta_query_one_name_args_t 
 {
     perr_t                     ret_value = SUCCEED;
     accumulate_storage_meta_t *accu_meta;
-    region_list_t *            req_region = NULL, *region_elt = NULL, *read_list_head = NULL;
+    region_list_t             *req_region = NULL, *region_elt = NULL, *read_list_head = NULL;
     int                        i, is_sort_read;
     size_t                     j;
 
@@ -5432,16 +5432,16 @@ PDC_Server_storage_meta_name_query_bulk_respond(const struct hg_cb_info *callbac
 {
     hg_return_t                         hg_ret = HG_SUCCESS;
     perr_t                              ret_value;
-    storage_meta_name_query_in_t *      args;
+    storage_meta_name_query_in_t       *args;
     storage_meta_query_one_name_args_t *query_args;
     hg_handle_t                         rpc_handle;
     hg_bulk_t                           bulk_handle;
     bulk_rpc_in_t                       bulk_rpc_in;
-    void **                             buf_ptrs;
-    hg_size_t *                         buf_sizes;
+    void                              **buf_ptrs;
+    hg_size_t                          *buf_sizes;
     uint32_t                            server_id;
-    region_info_transfer_t **           region_infos;
-    region_list_t *                     region_elt;
+    region_info_transfer_t            **region_infos;
+    region_list_t                      *region_elt;
     int                                 i, j;
     FUNC_ENTER(NULL);
 
@@ -5585,9 +5585,9 @@ PDC_Server_add_client_shm_to_cache(int cnt, void *buf_cp)
 {
     perr_t                     ret_value = SUCCEED;
     int                        i, j;
-    region_storage_meta_t *    storage_metas = (region_storage_meta_t *)buf_cp;
+    region_storage_meta_t     *storage_metas = (region_storage_meta_t *)buf_cp;
     pdc_data_server_io_list_t *io_list_elt, *io_list_target;
-    region_list_t *            new_region;
+    region_list_t             *new_region;
 
     FUNC_ENTER(NULL);
 
@@ -5699,7 +5699,7 @@ PDC_Server_data_read_to_buf_1_region(region_list_t *region)
 {
     perr_t   ret_value = SUCCEED;
     uint64_t offset, read_bytes;
-    FILE *   fp_read = NULL;
+    FILE    *fp_read = NULL;
 
     if (region->is_data_ready == 1)
         return SUCCEED;
@@ -5724,7 +5724,7 @@ PDC_Server_data_read_to_buf_1_region(region_list_t *region)
         goto done;
     }
 
-    region->buf = malloc(region->data_size);
+    region->buf = PDC_malloc(region->data_size);
 
     read_bytes = fread(region->buf, 1, region->data_size, fp_read);
     if (read_bytes != region->data_size) {
@@ -5748,9 +5748,9 @@ PDC_Server_data_read_to_buf(region_list_t *region_list_head)
 {
     perr_t         ret_value = SUCCEED;
     region_list_t *region_elt;
-    char *         prev_path = NULL;
+    char          *prev_path = NULL;
     uint64_t       offset, read_bytes;
-    FILE *         fp_read = NULL;
+    FILE          *fp_read = NULL;
 
     int read_count = 0;
 
@@ -5787,7 +5787,7 @@ PDC_Server_data_read_to_buf(region_list_t *region_list_head)
             continue;
         }
 
-        region_elt->buf = malloc(region_elt->data_size);
+        region_elt->buf = PDC_malloc(region_elt->data_size);
 
         read_bytes = fread(region_elt->buf, 1, region_elt->data_size, fp_read);
         if (read_bytes != region_elt->data_size) {
@@ -5889,8 +5889,8 @@ static perr_t
 PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_combine_op_t combine_op)
 {
     perr_t                     ret_value  = SUCCEED;
-    region_list_t *            req_region = NULL, *region_tmp = NULL;
-    region_list_t *            storage_region_list_head = NULL;
+    region_list_t             *req_region = NULL, *region_tmp = NULL;
+    region_list_t             *storage_region_list_head = NULL;
     pdc_data_server_io_list_t *io_list_elt, *io_list_target = NULL;
     uint64_t                   obj_id;
     int                        iter, count, is_same_region, i, can_skip;
@@ -6161,7 +6161,7 @@ compare_coords_3d(const void *a, const void *b)
     ({                                                                                                       \
         uint64_t idx, iii, jjj, ttt, cur_count = 0, istart, has_dup;                                         \
         int      is_good, _ndim;                                                                             \
-        TYPE *   edata = (TYPE *)(_data);                                                                    \
+        TYPE    *edata = (TYPE *)(_data);                                                                    \
         _ndim          = (_region)->ndim;                                                                    \
         istart         = (_sel)->nhits * _ndim;                                                              \
         if (_ndim > 3) {                                                                                     \
@@ -6306,7 +6306,7 @@ compare_coords_3d(const void *a, const void *b)
     ({                                                                                                       \
         uint64_t idx, iii, jjj, ttt, cur_count = 0, istart, has_dup;                                         \
         int      is_good, _ndim;                                                                             \
-        TYPE *   edata = (TYPE *)(_data);                                                                    \
+        TYPE    *edata = (TYPE *)(_data);                                                                    \
         _ndim          = (_region)->ndim;                                                                    \
         istart         = (_sel)->nhits * _ndim;                                                              \
         if (_ndim > 3) {                                                                                     \
@@ -6467,11 +6467,11 @@ generate_write_fastbit_idx(uint64_t obj_id, void *data, uint64_t dataCount, Fast
     char      keyName[128];
     char      offName[128];
     char      out_name[256];
-    double *  keys    = NULL;
-    int64_t * offsets = NULL;
+    double   *keys    = NULL;
+    int64_t  *offsets = NULL;
     uint32_t *bms     = NULL;
     uint64_t  nk = 0, no = 0, nb = 0;
-    FILE *    fp;
+    FILE     *fp;
 
     FUNC_ENTER(NULL);
 
@@ -6569,7 +6569,7 @@ int
 queryData(const char *name)
 {
     uint64_t               nhits, i;
-    uint64_t *             buf;
+    uint64_t              *buf;
     double                 val1 = 0.0, val2 = 10.0;
     FastBitSelectionHandle sel1 = fastbit_selection_osr(name, FastBitCompareGreater, val1);
     FastBitSelectionHandle sel2 = fastbit_selection_osr(name, FastBitCompareLess, val2);
@@ -6604,7 +6604,7 @@ PDC_load_fastbit_index(char *idx_name, uint64_t obj_id, FastBitDataType dtype, i
     char     offName[128];
     char     out_name[256];
     uint64_t nk = 0, no = 0, nb = 0, size;
-    FILE *   fp;
+    FILE    *fp;
 
     PDC_gen_fastbit_idx_name(bmsName, "bms", obj_id, timestep, ndim, start, count);
     PDC_gen_fastbit_idx_name(keyName, "key", obj_id, timestep, ndim, start, count);
@@ -6680,9 +6680,9 @@ PDC_query_fastbit_idx(region_list_t *region, pdc_query_constraint_t *constraint,
     perr_t          ret_value = SUCCEED;
     FastBitDataType ft        = 0;
     uint64_t        type_size;
-    uint32_t *      bms     = NULL;
-    double *        keys    = NULL;
-    int64_t *       offsets = NULL;
+    uint32_t       *bms     = NULL;
+    double         *keys    = NULL;
+    int64_t        *offsets = NULL;
     int             timestep;
     double          v1, v2;
     size_t          i;
@@ -6787,7 +6787,7 @@ PDC_query_fastbit_idx(region_list_t *region, pdc_query_constraint_t *constraint,
     }
     *nhit = fastbit_selection_evaluate(sel);
     if (*nhit > 0) {
-        *coords = malloc(*nhit * sizeof(uint64_t));
+        *coords = PDC_malloc(*nhit * sizeof(uint64_t));
         fastbit_selection_get_coordinates(sel, *coords, *nhit, 0);
     }
 
@@ -6857,7 +6857,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
                                     pdc_query_combine_op_t combine_op)
 {
     perr_t           ret_value = SUCCEED;
-    region_list_t *  region_elt, *region_list_head, *cache_region, tmp_region, *region_constraint = NULL;
+    region_list_t   *region_elt, *region_list_head, *cache_region, tmp_region, *region_constraint = NULL;
     pdc_selection_t *sel = query->sel;
     uint64_t         nelem;
     size_t           i, j, unit_size;
@@ -6871,7 +6871,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
     uint32_t ulo = 0, uhi = 0;
     int64_t  i64lo = 0, i64hi = 0;
     uint64_t ui64lo = 0, ui64hi = 0;
-    void *   value = NULL, *buf = NULL;
+    void    *value = NULL, *buf = NULL;
     int      n_eval_region = 0, can_skip, region_iter = 0;
 
     LOG_INFO("==PDC_SERVER[%d]: start query evaluation!\n", pdc_server_rank_g);
@@ -7212,7 +7212,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
 
             n_eval_region++;
         } // End DL_FOREACH
-    }     // End not use fastbit
+    } // End not use fastbit
 
     if (n_eval_region == 0 && combine_op == PDC_QUERY_AND) {
         if (sel->nhits > 0) {
@@ -7540,7 +7540,7 @@ PDC_Server_send_coords_to_client(query_task_t *task)
     hg_bulk_t     bulk_handle;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void *        buf;
+    void         *buf;
     int           client_id;
 
     FUNC_ENTER(NULL);
@@ -7622,7 +7622,7 @@ PDC_Server_send_coords_to_server(query_task_t *task)
     hg_bulk_t     bulk_handle = NULL;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void *        buf;
+    void         *buf;
     int           server_id;
 
     FUNC_ENTER(NULL);
@@ -7829,9 +7829,9 @@ hg_return_t
 PDC_Server_read_coords(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret  = HG_SUCCESS;
-    query_task_t *          task = (query_task_t *)callback_info->arg;
+    query_task_t           *task = (query_task_t *)callback_info->arg;
     pdc_query_constraint_t *constraint;
-    region_list_t *         storage_region_head, *region_elt, *cache_region;
+    region_list_t          *storage_region_head, *region_elt, *cache_region;
     size_t                  ndim, unit_size;
     uint64_t                i, *coord, data_off, buf_off, my_size;
 
@@ -7842,7 +7842,7 @@ PDC_Server_read_coords(const struct hg_cb_info *callback_info)
         ndim                = storage_region_head->ndim;
         unit_size           = PDC_get_var_type_size(constraint->type);
         my_size             = task->my_nread_coords * unit_size;
-        task->my_data       = malloc(my_size);
+        task->my_data       = PDC_malloc(my_size);
 
         if (NULL == task->my_data) {
             LOG_ERROR("==PDC_SERVER[%d]: error allocating %" PRIu64 " bytes for data read!\n",
@@ -7897,11 +7897,11 @@ PDC_recv_read_coords(const struct hg_cb_info *callback_info)
     hg_return_t         ret               = HG_SUCCESS;
     hg_bulk_t           local_bulk_handle = callback_info->info.bulk.local_handle;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    query_task_t *      task_elt          = NULL;
+    query_task_t       *task_elt          = NULL;
     uint64_t            nhits, obj_id;
     uint32_t            ndim;
     int                 query_id, origin;
-    void *              buf;
+    void               *buf;
 
     pdc_int_ret_t out;
     out.ret = 1;
@@ -7980,7 +7980,7 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
     hg_return_t         ret               = HG_SUCCESS;
     hg_bulk_t           local_bulk_handle = callback_info->info.bulk.local_handle;
     struct bulk_args_t *bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    query_task_t *      task_elt;
+    query_task_t       *task_elt;
     uint64_t            nhits = 0, total_hits;
     size_t              ndim, unit_size;
     int                 i, query_id, origin, found_task;
@@ -8198,7 +8198,7 @@ perr_t
 add_storage_region_to_buf(void **in_buf, uint64_t *buf_alloc, uint64_t *buf_off, const region_list_t *region)
 {
     perr_t   ret_value = SUCCEED;
-    void *   buf       = *in_buf;
+    void    *buf       = *in_buf;
     uint64_t my_size, tmp_size;
 
     if (in_buf == NULL || *in_buf == NULL || region == NULL || buf_alloc == NULL || buf_off == NULL ||
@@ -8394,8 +8394,8 @@ PDC_Server_distribute_query_storage_info(query_task_t *task, uint64_t obj_id, in
 {
     pdc_metadata_t *meta = NULL;
     int             i, server_id, count, avg_count, nsent, nsent_server;
-    region_list_t * elt, *new_region = NULL;
-    void *          region_bulk_buf;
+    region_list_t  *elt, *new_region = NULL;
+    void           *region_bulk_buf;
     uint64_t        buf_alloc = 0, buf_off = 0;
     bulk_rpc_in_t   header;
 
@@ -8535,16 +8535,16 @@ PDC_recv_query_metadata_bulk(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret               = HG_SUCCESS;
     hg_bulk_t               local_bulk_handle = callback_info->info.bulk.local_handle;
-    struct bulk_args_t *    bulk_args         = (struct bulk_args_t *)callback_info->arg;
-    void *                  buf;
-    region_list_t *         regions = NULL;
+    struct bulk_args_t     *bulk_args         = (struct bulk_args_t *)callback_info->arg;
+    void                   *buf;
+    region_list_t          *regions = NULL;
     int                     i, nregion, *loc_len_ptr, *has_hist_ptr, found_task;
     uint64_t                buf_off, *offset_ptr = NULL, *size_ptr = NULL;
-    char *                  loc_ptr         = NULL;
+    char                   *loc_ptr         = NULL;
     region_info_transfer_t *region_info_ptr = NULL;
-    pdc_histogram_t *       hist_ptr        = NULL;
-    query_task_t *          task_elt        = NULL;
-    pdc_query_t *           query           = NULL;
+    pdc_histogram_t        *hist_ptr        = NULL;
+    query_task_t           *task_elt        = NULL;
+    pdc_query_t            *query           = NULL;
 
     pdc_int_ret_t out;
     out.ret = 1;
@@ -8713,10 +8713,10 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
     hg_return_t       ret        = HG_SUCCESS;
     pdc_query_xfer_t *query_xfer = (pdc_query_xfer_t *)callback_info->arg;
     int               obj_idx    = 0;
-    uint64_t *        obj_ids;
-    query_task_t *    new_task       = NULL, *task_elt;
+    uint64_t         *obj_ids;
+    query_task_t     *new_task       = NULL, *task_elt;
     int               query_id_exist = 0;
-    pdc_query_t *     query;
+    pdc_query_t      *query;
 
     query = PDC_deserialize_query(query_xfer);
     if (NULL == query) {
@@ -8822,7 +8822,7 @@ PDC_Server_send_read_coords_to_server(int server_id, uint64_t *coord, uint64_t n
     hg_bulk_t     bulk_handle = NULL;
     bulk_rpc_in_t in;
     hg_size_t     buf_sizes;
-    void *        buf;
+    void         *buf;
 
     FUNC_ENTER(NULL);
 
@@ -8933,12 +8933,12 @@ hg_return_t
 PDC_Server_recv_read_sel_obj_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t             ret = HG_SUCCESS;
-    get_sel_data_rpc_in_t * in  = (get_sel_data_rpc_in_t *)callback_info->arg;
-    query_task_t *          task_elt, *task = NULL;
+    get_sel_data_rpc_in_t  *in  = (get_sel_data_rpc_in_t *)callback_info->arg;
+    query_task_t           *task_elt, *task = NULL;
     uint64_t                nhits, *coord, *coords = NULL, obj_id, buf_off, my_size, data_off, i;
     size_t                  ndim, unit_size;
     cache_storage_region_t *cache_region_elt;
-    region_list_t *         storage_region_head = NULL, *cache_region, *region_elt;
+    region_list_t          *storage_region_head = NULL, *cache_region, *region_elt;
     pdc_var_type_t          data_type;
 
     // find task
@@ -8984,7 +8984,7 @@ PDC_Server_recv_read_sel_obj_data(const struct hg_cb_info *callback_info)
     ndim          = storage_region_head->ndim;
     unit_size     = PDC_get_var_type_size(data_type);
     my_size       = nhits * unit_size;
-    task->my_data = malloc(my_size);
+    task->my_data = PDC_malloc(my_size);
     if (NULL == task->my_data) {
         LOG_ERROR("==PDC_SERVER[%d]: error allocating %" PRIu64 " bytes for data read!\n", pdc_server_rank_g,
                   nhits * unit_size);
@@ -9026,8 +9026,8 @@ PDC_Server_recv_get_sel_data(const struct hg_cb_info *callback_info)
 {
     hg_return_t            ret = HG_SUCCESS;
     get_sel_data_rpc_in_t *in  = (get_sel_data_rpc_in_t *)callback_info->arg;
-    query_task_t *         task_elt, *task = NULL;
-    pdc_metadata_t *       meta;
+    query_task_t          *task_elt, *task = NULL;
+    pdc_metadata_t        *meta;
     struct hg_cb_info      fake_callback_info = {0};
 
     DL_FOREACH(query_task_list_head_g, task_elt)

--- a/src/server/pdc_server_region/pdc_server_data.c
+++ b/src/server/pdc_server_region/pdc_server_data.c
@@ -803,7 +803,7 @@ PDC_Data_Server_buf_unmap(const struct hg_info *info, buf_unmap_in_t *in)
 #ifdef ENABLE_MULTITHREAD
                 hg_thread_mutex_destroy(&(elt->bulk_args->work_mutex));
                 hg_thread_cond_destroy(&(elt->bulk_args->work_cond));
-                free(elt->bulk_args);
+                elt->bulk_args = (struct buf_map_release_bulk_args *)PDC_free(elt->bulk_args);
 #endif
                 DL_DELETE(target_obj->region_buf_map_head, elt);
                 elt = (region_buf_map_t *)PDC_free(elt);
@@ -872,7 +872,7 @@ PDC_Data_Server_check_unmap()
         DL_FOREACH_SAFE(target_obj->region_buf_map_head, elt, tmp)
         {
             if (remote_obj_id == elt->remote_obj_id &&
-                PDC_region_is_identical(elt1->unmap_region, elt->remote_region_unit)) {
+                PDC_region_info_transfer_t_is_equal(&(elt1->unmap_region), &(elt->remote_region_unit))) {
                 hg_thread_mutex_lock(&(elt->bulk_args->work_mutex));
                 if (!elt->bulk_args->work_completed)
                     // wait for 100ms for work completed
@@ -884,17 +884,17 @@ PDC_Data_Server_check_unmap()
                     completed                      = 1;
                     elt->bulk_args->work_completed = 0;
                     if (elt->remote_data_ptr) {
-                        free(elt->remote_data_ptr);
+                        elt->remote_data_ptr = (void *)PDC_free(elt->remote_data_ptr);
                         elt->remote_data_ptr = NULL;
                     }
                     HG_Addr_free(elt1->info->hg_class, elt->local_addr);
                     HG_Bulk_free(elt->local_bulk_handle);
                     hg_thread_mutex_destroy(&(elt->bulk_args->work_mutex));
                     hg_thread_cond_destroy(&(elt->bulk_args->work_cond));
-                    free(elt->bulk_args);
+                    elt->bulk_args = (struct buf_map_release_bulk_args *)PDC_free(elt->bulk_args);
 
                     DL_DELETE(target_obj->region_buf_map_head, elt);
-                    free(elt);
+                    elt = (region_buf_map_t *)PDC_free(elt);
                 }
             }
         }
@@ -905,7 +905,7 @@ PDC_Data_Server_check_unmap()
         hg_thread_mutex_unlock(&data_buf_map_mutex_g);
         if (completed == 1) {
             DL_DELETE(dataserver_region_unmap, elt1);
-            free(elt1);
+            elt1 = (data_server_region_unmap_t *)PDC_free(elt1);
         }
     }
 
@@ -993,9 +993,9 @@ done:
     if (error == 1) {
         HG_Free_input(handle, &(lookup_args->buf_unmap_args->in));
         HG_Destroy(handle);
-        free(tranx_args);
+        tranx_args = (struct transfer_buf_unmap *)PDC_free(tranx_args);
     }
-    free(lookup_args);
+    lookup_args = (struct buf_unmap_server_lookup_args_t *)PDC_free(lookup_args);
     FUNC_LEAVE(ret_value);
 }
 
@@ -1030,7 +1030,7 @@ done:
     if (error == 1) {
         HG_Free_input(handle, &(transfer_args->in));
         HG_Destroy(handle);
-        free(transfer_args);
+        transfer_args = (struct transfer_buf_unmap *)PDC_free(transfer_args);
     }
 
     FUNC_LEAVE(ret_value);
@@ -1099,7 +1099,7 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
             if (in->remote_obj_id == elt->remote_obj_id &&
                 PDC_region_info_transfer_t_is_equal(&(in->remote_region), &(elt->remote_region_unit))) {
                 DL_DELETE(target_meta->region_buf_map_head, elt);
-                free(elt);
+                elt = (region_buf_map_t *)PDC_free(elt);
             }
         }
 #ifdef ENABLE_MULTITHREAD
@@ -1131,8 +1131,8 @@ PDC_Meta_Server_buf_unmap(buf_unmap_in_t *in, hg_handle_t *handle)
                 HG_Forward(server_send_buf_unmap_handle, server_send_buf_unmap_rpc_cb, buf_unmap_args, in);
             if (hg_ret != HG_SUCCESS) {
                 HG_Destroy(server_send_buf_unmap_handle);
-                free(buf_unmap_args);
-                error = 1;
+                buf_unmap_args = (struct transfer_buf_unmap_args *)PDC_free(buf_unmap_args);
+                error          = 1;
                 PGOTO_ERROR(FAIL, "PDC_Meta_Server_buf_unmap(): Could not start HG_Forward()");
             }
         }
@@ -1268,7 +1268,7 @@ PDC_Data_Server_buf_map(const struct hg_info *info, buf_map_in_t *in, region_lis
     }
     ret_value = buf_map_ptr;
 
-    free(request_region);
+    request_region = (region_list_t *)PDC_free(request_region);
 
 done:
     FUNC_LEAVE(ret_value);
@@ -1386,7 +1386,7 @@ done:
     HG_Destroy(tranx_args->handle);
     HG_Free_output(handle, &out);
     HG_Destroy(handle);
-    free(tranx_args);
+    tranx_args = (struct transfer_buf_map *)PDC_free(tranx_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -1440,9 +1440,9 @@ done:
     if (error == 1) {
         HG_Free_input(handle, &(lookup_args->buf_map_args->in));
         HG_Destroy(handle);
-        free(tranx_args);
+        tranx_args = (struct transfer_buf_map *)PDC_free(tranx_args);
     }
-    free(lookup_args);
+    lookup_args = (struct buf_map_server_lookup_args_t *)PDC_free(lookup_args);
     FUNC_LEAVE(ret_value);
 }
 
@@ -1476,7 +1476,7 @@ done:
     if (error == 1) {
         HG_Free_input(handle, &(transfer_args->in));
         HG_Destroy(handle);
-        free(transfer_args);
+        transfer_args = (struct transfer_buf_map *)PDC_free(transfer_args);
     }
 
     FUNC_LEAVE(ret_value);
@@ -1508,7 +1508,7 @@ done:
     HG_Destroy(tranx_args->handle);
     HG_Free_output(handle, &out);
     HG_Destroy(handle);
-    free(tranx_args);
+    tranx_args = (struct transfer_buf_map_args *)PDC_free(tranx_args);
 
     FUNC_LEAVE(ret_value);
 }
@@ -1588,8 +1588,7 @@ PDC_Meta_Server_buf_map(buf_map_in_t *in, region_buf_map_t *new_buf_map_ptr, hg_
             if (hg_ret != HG_SUCCESS) {
                 error = 1;
                 HG_Destroy(server_send_buf_map_handle);
-                free(tranx_args);
-                tranx_args = NULL;
+                tranx_args = (struct transfer_buf_map_args *)PDC_free(tranx_args);
                 PGOTO_ERROR(FAIL, "PDC_Server_transfer_region_info(): Could not start HG_Forward()");
             }
         }
@@ -1603,7 +1602,7 @@ done:
         HG_Free_input(*handle, in);
         HG_Destroy(*handle);
         if ((uint32_t)pdc_server_rank_g != in->meta_server_id && tranx_args != NULL)
-            free(tranx_args);
+            tranx_args = (struct transfer_buf_map_args *)PDC_free(tranx_args);
     }
     FUNC_LEAVE(ret_value);
 }
@@ -1778,9 +1777,9 @@ PDC_Server_notify_client_multi_io_complete_cb(const struct hg_cb_info *callback_
 
 done:
     if (args) {
-        free(args->buf_sizes);
-        free(args->buf_ptrs);
-        free(args);
+        args->buf_sizes = (void *)PDC_free(args->buf_sizes);
+        args->buf_ptrs  = (void *)PDC_free(args->buf_ptrs);
+        args            = (notify_multi_io_args_t *)PDC_free(args);
     }
 
     HG_Free_output(handle, &output);
@@ -1827,8 +1826,8 @@ PDC_Server_notify_client_multi_io_complete(uint32_t client_id, int client_seq_id
     }
 
     // Send the shm_addr + total data size to client
-    buf_sizes = (hg_size_t *)calloc(sizeof(hg_size_t), n_completed * 2);
-    buf_ptrs  = (void **)calloc(sizeof(void *), n_completed * 2);
+    buf_sizes = (hg_size_t *)PDC_calloc(sizeof(hg_size_t), n_completed * 2);
+    buf_ptrs  = (void **)PDC_calloc(sizeof(void *), n_completed * 2);
 
     i = 0;
     DL_FOREACH(completed_region_list, region_elt)
@@ -1855,7 +1854,7 @@ PDC_Server_notify_client_multi_io_complete(uint32_t client_id, int client_seq_id
     bulk_rpc_in.seq_id      = client_seq_id;
     bulk_rpc_in.bulk_handle = bulk_handle;
 
-    bulk_args              = (notify_multi_io_args_t *)calloc(1, sizeof(notify_multi_io_args_t));
+    bulk_args              = (notify_multi_io_args_t *)PDC_calloc(1, sizeof(notify_multi_io_args_t));
     bulk_args->bulk_handle = bulk_handle;
     bulk_args->buf_sizes   = buf_sizes;
     bulk_args->buf_ptrs    = buf_ptrs;
@@ -1994,9 +1993,8 @@ PDC_cache_region_to_bb_cb(const struct hg_cb_info *callback_info)
     if (ret != SUCCEED)
         LOG_ERROR("==PDC_SERVER[%d]: Error with PDC_Server_cache_region_to_BB\n", pdc_server_rank_g);
 
-    if (out != NULL) {
-        free(out);
-    }
+    if (out != NULL)
+        out = (server_read_check_out_t *)PDC_free(out);
 
     FUNC_LEAVE(ret_value);
 }
@@ -2059,7 +2057,7 @@ PDC_Server_read_check(data_server_read_check_in_t *in, server_read_check_out_t *
             out->region         = NULL;
             out->is_cache_to_bb = 0;
             if (region_elt->is_data_ready == 1) {
-                out->shm_addr = calloc(sizeof(char), ADDR_MAX);
+                out->shm_addr = PDC_calloc(sizeof(char), ADDR_MAX);
                 if (strlen(region_elt->shm_addr) == 0)
                     LOG_ERROR("==PDC_SERVER[%d]: found shm_addr is NULL!\n", pdc_server_rank_g);
                 else
@@ -2252,10 +2250,13 @@ update_region_storage_meta_bulk_cleanup_cb(update_storage_meta_list_t *meta_list
     (*n_updated)++;
 
     DL_DELETE(pdc_update_storage_meta_list_head_g, meta_list_target);
-    free(meta_list_target->storage_meta_bulk_xfer_data->buf_ptrs[0]);
-    free(meta_list_target->storage_meta_bulk_xfer_data->buf_sizes);
-    free(meta_list_target->storage_meta_bulk_xfer_data);
-    free(meta_list_target);
+    meta_list_target->storage_meta_bulk_xfer_data->buf_ptrs[0] =
+        (void *)PDC_free(meta_list_target->storage_meta_bulk_xfer_data->buf_ptrs[0]);
+    meta_list_target->storage_meta_bulk_xfer_data->buf_sizes =
+        (hg_size_t *)PDC_free(meta_list_target->storage_meta_bulk_xfer_data->buf_sizes);
+    meta_list_target->storage_meta_bulk_xfer_data =
+        (bulk_xfer_data_t *)PDC_free(meta_list_target->storage_meta_bulk_xfer_data);
+    meta_list_target = (update_storage_meta_list_t *)PDC_free(meta_list_target);
 
     if (NULL == pdc_update_storage_meta_list_head_g) {
         pdc_nbuffered_bulk_update_g      = 0;
@@ -2338,7 +2339,7 @@ done:
 #endif
 
     if (write_ret)
-        free(write_ret);
+        write_ret = (data_server_write_check_out_t *)PDC_free(write_ret);
     fflush(stdout);
 
     FUNC_LEAVE(ret_value);
@@ -2421,7 +2422,8 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
 
     // Only recv server needs allocation
     if (server_id == (uint32_t)pdc_server_rank_g) {
-        all_requests = (region_info_transfer_t *)calloc(pdc_server_size_g, data_size * nrequest_per_server);
+        all_requests =
+            (region_info_transfer_t *)PDC_calloc(pdc_server_size_g, data_size * nrequest_per_server);
     }
     else
         all_requests = local_region_transfer;
@@ -2435,17 +2437,17 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
 
     // NOTE: Assumes all data server send equal number of requests
     total_request_cnt   = nrequest_per_server * pdc_server_size_g;
-    send_bytes          = (int *)calloc(sizeof(int), pdc_server_size_g);
-    displs              = (int *)calloc(sizeof(int), pdc_server_size_g);
-    request_overlap_cnt = (int *)calloc(total_request_cnt, sizeof(int));
+    send_bytes          = (int *)PDC_calloc(sizeof(int), pdc_server_size_g);
+    displs              = (int *)PDC_calloc(sizeof(int), pdc_server_size_g);
+    request_overlap_cnt = (int *)PDC_calloc(total_request_cnt, sizeof(int));
     // ^storage meta results in all_requests to be returned to all data servers
 
     // Now server_id has all the data in all_requests, find all storage regions that overlaps with it
     // equivalent to storage metadadata searching
     if (server_id == (uint32_t)pdc_server_rank_g) {
-        send_buf = (update_region_storage_meta_bulk_t *)calloc(sizeof(update_region_storage_meta_bulk_t),
-                                                               pdc_server_size_g * nrequest_per_server *
-                                                                   PDC_MAX_OVERLAP_REGION_NUM);
+        send_buf = (update_region_storage_meta_bulk_t *)PDC_calloc(sizeof(update_region_storage_meta_bulk_t),
+                                                                   pdc_server_size_g * nrequest_per_server *
+                                                                       PDC_MAX_OVERLAP_REGION_NUM);
 
         // All participants are querying the same object, so obj_ids are the same
         // Search one by one
@@ -2453,7 +2455,8 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
         uint32_t overlap_cnt = 0;
         int      server_idx;
         // overlap_regions_2d has the ptrs to overlap storage regions to current request
-        overlap_regions_2d = (region_list_t **)calloc(sizeof(region_list_t *), PDC_MAX_OVERLAP_REGION_NUM);
+        overlap_regions_2d =
+            (region_list_t **)PDC_calloc(sizeof(region_list_t *), PDC_MAX_OVERLAP_REGION_NUM);
         for (i = 0; i < total_request_cnt; i++) {
             server_idx = i / nrequest_per_server;
             // server_idx should be [0, pdc_server_size_g)
@@ -2506,7 +2509,7 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
     // for each requested server, just scatter
 
     // result_storage_meta is the recv result storage metadata of the requests sent
-    result_storage_meta = (update_region_storage_meta_bulk_t *)calloc(
+    result_storage_meta = (update_region_storage_meta_bulk_t *)PDC_calloc(
         sizeof(update_region_storage_meta_bulk_t), nrequest_per_server * PDC_MAX_OVERLAP_REGION_NUM);
 
 #ifdef ENABLE_MPI
@@ -2531,7 +2534,7 @@ PDC_Server_get_storage_location_of_region_mpi(region_list_t *regions_head)
         if (region_elt->access_type == PDC_READ) {
             region_elt->n_overlap_storage_region = request_overlap_cnt[overlap_idx + region_idx];
             region_elt->overlap_storage_regions =
-                (region_list_t *)calloc(sizeof(region_list_t), region_elt->n_overlap_storage_region);
+                (region_list_t *)PDC_calloc(sizeof(region_list_t), region_elt->n_overlap_storage_region);
             for (i = 0; i < region_elt->n_overlap_storage_region; i++) {
                 PDC_region_transfer_t_to_list_t(&result_storage_meta[result_idx].region_transfer,
                                                 &region_elt->overlap_storage_regions[i]);
@@ -2562,16 +2565,16 @@ done:
         result_storage_meta = (update_region_storage_meta_bulk_t *)PDC_free(result_storage_meta);
 #else
     if (overlap_regions_2d)
-        free(overlap_regions_2d);
+        overlap_regions_2d = (region_list_t **)PDC_free(overlap_regions_2d);
     if (send_buf)
-        free(send_buf);
+        send_buf = (update_region_storage_meta_bulk_t *)PDC_free(send_buf);
 #endif
     if (send_bytes)
-        free(send_bytes);
+        send_bytes = (int *)PDC_free(send_bytes);
     if (displs)
-        free(displs);
+        displs = (int *)PDC_free(displs);
     if (request_overlap_cnt)
-        free(request_overlap_cnt);
+        request_overlap_cnt = (int *)PDC_free(request_overlap_cnt);
 
     fflush(stdout);
     FUNC_LEAVE(ret_value);
@@ -2766,7 +2769,7 @@ PDC_Server_data_io_via_shm(const struct hg_cb_info *callback_info)
     if (NULL == io_list_target) {
         // pdc_data_server_io_list_t maintains the request list for one object id,
         // write and read are separate lists
-        io_list_target = (pdc_data_server_io_list_t *)calloc(1, sizeof(pdc_data_server_io_list_t));
+        io_list_target = (pdc_data_server_io_list_t *)PDC_calloc(1, sizeof(pdc_data_server_io_list_t));
         if (NULL == io_list_target) {
             LOG_ERROR("==PDC_SERVER: ERROR allocating pdc_data_server_io_list_t!\n");
             ret_value = FAIL;
@@ -2831,14 +2834,14 @@ PDC_Server_data_io_via_shm(const struct hg_cb_info *callback_info)
             else {
                 // Remove that region
                 DL_DELETE(io_list_target->region_list_head, region_elt);
-                free(region_elt);
+                region_elt = (region_list_t *)PDC_free(region_elt);
             }
         }
     }
 
     if (has_read_cache != 1) {
         // append current request region to the io list
-        region_list_t *new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+        region_list_t *new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
         if (new_region == NULL) {
             LOG_ERROR("==PDC_SERVER: ERROR allocating new_region!\n");
             ret_value = FAIL;
@@ -3036,7 +3039,7 @@ PDC_Server_update_local_region_storage_loc(region_list_t *region, uint64_t obj_i
     if (update_success == -1) {
 
         // Create the region list
-        new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+        new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
         if (PDC_region_list_t_deep_cp(region, new_region) != SUCCEED) {
             LOG_ERROR("==PDC_SERVER[%d]: deep copy FAILED!\n", pdc_server_rank_g);
             ret_value = FAIL;
@@ -3216,11 +3219,11 @@ PDC_Server_add_region_storage_meta_to_bulk_buf(region_list_t *region, bulk_xfer_
     // Alloc space and init if it's empty
     if (0 == bulk_data->n_alloc) {
 
-        bulk_data->buf_ptrs = (void **)calloc(sizeof(void *), PDC_BULK_XFER_INIT_NALLOC + 1);
-        update_region_storage_meta_bulk_t *buf_ptrs_1d = (update_region_storage_meta_bulk_t *)calloc(
+        bulk_data->buf_ptrs = (void **)PDC_calloc(sizeof(void *), PDC_BULK_XFER_INIT_NALLOC + 1);
+        update_region_storage_meta_bulk_t *buf_ptrs_1d = (update_region_storage_meta_bulk_t *)PDC_calloc(
             sizeof(update_region_storage_meta_bulk_t), PDC_BULK_XFER_INIT_NALLOC);
 
-        bulk_data->buf_sizes = (hg_size_t *)calloc(sizeof(hg_size_t), PDC_BULK_XFER_INIT_NALLOC);
+        bulk_data->buf_sizes = (hg_size_t *)PDC_calloc(sizeof(hg_size_t), PDC_BULK_XFER_INIT_NALLOC);
         if (NULL == buf_ptrs_1d || NULL == bulk_data->buf_sizes) {
             LOG_ERROR("==PDC_SERVER[%d]: calloc FAILED!\n", pdc_server_rank_g);
             ret_value = FAIL;
@@ -3228,7 +3231,7 @@ PDC_Server_add_region_storage_meta_to_bulk_buf(region_list_t *region, bulk_xfer_
         }
 
         // first element of bulk_buf is the obj_id
-        bulk_data->buf_ptrs[0]  = (void *)calloc(sizeof(uint64_t), 1);
+        bulk_data->buf_ptrs[0]  = (void *)PDC_calloc(sizeof(uint64_t), 1);
         bulk_data->buf_sizes[0] = sizeof(uint64_t);
 
         for (i = 1; i < PDC_BULK_XFER_INIT_NALLOC + 1; i++) {
@@ -3314,7 +3317,7 @@ PDC_Server_update_region_storage_meta_bulk_local(update_region_storage_meta_bulk
 
         // Create a new region for each and copy the data from bulk data
 
-        new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+        new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&bulk_ptr->region_transfer, new_region);
         new_region->data_size = PDC_get_region_size(new_region);
         strcpy(new_region->storage_location, bulk_ptr->storage_location);
@@ -3349,7 +3352,7 @@ PDC_Server_update_region_storage_meta_bulk_local(update_region_storage_meta_bulk
                     LOG_ERROR("==PDC_SERVER[%d]: overwrite existing region location/offset\n",
                               pdc_server_rank_g);
                     fflush(stdout);
-                    free(new_region);
+                    new_region = (region_list_t *)PDC_free(new_region);
                     break;
                 }
             } // DL_FOREACH
@@ -3428,7 +3431,7 @@ PDC_Server_update_region_storage_meta_bulk_mpi(bulk_xfer_data_t *bulk_data)
 
     // Only recv server needs allocation
     if (server_id == (uint32_t)pdc_server_rank_g) {
-        recv_buf = (update_region_storage_meta_bulk_t *)calloc(pdc_server_size_g, data_size);
+        recv_buf = (update_region_storage_meta_bulk_t *)PDC_calloc(pdc_server_size_g, data_size);
     }
 
     // bulk_data->buf_ptrs[0] is number of metadata to be updated
@@ -3440,7 +3443,7 @@ PDC_Server_update_region_storage_meta_bulk_mpi(bulk_xfer_data_t *bulk_data)
 
     // Now server_id has all the data in recv_buf, start update all
     if (server_id == (uint32_t)pdc_server_rank_g) {
-        all_meta    = (void **)calloc(sizeof(void *), all_meta_cnt + 1);
+        all_meta    = (void **)PDC_calloc(sizeof(void *), all_meta_cnt + 1);
         all_meta[0] = bulk_data->buf_ptrs[0];
         for (i = 1; i < all_meta_cnt + 1; i++) {
             all_meta[i] = &recv_buf[i - 1];
@@ -3457,8 +3460,8 @@ PDC_Server_update_region_storage_meta_bulk_mpi(bulk_xfer_data_t *bulk_data)
 
 done:
     if (server_id == (uint32_t)pdc_server_rank_g) {
-        free(recv_buf);
-        free(all_meta);
+        recv_buf = (update_region_storage_meta_bulk_t *)PDC_free(recv_buf);
+        all_meta = (void **)PDC_free(all_meta);
     }
 #else
     LOG_ERROR("is not supposed to be called without MPI enabled!\n");
@@ -3484,8 +3487,8 @@ PDC_Server_update_region_storage_meta_bulk_with_cb(bulk_xfer_data_t           *b
 
     FUNC_ENTER(NULL);
 
-    cb_args =
-        (update_region_storage_meta_bulk_args_t *)calloc(1, sizeof(update_region_storage_meta_bulk_args_t));
+    cb_args = (update_region_storage_meta_bulk_args_t *)PDC_calloc(
+        1, sizeof(update_region_storage_meta_bulk_args_t));
     server_id = bulk_data->target_id;
 
     if (server_id == (uint32_t)pdc_server_rank_g) {
@@ -4288,7 +4291,7 @@ PDC_Server_data_io_direct(pdc_access_t io_type, uint64_t obj_id, struct pdc_regi
     FUNC_ENTER(NULL);
 
     is_server_direct_io_g = 1;
-    io_region             = (region_list_t *)calloc(1, sizeof(region_list_t));
+    io_region             = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
     PDC_init_region_list(io_region);
     PDC_region_info_to_list_t(region_info, io_region);
 
@@ -4424,7 +4427,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
     region = PDC_Server_get_obj_region(obj_id);
     PDC_Server_register_obj_region_by_pointer(&region, obj_id, 0);
 
-    region_list_t *request_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+    region_list_t *request_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
     for (i = 0; i < region_info->ndim; i++) {
         request_region->start[i] = region_info->offset[i];
         request_region->count[i] = region_info->size[i];
@@ -4523,7 +4526,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
                         ret_value = FAIL;
                         goto done;
                     }
-                    free(tmp_buf);
+                    tmp_buf = (char *)PDC_free(tmp_buf);
                 }
                 else {
                     if (region_info->ndim == 2) {
@@ -4562,7 +4565,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 #ifdef PDC_TIMING
                                 pdc_server_timings->PDCdata_server_write_posix += MPI_Wtime() - start_posix;
 #endif
-                                free(tmp_buf);
+                                tmp_buf = (char *)PDC_free(tmp_buf);
                             }
                             if (ret_value != SUCCEED) {
                                 LOG_ERROR("==PDC_SERVER[%d]: PDC_Server_posix_write FAILED!\n",
@@ -4643,7 +4646,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
 #ifdef PDC_TIMING
                                 pdc_server_timings->PDCdata_server_write_posix += MPI_Wtime() - start_posix;
 #endif
-                                free(tmp_buf);
+                                tmp_buf = (char *)PDC_free(tmp_buf);
                             }
                         }
                         else {
@@ -4680,7 +4683,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
                     }
                 }
             }
-            free(overlap_offset);
+            overlap_offset = (uint64_t *)PDC_free(overlap_offset);
         }
     }
     if (is_contained == 0) {
@@ -4739,7 +4742,7 @@ PDC_Server_data_write_out(uint64_t obj_id, struct pdc_region_info *region_info, 
     }
     else {
         PDC_Server_unregister_obj_region_by_pointer(region, 0);
-        free(request_region);
+        request_region = (region_list_t *)PDC_free(request_region);
     }
 
 #ifdef ENABLE_TIMING
@@ -4864,7 +4867,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
 #endif
 
 #ifdef ENABLE_ZFP
-                    // Uncompress the data
+                    //  Uncompress the data
                     zfp_field  *field;
                     zfp_stream *zfp;
                     size_t      bufsize, decompress_size;
@@ -4895,7 +4898,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
                             decompress_size = zfp_decompress(zfp, field);
                             if (decompress_size == 0)
                                 LOG_ERROR("==PDC_SERVER[%d]: zfp_decompress failed!\n", pdc_server_rank_g);
-                            free(tmp_buf);
+                            tmp_buf = (char *)PDC_free(tmp_buf);
                             tmp_buf = decompress_buffer;
                         }
                     }
@@ -4908,7 +4911,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
                                              overlap_region->count, buf, region_info->offset,
                                              region_info->size, overlap_offset, overlap_size);
 
-                    free(tmp_buf);
+                    tmp_buf = (char *)PDC_free(tmp_buf);
                 }
                 else {
                     if (region_info->ndim == 2) {
@@ -4953,7 +4956,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
                                 memcpy_overlap_subregion(region_info->ndim, unit, tmp_buf, overlap_offset,
                                                          overlap_size, buf, region_info->offset,
                                                          region_info->size, overlap_offset, overlap_size);
-                                free(tmp_buf);
+                                tmp_buf = (char *)PDC_free(tmp_buf);
                             }
                         }
                         else {
@@ -5027,7 +5030,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
                                 memcpy_overlap_subregion(region_info->ndim, unit, tmp_buf, overlap_offset,
                                                          overlap_size, buf, region_info->offset,
                                                          region_info->size, overlap_offset, overlap_size);
-                                free(tmp_buf);
+                                tmp_buf = (char *)PDC_free(tmp_buf);
                             }
                         }
                         else {
@@ -5064,7 +5067,7 @@ PDC_Server_data_read_from(uint64_t obj_id, struct pdc_region_info *region_info, 
                     }
                 }
             }
-            free(overlap_offset);
+            overlap_offset = (uint64_t *)PDC_free(overlap_offset);
         }
     }
     PDC_Server_unregister_obj_region_by_pointer(region, 0);
@@ -5145,7 +5148,7 @@ PDC_Server_get_local_storage_meta_with_one_name(storage_meta_query_one_name_args
     // Copy the matched regions with storage metadata to a result region list
     DL_COUNT(region_head, region_elt, region_count);
     args->n_res     = region_count;
-    res_region_list = (region_list_t *)calloc(region_count, sizeof(region_list_t));
+    res_region_list = (region_list_t *)PDC_calloc(region_count, sizeof(region_list_t));
 
     // Copy location and offset
     i = 0;
@@ -5355,11 +5358,11 @@ PDC_Server_query_read_names(query_read_names_args_t *query_read_args)
     // Temp storage to accumulate all storage meta of the requested objects
     // Each task should have one such structure
     accumulate_storage_meta_t *accmulate_meta =
-        (accumulate_storage_meta_t *)calloc(1, sizeof(accumulate_storage_meta_t));
+        (accumulate_storage_meta_t *)PDC_calloc(1, sizeof(accumulate_storage_meta_t));
     accmulate_meta->n_total       = query_read_args->cnt;
     accmulate_meta->client_id     = query_read_args->client_id;
     accmulate_meta->client_seq_id = query_read_args->client_seq_id;
-    accmulate_meta->storage_meta  = (storage_meta_query_one_name_args_t **)calloc(
+    accmulate_meta->storage_meta  = (storage_meta_query_one_name_args_t **)PDC_calloc(
         query_read_args->cnt, sizeof(storage_meta_query_one_name_args_t *));
 
     // Now we need to retrieve their storage metadata, some can be found in local metadata server,
@@ -5368,9 +5371,9 @@ PDC_Server_query_read_names(query_read_names_args_t *query_read_args)
     for (i = 0; i < query_read_args->cnt; i++) {
         // query_name_args is the struct to store all storage metadata of each request obj (obj_name)
         query_name_args =
-            (storage_meta_query_one_name_args_t *)calloc(1, sizeof(storage_meta_query_one_name_args_t));
+            (storage_meta_query_one_name_args_t *)PDC_calloc(1, sizeof(storage_meta_query_one_name_args_t));
         query_name_args->seq_id     = i;
-        query_name_args->req_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+        query_name_args->req_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
         PDC_init_region_list(query_name_args->req_region);
         query_name_args->req_region->access_type = PDC_READ;
         // TODO: if requesting partial data, adjust the actual region info accordingly
@@ -5445,7 +5448,8 @@ PDC_Server_storage_meta_name_query_bulk_respond(const struct hg_cb_info *callbac
     args = (storage_meta_name_query_in_t *)callback_info->arg;
 
     // Now metadata object is local
-    query_args = (storage_meta_query_one_name_args_t *)calloc(1, sizeof(storage_meta_query_one_name_args_t));
+    query_args =
+        (storage_meta_query_one_name_args_t *)PDC_calloc(1, sizeof(storage_meta_query_one_name_args_t));
     query_args->name = args->obj_name;
 
     ret_value = PDC_Server_get_local_storage_meta_with_one_name(query_args);
@@ -5474,9 +5478,9 @@ PDC_Server_storage_meta_name_query_bulk_respond(const struct hg_cb_info *callbac
     }
 
     int nbuf     = 3 * query_args->n_res + 1;
-    buf_sizes    = (hg_size_t *)calloc(sizeof(hg_size_t), nbuf);
-    buf_ptrs     = (void **)calloc(sizeof(void *), nbuf);
-    region_infos = (region_info_transfer_t **)calloc(sizeof(region_info_transfer_t *), query_args->n_res);
+    buf_sizes    = (hg_size_t *)PDC_calloc(sizeof(hg_size_t), nbuf);
+    buf_ptrs     = (void **)PDC_calloc(sizeof(void *), nbuf);
+    region_infos = (region_info_transfer_t **)PDC_calloc(sizeof(region_info_transfer_t *), query_args->n_res);
 
     // buf_ptrs[0]: task_id
     buf_ptrs[0] = &(args->task_id);
@@ -5488,7 +5492,7 @@ PDC_Server_storage_meta_name_query_bulk_respond(const struct hg_cb_info *callbac
     j = 0;
     DL_FOREACH(query_args->overlap_storage_region_list, region_elt)
     {
-        region_infos[j] = (region_info_transfer_t *)calloc(sizeof(region_info_transfer_t), 1);
+        region_infos[j] = (region_info_transfer_t *)PDC_calloc(sizeof(region_info_transfer_t), 1);
         PDC_region_list_t_to_transfer(region_elt, region_infos[j]);
 
         if (region_elt->cache_location[0] != 0) {
@@ -5602,7 +5606,7 @@ PDC_Server_add_client_shm_to_cache(int cnt, void *buf_cp)
 
         // If not found, create and insert one to the read list
         if (NULL == io_list_target) {
-            io_list_target = (pdc_data_server_io_list_t *)calloc(1, sizeof(pdc_data_server_io_list_t));
+            io_list_target = (pdc_data_server_io_list_t *)PDC_calloc(1, sizeof(pdc_data_server_io_list_t));
             io_list_target->obj_id = storage_metas[i].obj_id;
             io_list_target->total  = 0;
             io_list_target->count  = 0;
@@ -5616,7 +5620,7 @@ PDC_Server_add_client_shm_to_cache(int cnt, void *buf_cp)
         io_list_target->total++;
         io_list_target->count++;
 
-        new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+        new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
         PDC_region_transfer_t_to_list_t(&storage_metas[i].region_transfer, new_region);
         strcpy(new_region->shm_addr, storage_metas[i].storage_location);
         new_region->offset    = storage_metas[i].offset;
@@ -5662,18 +5666,18 @@ PDC_Server_free_query_task(query_task_t *task)
         PDCquery_free_all(task->query);
 
     if (task->coords)
-        free(task->coords);
+        task->coords = (uint64_t *)PDC_free(task->coords);
 
     for (i = 0; i < task->n_read_data_region; i++) {
         if (task->data_arr && task->data_arr[i])
-            free(task->data_arr[i]);
+            task->data_arr[i] = (void *)PDC_free(task->data_arr[i]);
     }
     if (task->data_arr)
-        free(task->data_arr);
+        task->data_arr = (void *)PDC_free(task->data_arr);
     if (task->n_hits_from_server)
-        free(task->n_hits_from_server);
+        task->n_hits_from_server = (uint64_t *)PDC_free(task->n_hits_from_server);
 
-    free(task);
+    task = (query_task_t *)PDC_free(task);
 }
 
 void
@@ -5918,7 +5922,7 @@ PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_com
     if (NULL == io_list_target) {
         // pdc_data_server_io_list_t maintains the request list for one object id,
         // write and read are separate lists
-        io_list_target = (pdc_data_server_io_list_t *)calloc(1, sizeof(pdc_data_server_io_list_t));
+        io_list_target = (pdc_data_server_io_list_t *)PDC_calloc(1, sizeof(pdc_data_server_io_list_t));
         if (NULL == io_list_target) {
             LOG_ERROR("==PDC_SERVER[%d]: ERROR allocating pdc_data_server_io_list_t!\n", pdc_server_rank_g);
             ret_value = FAIL;
@@ -5949,8 +5953,7 @@ PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_com
 
         if (combine_op == PDC_QUERY_OR) {
             if (task->invalid_region_ids != NULL) {
-                free(task->invalid_region_ids);
-                task->invalid_region_ids = NULL;
+                task->invalid_region_ids = (int *)PDC_free(task->invalid_region_ids);
                 task->ninvalid_region    = 0;
             }
         }
@@ -5976,7 +5979,7 @@ PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_com
 
             if (PDC_region_has_hits_from_hist(constraint, req_region->region_hist) == 0) {
                 if (task->invalid_region_ids == NULL)
-                    task->invalid_region_ids = (int *)calloc(count, sizeof(int));
+                    task->invalid_region_ids = (int *)PDC_calloc(count, sizeof(int));
 
                 can_skip = 0;
                 for (i = 0; i < task->ninvalid_region; i++) {
@@ -6003,7 +6006,7 @@ PDC_Server_load_query_data(query_task_t *task, pdc_query_t *query, pdc_query_com
 
         if (1 != is_same_region) {
             // append current request region to the io list
-            region_list_t *new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+            region_list_t *new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
             if (new_region == NULL) {
                 LOG_ERROR("==PDC_SERVER: ERROR allocating new_region!\n");
                 ret_value = FAIL;
@@ -6201,8 +6204,8 @@ compare_coords_3d(const void *a, const void *b)
                 if (is_good == 1) {                                                                          \
                     if ((istart + cur_count + 1) * _ndim > ((_sel)->coords_alloc)) {                         \
                         ((_sel)->coords_alloc) *= 2;                                                         \
-                        ((_sel)->coords) =                                                                   \
-                            (uint64_t *)realloc(((_sel)->coords), (_sel)->coords_alloc * sizeof(uint64_t));  \
+                        ((_sel)->coords) = (uint64_t *)PDC_realloc(((_sel)->coords),                         \
+                                                                   (_sel)->coords_alloc * sizeof(uint64_t)); \
                         if (NULL == ((_sel)->coords)) {                                                      \
                             LOG_ERROR("==PDC_SERVER[%d]: error with malloc!\n", pdc_server_rank_g);          \
                             ret_value = FAIL;                                                                \
@@ -6341,8 +6344,8 @@ compare_coords_3d(const void *a, const void *b)
                 if (is_good == 1) {                                                                          \
                     if ((istart + cur_count + 1) * _ndim > ((_sel)->coords_alloc)) {                         \
                         ((_sel)->coords_alloc) *= 2;                                                         \
-                        ((_sel)->coords) =                                                                   \
-                            (uint64_t *)realloc(((_sel)->coords), (_sel)->coords_alloc * sizeof(uint64_t));  \
+                        ((_sel)->coords) = (uint64_t *)PDC_realloc(((_sel)->coords),                         \
+                                                                   (_sel)->coords_alloc * sizeof(uint64_t)); \
                         if (NULL == ((_sel)->coords)) {                                                      \
                             LOG_ERROR("==PDC_SERVER[%d]: error with malloc!\n", pdc_server_rank_g);          \
                             ret_value = FAIL;                                                                \
@@ -6541,11 +6544,11 @@ generate_write_fastbit_idx(uint64_t obj_id, void *data, uint64_t dataCount, Fast
 
 done:
     if (bms)
-        free(bms);
+        bms = (uint32_t *)PDC_free(bms);
     if (keys)
-        free(keys);
+        keys = (double *)PDC_free(keys);
     if (offsets)
-        free(offsets);
+        offsets = (int64_t *)PDC_free(offsets);
     fastbit_iapi_free_all();
     FUNC_LEAVE(ret_value);
 }
@@ -6575,7 +6578,7 @@ queryData(const char *name)
     nhits = fastbit_selection_evaluate(sel);
     LOG_INFO("Query has %" PRIu64 " hits\n", nhits);
 
-    buf = (uint64_t *)calloc(nhits, sizeof(uint64_t));
+    buf = (uint64_t *)PDC_calloc(nhits, sizeof(uint64_t));
 
     nhits = fastbit_selection_get_coordinates(sel, buf, nhits, 0);
 
@@ -6585,7 +6588,7 @@ queryData(const char *name)
     }
     LOG_JUST_PRINT("\n");
 
-    free(buf);
+    buf = (uint64_t *)PDC_free(buf);
 
     fastbit_iapi_free_all();
     return 1;
@@ -6630,7 +6633,7 @@ PDC_load_fastbit_index(char *idx_name, uint64_t obj_id, FastBitDataType dtype, i
     fseek(fp, 0, SEEK_END);
     size = ftell(fp);
     nb   = size / sizeof(uint32_t);
-    *bms = (uint32_t *)calloc(nb, sizeof(uint32_t));
+    *bms = (uint32_t *)PDC_calloc(nb, sizeof(uint32_t));
     fseek(fp, 0, SEEK_SET);
     fread(*bms, nb, sizeof(uint32_t), fp);
     fclose(fp);
@@ -6645,7 +6648,7 @@ PDC_load_fastbit_index(char *idx_name, uint64_t obj_id, FastBitDataType dtype, i
     fseek(fp, 0, SEEK_END);
     size  = ftell(fp);
     nk    = size / sizeof(double);
-    *keys = (double *)calloc(nk, sizeof(double));
+    *keys = (double *)PDC_calloc(nk, sizeof(double));
     fseek(fp, 0, SEEK_SET);
     fread(*keys, nk, sizeof(double), fp);
     fclose(fp);
@@ -6659,7 +6662,7 @@ PDC_load_fastbit_index(char *idx_name, uint64_t obj_id, FastBitDataType dtype, i
     fseek(fp, 0, SEEK_END);
     size     = ftell(fp);
     no       = size / sizeof(int64_t);
-    *offsets = (int64_t *)calloc(no, sizeof(int64_t));
+    *offsets = (int64_t *)PDC_calloc(no, sizeof(int64_t));
     fseek(fp, 0, SEEK_SET);
     fread(*offsets, no, sizeof(int64_t), fp);
     fclose(fp);
@@ -6789,12 +6792,11 @@ PDC_query_fastbit_idx(region_list_t *region, pdc_query_constraint_t *constraint,
     }
 
     if (bms)
-        free(bms);
+        bms = (uint32_t *)PDC_free(bms);
     if (keys)
-
-        free(keys);
+        keys = (double *)PDC_free(keys);
     if (offsets)
-        free(offsets);
+        offsets = (int64_t *)PDC_free(offsets);
     if (sel)
         fastbit_selection_free(sel);
     fastbit_iapi_free_all();
@@ -7007,7 +7009,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
             if (gen_hist_g == 1) {
                 if (PDC_region_has_hits_from_hist(query->constraint, region_elt->region_hist) == 0) {
                     if (task->invalid_region_ids == NULL)
-                        task->invalid_region_ids = (int *)calloc(count, sizeof(int));
+                        task->invalid_region_ids = (int *)PDC_calloc(count, sizeof(int));
 
                     can_skip = 0;
                     for (i = 0; i < task->ninvalid_region; i++) {
@@ -7037,7 +7039,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
                         sel->coords_alloc = 2 * idx_nhits;
                     else
                         sel->coords_alloc *= 2;
-                    sel->coords = (uint64_t *)realloc(sel->coords, sel->coords_alloc * sizeof(uint64_t));
+                    sel->coords = (uint64_t *)PDC_realloc(sel->coords, sel->coords_alloc * sizeof(uint64_t));
                 }
                 for (iter = 0; iter < idx_nhits; iter++) {
                     if (ndim > 1)
@@ -7057,7 +7059,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
                 sel->nhits += idx_nhits;
 
                 if (idx_coords)
-                    free(idx_coords);
+                    idx_coords = (uint64_t *)PDC_free(idx_coords);
             }
 
             n_eval_region++;
@@ -7106,7 +7108,7 @@ PDC_Server_query_evaluate_merge_opt(pdc_query_t *query, query_task_t *task, pdc_
             if (gen_hist_g == 1) {
                 if (PDC_region_has_hits_from_hist(query->constraint, region_elt->region_hist) == 0) {
                     if (task->invalid_region_ids == NULL)
-                        task->invalid_region_ids = (int *)calloc(count, sizeof(int));
+                        task->invalid_region_ids = (int *)PDC_calloc(count, sizeof(int));
 
                     can_skip = 0;
                     for (i = 0; (int)i < task->ninvalid_region; i++) {
@@ -8021,16 +8023,16 @@ PDC_recv_coords(const struct hg_cb_info *callback_info)
         }
         if (found_task == 0) {
             // Need to create a task and insert to global list
-            task_elt           = (query_task_t *)calloc(1, sizeof(query_task_t));
+            task_elt           = (query_task_t *)PDC_calloc(1, sizeof(query_task_t));
             task_elt->query_id = query_id;
 
             DL_APPEND(query_task_list_head_g, task_elt);
         }
 
         if (NULL == task_elt->coords_arr)
-            task_elt->coords_arr = (uint64_t **)calloc(pdc_server_size_g, sizeof(uint64_t *));
+            task_elt->coords_arr = (uint64_t **)PDC_calloc(pdc_server_size_g, sizeof(uint64_t *));
         if (NULL == task_elt->n_hits_from_server)
-            task_elt->n_hits_from_server = (uint64_t *)calloc(pdc_server_size_g, sizeof(uint64_t));
+            task_elt->n_hits_from_server = (uint64_t *)PDC_calloc(pdc_server_size_g, sizeof(uint64_t));
 
         if (nhits > 0) {
             task_elt->coords_arr[origin] = (uint64_t *)PDC_malloc(bulk_args->nbytes);
@@ -8284,7 +8286,7 @@ add_to_cache_storage_region(uint64_t obj_id, region_list_t *region)
     }
 
     if (found == 0) {
-        new_cache_region         = (cache_storage_region_t *)calloc(sizeof(cache_storage_region_t), 1);
+        new_cache_region         = (cache_storage_region_t *)PDC_calloc(sizeof(cache_storage_region_t), 1);
         new_cache_region->obj_id = obj_id;
         DL_PREPEND(cache_storage_region_head_g, new_cache_region);
         DL_PREPEND(new_cache_region->storage_region_head, region);
@@ -8434,7 +8436,7 @@ PDC_Server_distribute_query_storage_info(query_task_t *task, uint64_t obj_id, in
         task->n_sent_server = ceil((1.0 * count) / avg_count);
 
         buf_alloc       = 4096 * avg_count;
-        region_bulk_buf = calloc(buf_alloc, 1);
+        region_bulk_buf = PDC_calloc(buf_alloc, 1);
 
         memset(&header, 0, sizeof(bulk_rpc_in_t));
         header.seq_id    = task->query_id;
@@ -8464,7 +8466,7 @@ PDC_Server_distribute_query_storage_info(query_task_t *task, uint64_t obj_id, in
 
             if (server_id == pdc_server_rank_g) {
                 // If needs to send to self, make a copy of the storage metadata
-                new_region = (region_list_t *)calloc(1, sizeof(region_list_t));
+                new_region = (region_list_t *)PDC_calloc(1, sizeof(region_list_t));
                 PDC_region_list_t_deep_cp(elt, new_region);
 
                 add_to_cache_storage_region(obj_id, new_region);
@@ -8486,7 +8488,7 @@ PDC_Server_distribute_query_storage_info(query_task_t *task, uint64_t obj_id, in
 
                     // new buf for another server
                     buf_off         = 0;
-                    region_bulk_buf = calloc(buf_alloc, 1);
+                    region_bulk_buf = PDC_calloc(buf_alloc, 1);
                 }
                 else {
                     task->n_recv_obj++;
@@ -8569,7 +8571,7 @@ PDC_recv_query_metadata_bulk(const struct hg_cb_info *callback_info)
         ret = HG_Bulk_access(local_bulk_handle, 0, bulk_args->nbytes, HG_BULK_READWRITE, 1, (void **)&buf,
                              NULL, NULL);
 
-        regions = (region_list_t *)calloc(nregion, sizeof(region_list_t));
+        regions = (region_list_t *)PDC_calloc(nregion, sizeof(region_list_t));
 
         buf_off = 0;
         for (i = 0; i < nregion; i++) {
@@ -8612,7 +8614,7 @@ PDC_recv_query_metadata_bulk(const struct hg_cb_info *callback_info)
                 hist_ptr->bin = (uint64_t *)(buf + buf_off);
                 buf_off += (hist_ptr->nbin * sizeof(uint64_t));
 
-                regions[i].region_hist = (pdc_histogram_t *)calloc(1, sizeof(pdc_histogram_t));
+                regions[i].region_hist = (pdc_histogram_t *)PDC_calloc(1, sizeof(pdc_histogram_t));
                 PDC_copy_hist(regions[i].region_hist, hist_ptr);
 
                 if (regions[i].region_hist->nbin == 0 || regions[i].region_hist->nbin > 1000) {
@@ -8646,7 +8648,7 @@ PDC_recv_query_metadata_bulk(const struct hg_cb_info *callback_info)
 
         if (found_task == 0) {
             // Need to create a task and insert to global list
-            task_elt           = (query_task_t *)calloc(1, sizeof(query_task_t));
+            task_elt           = (query_task_t *)PDC_calloc(1, sizeof(query_task_t));
             task_elt->query_id = bulk_args->query_id;
             task_elt->ndim     = bulk_args->ndim;
 
@@ -8685,7 +8687,7 @@ done:
         return ret;
 
     if (bulk_args->origin == task_elt->prev_server_id || task_elt->prev_server_id == -1) {
-        uint64_t *obj_ids = (uint64_t *)calloc(pdc_server_size_g, sizeof(uint64_t));
+        uint64_t *obj_ids = (uint64_t *)PDC_calloc(pdc_server_size_g, sizeof(uint64_t));
         int       obj_idx = 0;
         PDC_Server_distribute_query_workload(task_elt, query, &obj_idx, obj_ids, PDC_RECV_REGION_DO_QUERY);
         obj_ids = (uint64_t *)PDC_free(obj_ids);
@@ -8722,10 +8724,10 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
         goto done;
     }
 
-    query->sel               = (pdc_selection_t *)calloc(1, sizeof(pdc_selection_t));
+    query->sel               = (pdc_selection_t *)PDC_calloc(1, sizeof(pdc_selection_t));
     query->sel->nhits        = 0;
     query->sel->coords_alloc = 8192;
-    query->sel->coords       = (uint64_t *)calloc(query->sel->coords_alloc, sizeof(uint64_t));
+    query->sel->coords       = (uint64_t *)PDC_calloc(query->sel->coords_alloc, sizeof(uint64_t));
     if (NULL == query->sel->coords) {
         LOG_ERROR("==PDC_SERVER[%d]: error with calloc!\n", pdc_server_rank_g);
         goto done;
@@ -8747,7 +8749,7 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
     }
 
     if (0 == query_id_exist) {
-        new_task = (query_task_t *)calloc(1, sizeof(query_task_t));
+        new_task = (query_task_t *)PDC_calloc(1, sizeof(query_task_t));
         DL_APPEND(query_task_list_head_g, new_task);
     }
 
@@ -8756,7 +8758,7 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
     new_task->manager           = query_xfer->manager;
     new_task->query             = query;
     new_task->n_unique_obj      = query_xfer->n_unique_obj;
-    new_task->obj_ids           = (uint64_t *)calloc(query_xfer->n_unique_obj, sizeof(uint64_t));
+    new_task->obj_ids           = (uint64_t *)PDC_calloc(query_xfer->n_unique_obj, sizeof(uint64_t));
     new_task->get_op            = query_xfer->get_op;
     new_task->region_constraint = (region_list_t *)query->region_constraint;
     new_task->next_server_id    = query_xfer->next_server_id;
@@ -8783,7 +8785,7 @@ PDC_Server_recv_data_query(const struct hg_cb_info *callback_info)
 
         // Manager distributes data first
         if (pdc_server_rank_g == new_task->manager) {
-            obj_ids = (uint64_t *)calloc(query_xfer->n_unique_obj, sizeof(uint64_t));
+            obj_ids = (uint64_t *)PDC_calloc(query_xfer->n_unique_obj, sizeof(uint64_t));
             obj_idx = 0;
             PDC_Server_distribute_query_workload(new_task, query, &obj_idx, obj_ids,
                                                  PDC_RECV_REGION_DO_QUERY);
@@ -9053,7 +9055,7 @@ PDC_Server_recv_get_sel_data(const struct hg_cb_info *callback_info)
     if (pdc_server_size_g != 1) {
         if (meta->all_storage_region_distributed != 1) {
             // Storage metadata have not been distributed
-            uint64_t *obj_ids = (uint64_t *)calloc(pdc_server_size_g, sizeof(uint64_t));
+            uint64_t *obj_ids = (uint64_t *)PDC_calloc(pdc_server_size_g, sizeof(uint64_t));
             int       obj_idx = 0;
             PDC_Server_distribute_query_storage_info(task, in->obj_id, &obj_idx, obj_ids,
                                                      PDC_RECV_REGION_DO_READ);

--- a/src/server/pdc_server_region/pdc_server_region_cache.c
+++ b/src/server/pdc_server_region/pdc_server_region_cache.c
@@ -20,7 +20,7 @@
 #endif
 
 typedef struct pdc_region_cache {
-    struct pdc_region_info * region_cache_info;
+    struct pdc_region_info  *region_cache_info;
     struct pdc_region_cache *next;
 } pdc_region_cache;
 
@@ -28,9 +28,9 @@ typedef struct pdc_obj_cache {
     struct pdc_obj_cache *next;
     uint64_t              obj_id;
     int                   ndim;
-    uint64_t *            dims;
-    pdc_region_cache *    region_cache;
-    pdc_region_cache *    region_cache_end;
+    uint64_t             *dims;
+    pdc_region_cache     *region_cache;
+    pdc_region_cache     *region_cache_end;
     int                   region_cache_size;
     struct timeval        timestamp;
 } pdc_obj_cache;
@@ -156,8 +156,8 @@ extract_overlaping_region(const uint64_t *offset, const uint64_t *size, const ui
                           const uint64_t *size2, int ndim, uint64_t **offset_merged, uint64_t **size_merged)
 {
     int i;
-    *offset_merged = (uint64_t *)malloc(sizeof(uint64_t) * ndim);
-    *size_merged   = (uint64_t *)malloc(sizeof(uint64_t) * ndim);
+    *offset_merged = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim);
+    *size_merged   = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim);
     for (i = 0; i < ndim; ++i) {
         if (offset2[i] > offset[i]) {
             offset_merged[0][i] = offset2[i];
@@ -234,7 +234,7 @@ PDC_region_merge(const char *buf, const char *buf2, const uint64_t *offset, cons
 {
     int      connect_flag, i, j;
     uint64_t tmp_buf_size;
-    char *   buf_merged;
+    char    *buf_merged;
     connect_flag = -1;
     // Detect if two regions are connected. This means one dimension is fully connected and all other
     // dimensions are identical.
@@ -262,8 +262,8 @@ PDC_region_merge(const char *buf, const char *buf2, const uint64_t *offset, cons
         connect_flag = ndim - 1;
     }
     // If we reach here, then the two regions can be merged into one.
-    *offset_merged = (uint64_t *)malloc(sizeof(uint64_t) * ndim);
-    *size_merged   = (uint64_t *)malloc(sizeof(uint64_t) * ndim);
+    *offset_merged = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim);
+    *size_merged   = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim);
     for (i = 0; i < ndim; ++i) {
         if (i != connect_flag) {
             offset_merged[0][i] = offset[i];
@@ -295,7 +295,7 @@ PDC_region_merge(const char *buf, const char *buf2, const uint64_t *offset, cons
     for (i = 1; i < ndim; ++i) {
         tmp_buf_size *= size_merged[0][i];
     }
-    buf_merged      = (char *)malloc(sizeof(char) * tmp_buf_size);
+    buf_merged      = (char *)PDC_malloc(sizeof(char) * tmp_buf_size);
     *buf_merged_ptr = buf_merged;
     if (ndim == 1) {
         pdc_region_merge_buf_copy(offset, size, offset2, size2, buf, buf2, &buf_merged, unit, connect_flag);
@@ -350,9 +350,9 @@ int
 PDC_region_cache_copy(char *buf, char *buf2, const uint64_t *offset, const uint64_t *size,
                       const uint64_t *offset2, const uint64_t *size2, int ndim, size_t unit, int direction)
 {
-    char *    src, *dst;
+    char     *src, *dst;
     uint64_t  i, j;
-    uint64_t *local_offset = (uint64_t *)malloc(sizeof(uint64_t) * ndim);
+    uint64_t *local_offset = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim);
     memcpy(local_offset, offset2, sizeof(uint64_t) * ndim);
     /* Rescale I/O request to cache region offsets. */
     for (i = 0; i < (uint64_t)ndim; ++i) {
@@ -420,7 +420,7 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
                           size_t buf_size, const uint64_t *offset, const uint64_t *size, int ndim,
                           size_t unit)
 {
-    pdc_obj_cache *         obj_cache_iter, *obj_cache = NULL;
+    pdc_obj_cache          *obj_cache_iter, *obj_cache = NULL;
     struct pdc_region_info *region_cache_info;
     if (obj_ndim != ndim && obj_ndim > 0) {
         LOG_INFO("reports obj_ndim != ndim, %d != %d\n", obj_ndim, ndim);
@@ -446,7 +446,7 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
 
     if (obj_cache == NULL) {
         if (obj_cache_list != NULL) {
-            obj_cache_list_end->next = (pdc_obj_cache *)malloc(sizeof(pdc_obj_cache));
+            obj_cache_list_end->next = (pdc_obj_cache *)PDC_malloc(sizeof(pdc_obj_cache));
             obj_cache_list_end       = obj_cache_list_end->next;
             obj_cache_list_end->next = NULL;
 
@@ -456,7 +456,7 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
             obj_cache_list_end->region_cache_end  = NULL;
         }
         else {
-            obj_cache_list     = (pdc_obj_cache *)malloc(sizeof(pdc_obj_cache));
+            obj_cache_list     = (pdc_obj_cache *)PDC_malloc(sizeof(pdc_obj_cache));
             obj_cache_list_end = obj_cache_list;
 
             obj_cache_list_end->obj_id            = obj_id;
@@ -467,31 +467,31 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
         }
         obj_cache_list_end->ndim = obj_ndim;
         if (obj_ndim) {
-            obj_cache_list_end->dims = (uint64_t *)malloc(sizeof(uint64_t) * obj_ndim);
+            obj_cache_list_end->dims = (uint64_t *)PDC_malloc(sizeof(uint64_t) * obj_ndim);
             memcpy(obj_cache_list_end->dims, obj_dims, sizeof(uint64_t) * obj_ndim);
         }
         obj_cache = obj_cache_list_end;
     }
 
     if (obj_cache->region_cache == NULL) {
-        obj_cache->region_cache           = (pdc_region_cache *)malloc(sizeof(pdc_region_cache));
+        obj_cache->region_cache           = (pdc_region_cache *)PDC_malloc(sizeof(pdc_region_cache));
         obj_cache->region_cache_end       = obj_cache->region_cache;
         obj_cache->region_cache_end->next = NULL;
     }
     else {
-        obj_cache->region_cache_end->next = (pdc_region_cache *)malloc(sizeof(pdc_region_cache));
+        obj_cache->region_cache_end->next = (pdc_region_cache *)PDC_malloc(sizeof(pdc_region_cache));
         obj_cache->region_cache_end       = obj_cache->region_cache_end->next;
         obj_cache->region_cache_end->next = NULL;
     }
     obj_cache->region_cache_size++;
 
     obj_cache->region_cache_end->region_cache_info =
-        (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+        (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     region_cache_info         = obj_cache->region_cache_end->region_cache_info;
     region_cache_info->ndim   = ndim;
-    region_cache_info->offset = (uint64_t *)malloc(sizeof(uint64_t) * ndim * 2);
+    region_cache_info->offset = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim * 2);
     region_cache_info->size   = region_cache_info->offset + ndim;
-    region_cache_info->buf    = (char *)malloc(sizeof(char) * buf_size);
+    region_cache_info->buf    = (char *)PDC_malloc(sizeof(char) * buf_size);
     region_cache_info->unit   = unit;
 
     memcpy(region_cache_info->offset, offset, sizeof(uint64_t) * ndim);
@@ -517,7 +517,7 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
 int
 PDC_region_cache_free()
 {
-    pdc_obj_cache *   obj_cache_iter, *obj_temp;
+    pdc_obj_cache    *obj_cache_iter, *obj_temp;
     pdc_region_cache *region_cache_iter, *region_temp;
     obj_cache_iter = obj_cache_list;
     while (obj_cache_iter != NULL) {
@@ -541,9 +541,9 @@ PDC_transfer_request_data_write_out(uint64_t obj_id, int obj_ndim, const uint64_
 {
     // flag indicates whether the input region is fully contained in another cached region.
     int               flag;
-    pdc_obj_cache *   obj_cache, *obj_cache_iter;
+    pdc_obj_cache    *obj_cache, *obj_cache_iter;
     pdc_region_cache *region_cache_iter;
-    uint64_t *        overlap_offset, *overlap_size;
+    uint64_t         *overlap_offset, *overlap_size;
     perr_t            ret_value = SUCCEED;
     char              cur_time[64];
 
@@ -643,7 +643,7 @@ merge_requests(uint64_t *start, uint64_t *end, int request_size, char **buf, uin
 {
     int      i, index;
     int      merged_requests = 1;
-    char *   ptr;
+    char    *ptr;
     size_t   total_data_size = end[0] - start[0];
     uint64_t prev_end        = end[0];
     for (i = 1; i < request_size; ++i) {
@@ -659,15 +659,15 @@ merge_requests(uint64_t *start, uint64_t *end, int request_size, char **buf, uin
             }
         }
     }
-    *new_start = (uint64_t *)malloc(sizeof(uint64_t) * merged_requests * 2);
+    *new_start = (uint64_t *)PDC_malloc(sizeof(uint64_t) * merged_requests * 2);
     *new_end   = new_start[0] + merged_requests;
 
     index           = 0;
     new_start[0][0] = start[0];
     new_end[0][0]   = end[0];
 
-    *new_buf      = (char **)malloc(merged_requests * sizeof(char *));
-    new_buf[0][0] = (char *)malloc(total_data_size * unit);
+    *new_buf      = (char **)PDC_malloc(merged_requests * sizeof(char *));
+    new_buf[0][0] = (char *)PDC_malloc(total_data_size * unit);
     ptr           = new_buf[0][0];
     memcpy(ptr, buf[0], (end[0] - start[0]) * unit);
     ptr += (end[0] - start[0]) * unit;
@@ -707,16 +707,15 @@ sort_by_offset(const void *elem1, const void *elem2)
     return 0;
 #pragma GCC diagnostic pop
 }
-
 int
 PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int flag)
 {
     int                      i, nflush = 0;
-    pdc_region_cache *       region_cache_iter, *region_cache_temp;
-    struct pdc_region_info * region_cache_info;
+    pdc_region_cache        *region_cache_iter, *region_cache_temp;
+    struct pdc_region_info  *region_cache_info;
     uint64_t                 write_size = 0;
-    char **                  buf, **new_buf, *buf_ptr = NULL, *env_char;
-    uint64_t *               start, *end, *new_start, *new_end;
+    char                   **buf, **new_buf, *buf_ptr = NULL, *env_char;
+    uint64_t                *start, *end, *new_start, *new_end;
     int                      merged_request_size = 0;
     uint64_t                 unit;
     struct pdc_region_info **obj_regions;
@@ -734,13 +733,13 @@ PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int
 
     // For 1D case, we can merge regions to minimize the number of POSIX calls.
     if (obj_cache->ndim == 1 && obj_cache->region_cache_size) {
-        start = (uint64_t *)malloc(sizeof(uint64_t) * obj_cache->region_cache_size * 2);
+        start = (uint64_t *)PDC_malloc(sizeof(uint64_t) * obj_cache->region_cache_size * 2);
         end   = start + obj_cache->region_cache_size;
-        buf   = (char **)malloc(sizeof(char *) * obj_cache->region_cache_size);
+        buf   = (char **)PDC_malloc(sizeof(char *) * obj_cache->region_cache_size);
 
         // Sort the regions based on start index
-        obj_regions       = (struct pdc_region_info **)malloc(sizeof(struct pdc_region_info *) *
-                                                        obj_cache->region_cache_size);
+        obj_regions       = (struct pdc_region_info **)PDC_malloc(sizeof(struct pdc_region_info *) *
+                                                                  obj_cache->region_cache_size);
         unit              = obj_cache->region_cache->region_cache_info->unit;
         region_cache_iter = obj_cache->region_cache;
         i                 = 0;
@@ -755,13 +754,13 @@ PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int
             end[i]   = obj_regions[i]->offset[0] + obj_regions[i]->size[0];
             buf[i]   = obj_regions[i]->buf;
         }
-        free(obj_regions);
+        obj_regions = (struct pdc_region_info **)PDC_free(obj_regions);
 
         // Merge adjacent regions
         merge_requests(start, end, obj_cache->region_cache_size, buf, &new_start, &new_end, &new_buf, unit,
                        &merged_request_size);
-        free(start);
-        free(buf);
+        start = (uint64_t *)PDC_free(start);
+        buf   = (char **)PDC_free(buf);
         // Record buffer pointer to be freed later.
         buf_ptr = new_buf[0];
         // Override the first merge_request_size number of cache regions with the merge regions
@@ -771,8 +770,8 @@ PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int
             region_cache_info            = region_cache_iter->region_cache_info;
             region_cache_info->offset[0] = new_start[i];
             region_cache_info->size[0]   = new_end[i] - new_start[i];
-            free(region_cache_info->buf);
-            region_cache_info->buf = new_buf[i];
+            region_cache_info->buf       = (void *)PDC_free(region_cache_info->buf);
+            region_cache_info->buf       = new_buf[i];
             if (i == merged_request_size - 1) {
                 region_cache_temp       = region_cache_iter->next;
                 region_cache_iter->next = NULL;
@@ -782,17 +781,17 @@ PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int
                 region_cache_iter = region_cache_iter->next;
             }
         }
-        free(new_start);
-        free(new_buf);
+        new_start = (uint64_t *)PDC_free(new_start);
+        new_buf   = (char **)PDC_free(new_buf);
         // Free other regions.
         while (region_cache_iter) {
-            region_cache_info = region_cache_iter->region_cache_info;
-            free(region_cache_info->offset);
-            free(region_cache_info->buf);
-            free(region_cache_info);
-            region_cache_temp = region_cache_iter;
-            region_cache_iter = region_cache_iter->next;
-            free(region_cache_temp);
+            region_cache_info         = region_cache_iter->region_cache_info;
+            region_cache_info->offset = (uint64_t *)PDC_free(region_cache_info->offset);
+            region_cache_info->buf    = (void *)PDC_free(region_cache_info->buf);
+            region_cache_info         = (struct pdc_region_info *)PDC_free(region_cache_info);
+            region_cache_temp         = region_cache_iter;
+            region_cache_iter         = region_cache_iter->next;
+            region_cache_temp         = (pdc_region_cache *)PDC_free(region_cache_temp);
         }
         nflush += merged_request_size;
     } // End for 1D
@@ -817,18 +816,17 @@ PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int
         }
 
         total_cache_size -= write_size;
-        free(region_cache_info->offset);
-        if (obj_cache->ndim > 1) {
-            free(region_cache_info->buf);
-        }
-        free(region_cache_info);
+        region_cache_info->offset = (uint64_t *)PDC_free(region_cache_info->offset);
+        if (obj_cache->ndim > 1)
+            region_cache_info->buf = (void *)PDC_free(region_cache_info->buf);
+        region_cache_info = (struct pdc_region_info *)PDC_free(region_cache_info);
         region_cache_temp = region_cache_iter;
         region_cache_iter = region_cache_iter->next;
-        free(region_cache_temp);
+        region_cache_temp = (pdc_region_cache *)PDC_free(region_cache_temp);
         nflush++;
     }
     if (merged_request_size && obj_cache->ndim == 1) {
-        free(buf_ptr);
+        buf_ptr = (char *)PDC_free(buf_ptr);
     }
     obj_cache->region_cache      = NULL;
     obj_cache->region_cache_size = 0;
@@ -877,21 +875,14 @@ PDC_region_cache_flush_all()
 
     obj_cache_iter = obj_cache_list;
     while (obj_cache_iter != NULL) {
-
-#ifdef TANG_DEBUG
-        char cur_time[64];
-        PDC_get_time_str(cur_time);
-        LOG_INFO("%s ==PDC_SERVER[%d]: going to flush\n", cur_time, PDC_get_rank());
-#endif
-
         PDC_region_cache_flush_by_pointer(obj_cache_iter->obj_id, obj_cache_iter, 0);
         obj_cache_temp = obj_cache_iter;
         obj_cache_iter = obj_cache_iter->next;
         if (obj_cache_temp->ndim) {
-            free(obj_cache_temp->dims);
+            obj_cache_temp->dims = (uint64_t *)PDC_free(obj_cache_temp->dims);
         }
 
-        free(obj_cache_temp);
+        obj_cache_temp = (pdc_obj_cache *)PDC_free(obj_cache_temp);
     }
     obj_cache_list = NULL;
     pthread_mutex_unlock(&pdc_obj_cache_list_mutex);
@@ -907,7 +898,7 @@ PDC_region_cache_clock_cycle(void *ptr)
     int            nflush = 0;
     double         elapsed_time;
     time_t         t;
-    struct tm *    tm;
+    struct tm     *tm;
     char           cur_time[64];
 
     if (ptr == NULL) {
@@ -1002,7 +993,7 @@ PDC_region_fetch(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dims, struct
     int            flag      = 0;
     // size_t                  j;
     pdc_region_cache *region_cache_iter;
-    uint64_t *        overlap_offset, *overlap_size;
+    uint64_t         *overlap_offset, *overlap_size;
 
     obj_cache_iter = obj_cache_list;
     while (obj_cache_iter != NULL) {
@@ -1029,7 +1020,7 @@ PDC_region_fetch(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dims, struct
                                          region_cache_iter->region_cache_info->offset,
                                          region_cache_iter->region_cache_info->size, buf, region_info->offset,
                                          region_info->size, overlap_offset, overlap_size);
-                free(overlap_offset);
+                overlap_offset = (uint64_t *)PDC_free(overlap_offset);
                 // flag = 1 at here.
                 break;
             }

--- a/src/server/pdc_server_region/pdc_server_region_cache.c
+++ b/src/server/pdc_server_region/pdc_server_region_cache.c
@@ -404,7 +404,7 @@ PDC_region_cache_copy(char *buf, char *buf2, const uint64_t *offset, const uint6
             }
         }
     }
-    free(local_offset);
+    local_offset = (uint64_t *)PDC_free(local_offset);
     return 0;
 }
 
@@ -523,14 +523,15 @@ PDC_region_cache_free()
     while (obj_cache_iter != NULL) {
         region_cache_iter = obj_cache_iter->region_cache;
         while (region_cache_iter != NULL) {
-            free(region_cache_iter->region_cache_info);
+            region_cache_iter->region_cache_info =
+                (struct pdc_region_info *)PDC_free(region_cache_iter->region_cache_info);
             region_temp       = region_cache_iter;
             region_cache_iter = region_cache_iter->next;
-            free(region_temp);
+            region_temp       = (pdc_region_cache *)PDC_free(region_temp);
         }
         obj_temp       = obj_cache_iter;
         obj_cache_iter = obj_cache_iter->next;
-        free(obj_temp);
+        obj_temp       = (pdc_obj_cache *)PDC_free(obj_temp);
     }
     return 0;
 }
@@ -595,7 +596,7 @@ PDC_transfer_request_data_write_out(uint64_t obj_id, int obj_ndim, const uint64_
                     region_info->ndim, unit, buf, region_info->offset, region_info->size,
                     region_cache_iter->region_cache_info->buf, region_cache_iter->region_cache_info->offset,
                     region_cache_iter->region_cache_info->size, overlap_offset, overlap_size);
-                free(overlap_offset);
+                overlap_offset = (uint64_t *)PDC_free(overlap_offset);
                 if (flag) {
                     break;
                 }

--- a/src/server/pdc_server_region/pdc_server_region_cache.c
+++ b/src/server/pdc_server_region/pdc_server_region_cache.c
@@ -20,7 +20,7 @@
 #endif
 
 typedef struct pdc_region_cache {
-    struct pdc_region_info  *region_cache_info;
+    struct pdc_region_info * region_cache_info;
     struct pdc_region_cache *next;
 } pdc_region_cache;
 
@@ -28,9 +28,9 @@ typedef struct pdc_obj_cache {
     struct pdc_obj_cache *next;
     uint64_t              obj_id;
     int                   ndim;
-    uint64_t             *dims;
-    pdc_region_cache     *region_cache;
-    pdc_region_cache     *region_cache_end;
+    uint64_t *            dims;
+    pdc_region_cache *    region_cache;
+    pdc_region_cache *    region_cache_end;
     int                   region_cache_size;
     struct timeval        timestamp;
 } pdc_obj_cache;
@@ -234,7 +234,7 @@ PDC_region_merge(const char *buf, const char *buf2, const uint64_t *offset, cons
 {
     int      connect_flag, i, j;
     uint64_t tmp_buf_size;
-    char    *buf_merged;
+    char *   buf_merged;
     connect_flag = -1;
     // Detect if two regions are connected. This means one dimension is fully connected and all other
     // dimensions are identical.
@@ -350,7 +350,7 @@ int
 PDC_region_cache_copy(char *buf, char *buf2, const uint64_t *offset, const uint64_t *size,
                       const uint64_t *offset2, const uint64_t *size2, int ndim, size_t unit, int direction)
 {
-    char     *src, *dst;
+    char *    src, *dst;
     uint64_t  i, j;
     uint64_t *local_offset = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim);
     memcpy(local_offset, offset2, sizeof(uint64_t) * ndim);
@@ -420,7 +420,7 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
                           size_t buf_size, const uint64_t *offset, const uint64_t *size, int ndim,
                           size_t unit)
 {
-    pdc_obj_cache          *obj_cache_iter, *obj_cache = NULL;
+    pdc_obj_cache *         obj_cache_iter, *obj_cache = NULL;
     struct pdc_region_info *region_cache_info;
     if (obj_ndim != ndim && obj_ndim > 0) {
         LOG_INFO("reports obj_ndim != ndim, %d != %d\n", obj_ndim, ndim);
@@ -517,7 +517,7 @@ PDC_region_cache_register(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dim
 int
 PDC_region_cache_free()
 {
-    pdc_obj_cache    *obj_cache_iter, *obj_temp;
+    pdc_obj_cache *   obj_cache_iter, *obj_temp;
     pdc_region_cache *region_cache_iter, *region_temp;
     obj_cache_iter = obj_cache_list;
     while (obj_cache_iter != NULL) {
@@ -542,9 +542,9 @@ PDC_transfer_request_data_write_out(uint64_t obj_id, int obj_ndim, const uint64_
 {
     // flag indicates whether the input region is fully contained in another cached region.
     int               flag;
-    pdc_obj_cache    *obj_cache, *obj_cache_iter;
+    pdc_obj_cache *   obj_cache, *obj_cache_iter;
     pdc_region_cache *region_cache_iter;
-    uint64_t         *overlap_offset, *overlap_size;
+    uint64_t *        overlap_offset, *overlap_size;
     perr_t            ret_value = SUCCEED;
     char              cur_time[64];
 
@@ -644,7 +644,7 @@ merge_requests(uint64_t *start, uint64_t *end, int request_size, char **buf, uin
 {
     int      i, index;
     int      merged_requests = 1;
-    char    *ptr;
+    char *   ptr;
     size_t   total_data_size = end[0] - start[0];
     uint64_t prev_end        = end[0];
     for (i = 1; i < request_size; ++i) {
@@ -712,11 +712,11 @@ int
 PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int flag)
 {
     int                      i, nflush = 0;
-    pdc_region_cache        *region_cache_iter, *region_cache_temp;
-    struct pdc_region_info  *region_cache_info;
+    pdc_region_cache *       region_cache_iter, *region_cache_temp;
+    struct pdc_region_info * region_cache_info;
     uint64_t                 write_size = 0;
-    char                   **buf, **new_buf, *buf_ptr = NULL, *env_char;
-    uint64_t                *start, *end, *new_start, *new_end;
+    char **                  buf, **new_buf, *buf_ptr = NULL, *env_char;
+    uint64_t *               start, *end, *new_start, *new_end;
     int                      merged_request_size = 0;
     uint64_t                 unit;
     struct pdc_region_info **obj_regions;
@@ -740,7 +740,7 @@ PDC_region_cache_flush_by_pointer(uint64_t obj_id, pdc_obj_cache *obj_cache, int
 
         // Sort the regions based on start index
         obj_regions       = (struct pdc_region_info **)PDC_malloc(sizeof(struct pdc_region_info *) *
-                                                                  obj_cache->region_cache_size);
+                                                            obj_cache->region_cache_size);
         unit              = obj_cache->region_cache->region_cache_info->unit;
         region_cache_iter = obj_cache->region_cache;
         i                 = 0;
@@ -899,7 +899,7 @@ PDC_region_cache_clock_cycle(void *ptr)
     int            nflush = 0;
     double         elapsed_time;
     time_t         t;
-    struct tm     *tm;
+    struct tm *    tm;
     char           cur_time[64];
 
     if (ptr == NULL) {
@@ -994,7 +994,7 @@ PDC_region_fetch(uint64_t obj_id, int obj_ndim, const uint64_t *obj_dims, struct
     int            flag      = 0;
     // size_t                  j;
     pdc_region_cache *region_cache_iter;
-    uint64_t         *overlap_offset, *overlap_size;
+    uint64_t *        overlap_offset, *overlap_size;
 
     obj_cache_iter = obj_cache_list;
     while (obj_cache_iter != NULL) {

--- a/src/server/pdc_server_region/pdc_server_region_request_handler.h
+++ b/src/server/pdc_server_region/pdc_server_region_request_handler.h
@@ -38,14 +38,14 @@ hg_return_t
 transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)
 {
     struct transfer_request_all_local_bulk_args2 *local_bulk_args2;
-    struct transfer_request_all_local_bulk_args  *local_bulk_args = info->arg;
-    const struct hg_info                         *handle_info;
+    struct transfer_request_all_local_bulk_args * local_bulk_args = info->arg;
+    const struct hg_info *                        handle_info;
     transfer_request_all_data                     request_data;
     hg_return_t                                   ret = HG_SUCCESS;
-    struct pdc_region_info                       *remote_reg_info;
+    struct pdc_region_info *                      remote_reg_info;
     int                                           i, j;
     uint64_t                                      total_mem_size, mem_size;
-    char                                         *ptr;
+    char *                                        ptr;
 
     FUNC_ENTER(NULL);
 
@@ -164,7 +164,7 @@ transfer_request_all_bulk_transfer_write_cb(const struct hg_cb_info *info)
     struct transfer_request_all_local_bulk_args *local_bulk_args = info->arg;
     transfer_request_all_data                    request_data;
     hg_return_t                                  ret = HG_SUCCESS;
-    struct pdc_region_info                      *remote_reg_info;
+    struct pdc_region_info *                     remote_reg_info;
     int                                          i;
     char                                         cur_time[64];
 
@@ -278,8 +278,8 @@ transfer_request_wait_all_bulk_transfer_cb(const struct hg_cb_info *info)
     pdcid_t               transfer_request_id;
     hg_return_t           ret = HG_SUCCESS;
     int                   i, fast_return;
-    char                 *ptr;
-    int                  *handle_ref;
+    char *                ptr;
+    int *                 handle_ref;
     pdc_transfer_status_t status;
 
     FUNC_ENTER(NULL);
@@ -333,7 +333,7 @@ transfer_request_bulk_transfer_write_cb(const struct hg_cb_info *info)
 {
     struct transfer_request_local_bulk_args *local_bulk_args = info->arg;
     hg_return_t                              ret             = HG_SUCCESS;
-    struct pdc_region_info                  *remote_reg_info;
+    struct pdc_region_info *                 remote_reg_info;
     uint64_t                                 obj_dims[3];
 
     FUNC_ENTER(NULL);
@@ -460,7 +460,7 @@ HG_TEST_RPC_CB(transfer_request_wait, handle)
     transfer_request_wait_out_t out;
     pdc_transfer_status_t       status;
     int                         fast_return = 0;
-    int                        *handle_ref;
+    int *                       handle_ref;
 
     FUNC_ENTER(NULL);
 #ifdef PDC_TIMING
@@ -509,7 +509,7 @@ HG_TEST_RPC_CB(transfer_request_wait, handle)
 HG_TEST_RPC_CB(transfer_request_wait_all, handle)
 {
     struct transfer_request_wait_all_local_bulk_args *local_bulk_args;
-    const struct hg_info                             *info;
+    const struct hg_info *                            info;
     transfer_request_wait_all_in_t                    in;
     hg_return_t                                       ret_value = HG_SUCCESS;
     FUNC_ENTER(NULL);
@@ -546,7 +546,7 @@ HG_TEST_RPC_CB(transfer_request_wait_all, handle)
 HG_TEST_RPC_CB(transfer_request_all, handle)
 {
     struct transfer_request_all_local_bulk_args *local_bulk_args;
-    const struct hg_info                        *info;
+    const struct hg_info *                       info;
     transfer_request_all_in_t                    in;
     transfer_request_all_out_t                   out;
     hg_return_t                                  ret_value = HG_SUCCESS;
@@ -679,7 +679,7 @@ transfer_request_metadata_query_bulk_transfer_cb(const struct hg_cb_info *info)
 HG_TEST_RPC_CB(transfer_request_metadata_query, handle)
 {
     struct transfer_request_metadata_query_local_bulk_args *local_bulk_args;
-    const struct hg_info                                   *info;
+    const struct hg_info *                                  info;
     transfer_request_metadata_query_in_t                    in;
 
     hg_return_t ret_value = HG_SUCCESS;
@@ -734,7 +734,7 @@ transfer_request_metadata_query2_bulk_transfer_cb(const struct hg_cb_info *info)
 HG_TEST_RPC_CB(transfer_request_metadata_query2, handle)
 {
     struct transfer_request_metadata_query2_local_bulk_args *local_bulk_args;
-    const struct hg_info                                    *info;
+    const struct hg_info *                                   info;
     transfer_request_metadata_query2_in_t                    in;
 
     hg_return_t ret_value = HG_SUCCESS;
@@ -778,8 +778,8 @@ HG_TEST_RPC_CB(transfer_request, handle)
     transfer_request_out_t                   out;
     struct transfer_request_local_bulk_args *local_bulk_args;
     size_t                                   total_mem_size;
-    const struct hg_info                    *info;
-    struct pdc_region_info                  *remote_reg_info;
+    const struct hg_info *                   info;
+    struct pdc_region_info *                 remote_reg_info;
     uint64_t                                 obj_dims[3];
 
     FUNC_ENTER(NULL);

--- a/src/server/pdc_server_region/pdc_server_region_request_handler.h
+++ b/src/server/pdc_server_region/pdc_server_region_request_handler.h
@@ -286,7 +286,7 @@ transfer_request_wait_all_bulk_transfer_cb(const struct hg_cb_info *info)
 
     // free is in PDC_finish_request
     fast_return = 1;
-    handle_ref  = (int *)calloc(1, sizeof(int));
+    handle_ref  = (int *)PDC_calloc(1, sizeof(int));
     pthread_mutex_lock(&transfer_request_status_mutex);
     ptr = local_bulk_args->data_buf;
     for (i = 0; i < local_bulk_args->in.n_objs; ++i) {
@@ -471,7 +471,7 @@ HG_TEST_RPC_CB(transfer_request_wait, handle)
     pthread_mutex_lock(&transfer_request_status_mutex);
     status = PDC_check_request(in.transfer_request_id);
     if (status == PDC_TRANSFER_STATUS_PENDING) {
-        handle_ref = (int *)calloc(1, sizeof(int));
+        handle_ref = (int *)PDC_calloc(1, sizeof(int));
         PDC_try_finish_request(in.transfer_request_id, handle, handle_ref, 0);
     }
     else {

--- a/src/server/pdc_server_region/pdc_server_region_request_handler.h
+++ b/src/server/pdc_server_region/pdc_server_region_request_handler.h
@@ -17,11 +17,11 @@ transfer_request_all_bulk_transfer_read_cb2(const struct hg_cb_info *info)
     }
     pthread_mutex_unlock(&transfer_request_status_mutex);
     clean_write_bulk_data(&(local_bulk_args2->request_data));
-    free(local_bulk_args2->data_buf);
-    free(local_bulk_args2->transfer_request_id);
+    local_bulk_args2->data_buf            = (void *)PDC_free(local_bulk_args2->data_buf);
+    local_bulk_args2->transfer_request_id = (uint64_t *)PDC_free(local_bulk_args2->transfer_request_id);
     HG_Bulk_free(local_bulk_args2->bulk_handle);
     HG_Destroy(local_bulk_args2->handle);
-    free(local_bulk_args2);
+    local_bulk_args2 = (struct transfer_request_all_local_bulk_args2 *)PDC_free(local_bulk_args2);
 
 #ifdef PDC_TIMING
     // transfer_request_inner_read_all_bulk is purely for transferring read data from server to client.
@@ -38,14 +38,14 @@ hg_return_t
 transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)
 {
     struct transfer_request_all_local_bulk_args2 *local_bulk_args2;
-    struct transfer_request_all_local_bulk_args * local_bulk_args = info->arg;
-    const struct hg_info *                        handle_info;
+    struct transfer_request_all_local_bulk_args  *local_bulk_args = info->arg;
+    const struct hg_info                         *handle_info;
     transfer_request_all_data                     request_data;
     hg_return_t                                   ret = HG_SUCCESS;
-    struct pdc_region_info *                      remote_reg_info;
+    struct pdc_region_info                       *remote_reg_info;
     int                                           i, j;
     uint64_t                                      total_mem_size, mem_size;
-    char *                                        ptr;
+    char                                         *ptr;
 
     FUNC_ENTER(NULL);
 
@@ -58,7 +58,7 @@ transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)
     parse_bulk_data(local_bulk_args->data_buf, &request_data, PDC_READ);
     // print_bulk_data(&request_data);
 
-    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     total_mem_size  = 0;
     for (i = 0; i < request_data.n_objs; ++i) {
         mem_size = request_data.unit[i];
@@ -68,14 +68,14 @@ transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)
         total_mem_size += mem_size;
     }
 
-    local_bulk_args2 = (struct transfer_request_all_local_bulk_args2 *)malloc(
+    local_bulk_args2 = (struct transfer_request_all_local_bulk_args2 *)PDC_malloc(
         sizeof(struct transfer_request_all_local_bulk_args2));
-    local_bulk_args2->data_buf = (char *)malloc(total_mem_size);
+    local_bulk_args2->data_buf = (char *)PDC_malloc(total_mem_size);
     ptr                        = local_bulk_args2->data_buf;
 
 #ifndef PDC_SERVER_CACHE
     data_server_region_t **temp_ptrs =
-        (data_server_region_t **)malloc(sizeof(data_server_region_t *) * request_data.n_objs);
+        (data_server_region_t **)PDC_malloc(sizeof(data_server_region_t *) * request_data.n_objs);
     for (i = 0; i < request_data.n_objs; ++i) {
         temp_ptrs[i] = PDC_Server_get_obj_region(request_data.obj_id[i]);
         PDC_Server_register_obj_region_by_pointer(temp_ptrs + i, request_data.obj_id[i], 1);
@@ -113,7 +113,7 @@ transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)
     for (i = 0; i < request_data.n_objs; ++i) {
         PDC_Server_unregister_obj_region_by_pointer(temp_ptrs[i], 1);
     }
-    free(temp_ptrs);
+    temp_ptrs = (data_server_region_t **)PDC_free(temp_ptrs);
 #endif
 
 #ifdef PDC_TIMING
@@ -146,14 +146,14 @@ transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)
         LOG_ERROR("Error at transfer_request_all_bulk_transfer_read_cb(const struct hg_cb_info *info)");
     }
     // pointers in request_data are freed in the next call back function
-    free(local_bulk_args->data_buf);
-    free(remote_reg_info);
+    local_bulk_args->data_buf = (void *)PDC_free(local_bulk_args->data_buf);
+    remote_reg_info           = (struct pdc_region_info *)PDC_free(remote_reg_info);
 
     HG_Bulk_free(local_bulk_args->bulk_handle);
 
     HG_Free_input(local_bulk_args->handle, &(local_bulk_args->in));
 
-    free(local_bulk_args);
+    local_bulk_args = (struct transfer_request_all_local_bulk_args *)PDC_free(local_bulk_args);
 
     FUNC_LEAVE(ret);
 }
@@ -164,7 +164,7 @@ transfer_request_all_bulk_transfer_write_cb(const struct hg_cb_info *info)
     struct transfer_request_all_local_bulk_args *local_bulk_args = info->arg;
     transfer_request_all_data                    request_data;
     hg_return_t                                  ret = HG_SUCCESS;
-    struct pdc_region_info *                     remote_reg_info;
+    struct pdc_region_info                      *remote_reg_info;
     int                                          i;
     char                                         cur_time[64];
 
@@ -185,14 +185,14 @@ transfer_request_all_bulk_transfer_write_cb(const struct hg_cb_info *info)
     start = MPI_Wtime();
 #endif
 
-    remote_reg_info     = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info     = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
     request_data.n_objs = local_bulk_args->in.n_objs;
     parse_bulk_data(local_bulk_args->data_buf, &request_data, PDC_WRITE);
     // print_bulk_data(&request_data);
 
 #ifndef PDC_SERVER_CACHE
     data_server_region_t **temp_ptrs =
-        (data_server_region_t **)malloc(sizeof(data_server_region_t *) * request_data.n_objs);
+        (data_server_region_t **)PDC_malloc(sizeof(data_server_region_t *) * request_data.n_objs);
     for (i = 0; i < request_data.n_objs; ++i) {
         temp_ptrs[i] = PDC_Server_get_obj_region(request_data.obj_id[i]);
         PDC_Server_register_obj_region_by_pointer(temp_ptrs + i, request_data.obj_id[i], 1);
@@ -240,20 +240,20 @@ transfer_request_all_bulk_transfer_write_cb(const struct hg_cb_info *info)
     for (i = 0; i < request_data.n_objs; ++i) {
         PDC_Server_unregister_obj_region_by_pointer(temp_ptrs[i], 1);
     }
-    free(temp_ptrs);
+    temp_ptrs = (data_server_region_t **)PDC_free(temp_ptrs);
 #endif
 
     clean_write_bulk_data(&request_data);
-    free(local_bulk_args->transfer_request_id);
-    free(local_bulk_args->data_buf);
-    free(remote_reg_info);
+    local_bulk_args->transfer_request_id = (uint64_t *)PDC_free(local_bulk_args->transfer_request_id);
+    local_bulk_args->data_buf            = (void *)PDC_free(local_bulk_args->data_buf);
+    remote_reg_info                      = (struct pdc_region_info *)PDC_free(remote_reg_info);
 
     HG_Bulk_free(local_bulk_args->bulk_handle);
 
     HG_Free_input(local_bulk_args->handle, &(local_bulk_args->in));
     HG_Destroy(local_bulk_args->handle);
 
-    free(local_bulk_args);
+    local_bulk_args = (struct transfer_request_all_local_bulk_args *)PDC_free(local_bulk_args);
 
 #ifdef PDC_TIMING
     end = MPI_Wtime();
@@ -278,8 +278,8 @@ transfer_request_wait_all_bulk_transfer_cb(const struct hg_cb_info *info)
     pdcid_t               transfer_request_id;
     hg_return_t           ret = HG_SUCCESS;
     int                   i, fast_return;
-    char *                ptr;
-    int *                 handle_ref;
+    char                 *ptr;
+    int                  *handle_ref;
     pdc_transfer_status_t status;
 
     FUNC_ENTER(NULL);
@@ -302,9 +302,9 @@ transfer_request_wait_all_bulk_transfer_cb(const struct hg_cb_info *info)
     }
     pthread_mutex_unlock(&transfer_request_status_mutex);
     if (fast_return) {
-        free(handle_ref);
-        out.ret = 1;
-        ret     = HG_Respond(local_bulk_args->handle, NULL, NULL, &out);
+        handle_ref = (int *)PDC_free(handle_ref);
+        out.ret    = 1;
+        ret        = HG_Respond(local_bulk_args->handle, NULL, NULL, &out);
         HG_Free_input(local_bulk_args->handle, &(local_bulk_args->in));
         HG_Destroy(local_bulk_args->handle);
     }
@@ -312,11 +312,11 @@ transfer_request_wait_all_bulk_transfer_cb(const struct hg_cb_info *info)
         HG_Free_input(local_bulk_args->handle, &(local_bulk_args->in));
     }
 
-    free(local_bulk_args->data_buf);
+    local_bulk_args->data_buf = (void *)PDC_free(local_bulk_args->data_buf);
 
     HG_Bulk_free(local_bulk_args->bulk_handle);
 
-    free(local_bulk_args);
+    local_bulk_args = (struct transfer_request_wait_all_local_bulk_args *)PDC_free(local_bulk_args);
 
 #ifdef PDC_TIMING
     double end = MPI_Wtime();
@@ -333,7 +333,7 @@ transfer_request_bulk_transfer_write_cb(const struct hg_cb_info *info)
 {
     struct transfer_request_local_bulk_args *local_bulk_args = info->arg;
     hg_return_t                              ret             = HG_SUCCESS;
-    struct pdc_region_info *                 remote_reg_info;
+    struct pdc_region_info                  *remote_reg_info;
     uint64_t                                 obj_dims[3];
 
     FUNC_ENTER(NULL);
@@ -354,11 +354,11 @@ transfer_request_bulk_transfer_write_cb(const struct hg_cb_info *info)
     start = MPI_Wtime();
 #endif
 
-    remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+    remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
 
     remote_reg_info->ndim   = (local_bulk_args->in.remote_region).ndim;
-    remote_reg_info->offset = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
-    remote_reg_info->size   = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
+    remote_reg_info->offset = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
+    remote_reg_info->size   = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
 
     PDC_copy_region_desc((local_bulk_args->in).remote_region.start, remote_reg_info->offset,
                          remote_reg_info->ndim, remote_reg_info->ndim);
@@ -382,8 +382,8 @@ transfer_request_bulk_transfer_write_cb(const struct hg_cb_info *info)
     pthread_mutex_lock(&transfer_request_status_mutex);
     PDC_finish_request(local_bulk_args->transfer_request_id);
     pthread_mutex_unlock(&transfer_request_status_mutex);
-    free(local_bulk_args->data_buf);
-    free(remote_reg_info);
+    local_bulk_args->data_buf = (void *)PDC_free(local_bulk_args->data_buf);
+    remote_reg_info           = (struct pdc_region_info *)PDC_free(remote_reg_info);
 
     HG_Bulk_free(local_bulk_args->bulk_handle);
 
@@ -460,7 +460,7 @@ HG_TEST_RPC_CB(transfer_request_wait, handle)
     transfer_request_wait_out_t out;
     pdc_transfer_status_t       status;
     int                         fast_return = 0;
-    int *                       handle_ref;
+    int                        *handle_ref;
 
     FUNC_ENTER(NULL);
 #ifdef PDC_TIMING
@@ -509,7 +509,7 @@ HG_TEST_RPC_CB(transfer_request_wait, handle)
 HG_TEST_RPC_CB(transfer_request_wait_all, handle)
 {
     struct transfer_request_wait_all_local_bulk_args *local_bulk_args;
-    const struct hg_info *                            info;
+    const struct hg_info                             *info;
     transfer_request_wait_all_in_t                    in;
     hg_return_t                                       ret_value = HG_SUCCESS;
     FUNC_ENTER(NULL);
@@ -517,11 +517,11 @@ HG_TEST_RPC_CB(transfer_request_wait_all, handle)
 
     info = HG_Get_info(handle);
 
-    local_bulk_args = (struct transfer_request_wait_all_local_bulk_args *)malloc(
+    local_bulk_args = (struct transfer_request_wait_all_local_bulk_args *)PDC_malloc(
         sizeof(struct transfer_request_wait_all_local_bulk_args));
 
     local_bulk_args->handle   = handle;
-    local_bulk_args->data_buf = malloc(in.total_buf_size);
+    local_bulk_args->data_buf = PDC_malloc(in.total_buf_size);
     local_bulk_args->in       = in;
 
 #ifdef PDC_TIMING
@@ -546,7 +546,7 @@ HG_TEST_RPC_CB(transfer_request_wait_all, handle)
 HG_TEST_RPC_CB(transfer_request_all, handle)
 {
     struct transfer_request_all_local_bulk_args *local_bulk_args;
-    const struct hg_info *                       info;
+    const struct hg_info                        *info;
     transfer_request_all_in_t                    in;
     transfer_request_all_out_t                   out;
     hg_return_t                                  ret_value = HG_SUCCESS;
@@ -569,14 +569,14 @@ HG_TEST_RPC_CB(transfer_request_all, handle)
     gettimeofday(&last_cache_activity_timeval_g, NULL);
 
     info            = HG_Get_info(handle);
-    local_bulk_args = (struct transfer_request_all_local_bulk_args *)malloc(
+    local_bulk_args = (struct transfer_request_all_local_bulk_args *)PDC_malloc(
         sizeof(struct transfer_request_all_local_bulk_args));
 
     // Read will return to client in the first call back (after metadata for region request is received)
     local_bulk_args->handle              = handle;
-    local_bulk_args->data_buf            = malloc(in.total_buf_size);
+    local_bulk_args->data_buf            = PDC_malloc(in.total_buf_size);
     local_bulk_args->in                  = in;
-    local_bulk_args->transfer_request_id = (uint64_t *)malloc(sizeof(uint64_t) * in.n_objs);
+    local_bulk_args->transfer_request_id = (uint64_t *)PDC_malloc(sizeof(uint64_t) * in.n_objs);
 
     // [Tang]TODO is this necessary?
     /* pthread_mutex_lock(&transfer_request_id_mutex); */
@@ -665,9 +665,9 @@ transfer_request_metadata_query_bulk_transfer_cb(const struct hg_cb_info *info)
     out.query_id =
         transfer_request_metadata_query_parse(local_bulk_args->in.n_objs, (char *)local_bulk_args->data_buf,
                                               local_bulk_args->in.is_write, &(out.total_buf_size));
-    free(local_bulk_args->data_buf);
-    out.ret = 1;
-    ret     = HG_Respond(local_bulk_args->handle, NULL, NULL, &out);
+    local_bulk_args->data_buf = (void *)PDC_free(local_bulk_args->data_buf);
+    out.ret                   = 1;
+    ret                       = HG_Respond(local_bulk_args->handle, NULL, NULL, &out);
     HG_Bulk_free(local_bulk_args->bulk_handle);
     HG_Destroy(local_bulk_args->handle);
     FUNC_LEAVE(ret);
@@ -679,7 +679,7 @@ transfer_request_metadata_query_bulk_transfer_cb(const struct hg_cb_info *info)
 HG_TEST_RPC_CB(transfer_request_metadata_query, handle)
 {
     struct transfer_request_metadata_query_local_bulk_args *local_bulk_args;
-    const struct hg_info *                                  info;
+    const struct hg_info                                   *info;
     transfer_request_metadata_query_in_t                    in;
 
     hg_return_t ret_value = HG_SUCCESS;
@@ -687,10 +687,10 @@ HG_TEST_RPC_CB(transfer_request_metadata_query, handle)
     FUNC_ENTER(NULL);
     HG_Get_input(handle, &in);
     info            = HG_Get_info(handle);
-    local_bulk_args = (struct transfer_request_metadata_query_local_bulk_args *)malloc(
+    local_bulk_args = (struct transfer_request_metadata_query_local_bulk_args *)PDC_malloc(
         sizeof(struct transfer_request_metadata_query_local_bulk_args));
 
-    local_bulk_args->data_buf = malloc(in.total_buf_size);
+    local_bulk_args->data_buf = PDC_malloc(in.total_buf_size);
     local_bulk_args->in       = in;
     local_bulk_args->handle   = handle;
     ret_value = HG_Bulk_create(info->hg_class, 1, &(local_bulk_args->data_buf), &(in.total_buf_size),
@@ -720,9 +720,9 @@ transfer_request_metadata_query2_bulk_transfer_cb(const struct hg_cb_info *info)
 
     FUNC_ENTER(NULL);
 
-    out.ret = 1;
-    free(local_bulk_args->data_buf);
-    ret = HG_Respond(local_bulk_args->handle, NULL, NULL, &out);
+    out.ret                   = 1;
+    local_bulk_args->data_buf = (void *)PDC_free(local_bulk_args->data_buf);
+    ret                       = HG_Respond(local_bulk_args->handle, NULL, NULL, &out);
     HG_Bulk_free(local_bulk_args->bulk_handle);
     HG_Destroy(local_bulk_args->handle);
     FUNC_LEAVE(ret);
@@ -734,7 +734,7 @@ transfer_request_metadata_query2_bulk_transfer_cb(const struct hg_cb_info *info)
 HG_TEST_RPC_CB(transfer_request_metadata_query2, handle)
 {
     struct transfer_request_metadata_query2_local_bulk_args *local_bulk_args;
-    const struct hg_info *                                   info;
+    const struct hg_info                                    *info;
     transfer_request_metadata_query2_in_t                    in;
 
     hg_return_t ret_value = HG_SUCCESS;
@@ -743,7 +743,7 @@ HG_TEST_RPC_CB(transfer_request_metadata_query2, handle)
     HG_Get_input(handle, &in);
 
     info            = HG_Get_info(handle);
-    local_bulk_args = (struct transfer_request_metadata_query2_local_bulk_args *)malloc(
+    local_bulk_args = (struct transfer_request_metadata_query2_local_bulk_args *)PDC_malloc(
         sizeof(struct transfer_request_metadata_query2_local_bulk_args));
 
     local_bulk_args->handle = handle;
@@ -778,8 +778,8 @@ HG_TEST_RPC_CB(transfer_request, handle)
     transfer_request_out_t                   out;
     struct transfer_request_local_bulk_args *local_bulk_args;
     size_t                                   total_mem_size;
-    const struct hg_info *                   info;
-    struct pdc_region_info *                 remote_reg_info;
+    const struct hg_info                    *info;
+    struct pdc_region_info                  *remote_reg_info;
     uint64_t                                 obj_dims[3];
 
     FUNC_ENTER(NULL);
@@ -804,11 +804,11 @@ HG_TEST_RPC_CB(transfer_request, handle)
     PDC_commit_request(out.metadata_id);
     pthread_mutex_unlock(&transfer_request_status_mutex);
 
-    local_bulk_args =
-        (struct transfer_request_local_bulk_args *)malloc(sizeof(struct transfer_request_local_bulk_args));
+    local_bulk_args = (struct transfer_request_local_bulk_args *)PDC_malloc(
+        sizeof(struct transfer_request_local_bulk_args));
     local_bulk_args->handle              = handle;
     local_bulk_args->total_mem_size      = total_mem_size;
-    local_bulk_args->data_buf            = malloc(total_mem_size);
+    local_bulk_args->data_buf            = PDC_malloc(total_mem_size);
     local_bulk_args->in                  = in;
     local_bulk_args->transfer_request_id = out.metadata_id;
 #ifdef PDC_TIMING
@@ -831,11 +831,11 @@ HG_TEST_RPC_CB(transfer_request, handle)
                                      local_bulk_args->bulk_handle, 0, total_mem_size, HG_OP_ID_IGNORE);
     }
     else {
-        remote_reg_info = (struct pdc_region_info *)malloc(sizeof(struct pdc_region_info));
+        remote_reg_info = (struct pdc_region_info *)PDC_malloc(sizeof(struct pdc_region_info));
 
         remote_reg_info->ndim   = (in.remote_region).ndim;
-        remote_reg_info->offset = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
-        remote_reg_info->size   = (uint64_t *)malloc(remote_reg_info->ndim * sizeof(uint64_t));
+        remote_reg_info->offset = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
+        remote_reg_info->size   = (uint64_t *)PDC_malloc(remote_reg_info->ndim * sizeof(uint64_t));
 
         PDC_copy_region_desc((in.remote_region).start, remote_reg_info->offset, remote_reg_info->ndim,
                              remote_reg_info->ndim);
@@ -863,7 +863,7 @@ HG_TEST_RPC_CB(transfer_request, handle)
         ret_value = HG_Bulk_transfer(info->context, transfer_request_bulk_transfer_read_cb, local_bulk_args,
                                      HG_BULK_PUSH, info->addr, in.local_bulk_handle, 0,
                                      local_bulk_args->bulk_handle, 0, total_mem_size, HG_OP_ID_IGNORE);
-        free(remote_reg_info);
+        remote_reg_info = (struct pdc_region_info *)PDC_free(remote_reg_info);
     }
     if (ret_value != HG_SUCCESS) {
         LOG_ERROR("Error at HG_TEST_RPC_CB(transfer_request, handle)\n");

--- a/src/server/pdc_server_region/pdc_server_region_transfer.c
+++ b/src/server/pdc_server_region/pdc_server_region_transfer.c
@@ -2,6 +2,7 @@
 #include "pdc_server_data.h"
 #include "pdc_timing.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 static int io_by_region_g = 1;
 
@@ -48,7 +49,7 @@ PDC_commit_request(uint64_t transfer_request_id)
 
     if (transfer_request_status_list == NULL) {
         transfer_request_status_list =
-            (pdc_transfer_request_status *)malloc(sizeof(pdc_transfer_request_status));
+            (pdc_transfer_request_status *)PDC_malloc(sizeof(pdc_transfer_request_status));
         transfer_request_status_list->status              = PDC_TRANSFER_STATUS_PENDING;
         transfer_request_status_list->handle_ref          = NULL;
         transfer_request_status_list->out_type            = -1;
@@ -57,11 +58,11 @@ PDC_commit_request(uint64_t transfer_request_id)
         transfer_request_status_list_end                  = transfer_request_status_list;
     }
     else {
-        ptr                   = transfer_request_status_list_end;
-        ptr->next             = (pdc_transfer_request_status *)malloc(sizeof(pdc_transfer_request_status));
-        ptr->next->status     = PDC_TRANSFER_STATUS_PENDING;
-        ptr->next->handle_ref = NULL;
-        ptr->next->out_type   = -1;
+        ptr               = transfer_request_status_list_end;
+        ptr->next         = (pdc_transfer_request_status *)PDC_malloc(sizeof(pdc_transfer_request_status));
+        ptr->next->status = PDC_TRANSFER_STATUS_PENDING;
+        ptr->next->handle_ref            = NULL;
+        ptr->next->out_type              = -1;
         ptr->next->transfer_request_id   = transfer_request_id;
         ptr->next->next                  = NULL;
         transfer_request_status_list_end = ptr->next;
@@ -79,7 +80,7 @@ PDC_commit_request(uint64_t transfer_request_id)
 perr_t
 PDC_finish_request(uint64_t transfer_request_id)
 {
-    pdc_transfer_request_status *   ptr, *tmp = NULL;
+    pdc_transfer_request_status    *ptr, *tmp = NULL;
     perr_t                          ret_value = SUCCEED;
     transfer_request_wait_out_t     out;
     transfer_request_wait_all_out_t out_all;
@@ -108,7 +109,7 @@ PDC_finish_request(uint64_t transfer_request_id)
                         ret_value = HG_Respond(ptr->handle, NULL, NULL, &out);
                     }
                     HG_Destroy(ptr->handle);
-                    free(ptr->handle_ref);
+                    ptr->handle_ref = (int *)PDC_free(ptr->handle_ref);
                 }
                 if (tmp != NULL) {
                     /* Case for removing the any nodes but the first one. */
@@ -117,13 +118,13 @@ PDC_finish_request(uint64_t transfer_request_id)
                     if (ptr->next == NULL) {
                         transfer_request_status_list_end = tmp;
                     }
-                    free(ptr);
+                    ptr = (pdc_transfer_request_status *)PDC_free(ptr);
                 }
                 else {
                     /* Case for removing the first node, i.e ptr == transfer_request_status_list*/
                     tmp                          = transfer_request_status_list;
                     transfer_request_status_list = transfer_request_status_list->next;
-                    free(tmp);
+                    tmp                          = (pdc_transfer_request_status *)PDC_free(tmp);
                     /* Free pointer is the last list node, so nothing is left in the list. */
                     if (transfer_request_status_list == NULL) {
                         transfer_request_status_list_end = NULL;
@@ -169,13 +170,13 @@ PDC_check_request(uint64_t transfer_request_id)
                     if (ptr->next == NULL) {
                         transfer_request_status_list_end = tmp;
                     }
-                    free(ptr);
+                    ptr = (pdc_transfer_request_status *)PDC_free(ptr);
                 }
                 else {
                     /* Case for removing the first node, i.e ptr == transfer_request_status_list*/
                     tmp                          = transfer_request_status_list;
                     transfer_request_status_list = transfer_request_status_list->next;
-                    free(tmp);
+                    tmp                          = (pdc_transfer_request_status *)PDC_free(tmp);
                     /* Free pointer is the last list node, so nothing is left in the list. */
                     if (transfer_request_status_list == NULL) {
                         transfer_request_status_list_end = NULL;
@@ -264,8 +265,8 @@ PDC_Server_transfer_request_io(uint64_t obj_id, int obj_ndim, const uint64_t *ob
 {
     perr_t   ret_value = SUCCEED;
     int      fd;
-    char *   data_path                = NULL;
-    char *   user_specified_data_path = NULL;
+    char    *data_path                = NULL;
+    char    *user_specified_data_path = NULL;
     char     storage_location[ADDR_MAX];
     ssize_t  io_size;
     uint64_t i, j;
@@ -381,31 +382,31 @@ done:
 int
 clean_write_bulk_data(transfer_request_all_data *request_data)
 {
-    free(request_data->obj_id);
-    free(request_data->obj_ndim);
-    free(request_data->remote_ndim);
-    free(request_data->remote_offset);
-    free(request_data->unit);
-    free(request_data->data_buf);
+    request_data->obj_id        = (pdcid_t *)PDC_free(request_data->obj_id);
+    request_data->obj_ndim      = (int *)PDC_free(request_data->obj_ndim);
+    request_data->remote_ndim   = (int *)PDC_free(request_data->remote_ndim);
+    request_data->remote_offset = (uint64_t **)PDC_free(request_data->remote_offset);
+    request_data->unit          = (size_t *)PDC_free(request_data->unit);
+    request_data->data_buf      = (char **)PDC_free(request_data->data_buf);
     return 0;
 }
 
 int
 parse_bulk_data(void *buf, transfer_request_all_data *request_data, pdc_access_t access_type)
 {
-    char *   ptr = (char *)buf;
+    char    *ptr = (char *)buf;
     int      i, j;
     uint64_t data_size;
 
     // preallocate arrays of size number of objects
-    request_data->obj_id        = (pdcid_t *)malloc(sizeof(pdcid_t) * request_data->n_objs);
-    request_data->obj_ndim      = (int *)malloc(sizeof(int) * request_data->n_objs);
-    request_data->remote_ndim   = (int *)malloc(sizeof(int) * request_data->n_objs);
-    request_data->remote_offset = (uint64_t **)malloc(sizeof(uint64_t *) * request_data->n_objs * 3);
+    request_data->obj_id        = (pdcid_t *)PDC_malloc(sizeof(pdcid_t) * request_data->n_objs);
+    request_data->obj_ndim      = (int *)PDC_malloc(sizeof(int) * request_data->n_objs);
+    request_data->remote_ndim   = (int *)PDC_malloc(sizeof(int) * request_data->n_objs);
+    request_data->remote_offset = (uint64_t **)PDC_malloc(sizeof(uint64_t *) * request_data->n_objs * 3);
     request_data->remote_length = request_data->remote_offset + request_data->n_objs;
     request_data->obj_dims      = request_data->remote_length + request_data->n_objs;
-    request_data->unit          = (size_t *)malloc(sizeof(size_t) * request_data->n_objs);
-    request_data->data_buf      = (char **)malloc(sizeof(char *) * request_data->n_objs);
+    request_data->unit          = (size_t *)PDC_malloc(sizeof(size_t) * request_data->n_objs);
+    request_data->data_buf      = (char **)PDC_malloc(sizeof(char *) * request_data->n_objs);
 
     /*
      * The following times n_objs (one set per object).

--- a/src/server/pdc_server_region/pdc_server_region_transfer.c
+++ b/src/server/pdc_server_region/pdc_server_region_transfer.c
@@ -80,7 +80,7 @@ PDC_commit_request(uint64_t transfer_request_id)
 perr_t
 PDC_finish_request(uint64_t transfer_request_id)
 {
-    pdc_transfer_request_status    *ptr, *tmp = NULL;
+    pdc_transfer_request_status *   ptr, *tmp = NULL;
     perr_t                          ret_value = SUCCEED;
     transfer_request_wait_out_t     out;
     transfer_request_wait_all_out_t out_all;
@@ -265,8 +265,8 @@ PDC_Server_transfer_request_io(uint64_t obj_id, int obj_ndim, const uint64_t *ob
 {
     perr_t   ret_value = SUCCEED;
     int      fd;
-    char    *data_path                = NULL;
-    char    *user_specified_data_path = NULL;
+    char *   data_path                = NULL;
+    char *   user_specified_data_path = NULL;
     char     storage_location[ADDR_MAX];
     ssize_t  io_size;
     uint64_t i, j;
@@ -394,7 +394,7 @@ clean_write_bulk_data(transfer_request_all_data *request_data)
 int
 parse_bulk_data(void *buf, transfer_request_all_data *request_data, pdc_access_t access_type)
 {
-    char    *ptr = (char *)buf;
+    char *   ptr = (char *)buf;
     int      i, j;
     uint64_t data_size;
 

--- a/src/server/pdc_server_region/pdc_server_region_transfer_metadata_query.c
+++ b/src/server/pdc_server_region/pdc_server_region_transfer_metadata_query.c
@@ -4,10 +4,11 @@
 #include <string.h>
 #include "pdc_region.h"
 #include "pdc_logger.h"
+#include "pdc_malloc.h"
 
 typedef struct pdc_region_metadata_pkg {
-    uint64_t *                      reg_offset;
-    uint64_t *                      reg_size;
+    uint64_t                       *reg_offset;
+    uint64_t                       *reg_size;
     uint32_t                        data_server_id;
     struct pdc_region_metadata_pkg *next;
 } pdc_region_metadata_pkg;
@@ -15,8 +16,8 @@ typedef struct pdc_region_metadata_pkg {
 typedef struct pdc_obj_metadata_pkg {
     int                          ndim;
     uint64_t                     obj_id;
-    pdc_region_metadata_pkg *    regions;
-    pdc_region_metadata_pkg *    regions_end;
+    pdc_region_metadata_pkg     *regions;
+    pdc_region_metadata_pkg     *regions_end;
     struct pdc_obj_metadata_pkg *next;
 } pdc_obj_metadata_pkg;
 
@@ -29,13 +30,13 @@ typedef struct pdc_obj_region_metadata {
 
 typedef struct pdc_metadata_query_buf {
     uint64_t                       id;
-    char *                         buf;
+    char                          *buf;
     struct pdc_metadata_query_buf *next;
 } pdc_metadata_query_buf;
 
-static pdc_obj_metadata_pkg *  metadata_server_objs;
-static pdc_obj_metadata_pkg *  metadata_server_objs_end;
-static uint64_t *              data_server_bytes;
+static pdc_obj_metadata_pkg   *metadata_server_objs;
+static pdc_obj_metadata_pkg   *metadata_server_objs_end;
+static uint64_t               *data_server_bytes;
 static int                     pdc_server_size;
 static uint64_t                query_id_g;
 static pdc_metadata_query_buf *metadata_query_buf_head;
@@ -59,7 +60,7 @@ perr_t
 transfer_request_metadata_query_init(int pdc_server_size_input, char *checkpoint)
 {
     hg_return_t ret_value = HG_SUCCESS;
-    char *      ptr;
+    char       *ptr;
     int         n_objs, reg_count;
     int         i, j;
     FUNC_ENTER(NULL);
@@ -79,11 +80,12 @@ transfer_request_metadata_query_init(int pdc_server_size_input, char *checkpoint
         ptr += sizeof(int);
         for (i = 0; i < n_objs; ++i) {
             if (metadata_server_objs) {
-                metadata_server_objs_end->next = (pdc_obj_metadata_pkg *)malloc(sizeof(pdc_obj_metadata_pkg));
-                metadata_server_objs_end       = metadata_server_objs_end->next;
+                metadata_server_objs_end->next =
+                    (pdc_obj_metadata_pkg *)PDC_malloc(sizeof(pdc_obj_metadata_pkg));
+                metadata_server_objs_end = metadata_server_objs_end->next;
             }
             else {
-                metadata_server_objs     = (pdc_obj_metadata_pkg *)malloc(sizeof(pdc_obj_metadata_pkg));
+                metadata_server_objs     = (pdc_obj_metadata_pkg *)PDC_malloc(sizeof(pdc_obj_metadata_pkg));
                 metadata_server_objs_end = metadata_server_objs;
             }
 
@@ -95,12 +97,12 @@ transfer_request_metadata_query_init(int pdc_server_size_input, char *checkpoint
             ptr += sizeof(int);
 
             metadata_server_objs_end->regions =
-                (pdc_region_metadata_pkg *)malloc(sizeof(pdc_region_metadata_pkg));
+                (pdc_region_metadata_pkg *)PDC_malloc(sizeof(pdc_region_metadata_pkg));
             metadata_server_objs_end->regions_end = metadata_server_objs_end->regions;
 
             metadata_server_objs_end->regions_end->next = NULL;
             metadata_server_objs_end->regions_end->reg_offset =
-                (uint64_t *)malloc(sizeof(uint64_t) * metadata_server_objs_end->ndim * 2);
+                (uint64_t *)PDC_malloc(sizeof(uint64_t) * metadata_server_objs_end->ndim * 2);
             metadata_server_objs_end->regions_end->reg_size =
                 metadata_server_objs_end->regions_end->reg_offset + metadata_server_objs_end->ndim;
             metadata_server_objs_end->regions_end->data_server_id = *(uint32_t *)ptr;
@@ -111,12 +113,12 @@ transfer_request_metadata_query_init(int pdc_server_size_input, char *checkpoint
 
             for (j = 1; j < reg_count; ++j) {
                 metadata_server_objs_end->regions->next =
-                    (pdc_region_metadata_pkg *)malloc(sizeof(pdc_region_metadata_pkg));
+                    (pdc_region_metadata_pkg *)PDC_malloc(sizeof(pdc_region_metadata_pkg));
                 metadata_server_objs_end->regions_end = metadata_server_objs_end->regions_end->next;
 
                 metadata_server_objs_end->regions_end->next = NULL;
                 metadata_server_objs_end->regions_end->reg_offset =
-                    (uint64_t *)malloc(sizeof(uint64_t) * metadata_server_objs_end->ndim * 2);
+                    (uint64_t *)PDC_malloc(sizeof(uint64_t) * metadata_server_objs_end->ndim * 2);
                 metadata_server_objs_end->regions_end->reg_size =
                     metadata_server_objs_end->regions_end->reg_offset + metadata_server_objs_end->ndim;
                 metadata_server_objs_end->regions_end->data_server_id = *(uint32_t *)ptr;
@@ -139,7 +141,7 @@ perr_t
 transfer_request_metadata_query_finalize()
 {
     hg_return_t              ret_value = HG_SUCCESS;
-    pdc_obj_metadata_pkg *   obj_temp, *obj_temp2;
+    pdc_obj_metadata_pkg    *obj_temp, *obj_temp2;
     pdc_region_metadata_pkg *region_temp, *region_temp2;
     FUNC_ENTER(NULL);
 
@@ -147,14 +149,14 @@ transfer_request_metadata_query_finalize()
     while (obj_temp) {
         region_temp = obj_temp->regions;
         while (region_temp) {
-            region_temp2 = region_temp;
-            region_temp  = region_temp->next;
-            free(region_temp2->reg_offset);
-            free(region_temp2);
+            region_temp2             = region_temp;
+            region_temp              = region_temp->next;
+            region_temp2->reg_offset = (uint64_t *)PDC_free(region_temp2->reg_offset);
+            region_temp2             = (pdc_region_metadata_pkg *)PDC_free(region_temp2);
         }
         obj_temp2 = obj_temp;
         obj_temp  = obj_temp->next;
-        free(obj_temp2);
+        obj_temp2 = (pdc_obj_metadata_pkg *)PDC_free(obj_temp2);
     }
     metadata_server_objs = NULL;
 
@@ -177,9 +179,9 @@ perr_t
 transfer_request_metadata_query_checkpoint(char **checkpoint, uint64_t *checkpoint_size)
 {
     hg_return_t              ret_value = HG_SUCCESS;
-    pdc_obj_metadata_pkg *   obj_temp;
+    pdc_obj_metadata_pkg    *obj_temp;
     pdc_region_metadata_pkg *region_temp;
-    char *                   ptr;
+    char                    *ptr;
     int                      reg_count, obj_count;
     FUNC_ENTER(NULL);
     pthread_mutex_lock(&metadata_query_mutex);
@@ -201,7 +203,7 @@ transfer_request_metadata_query_checkpoint(char **checkpoint, uint64_t *checkpoi
         obj_temp = obj_temp->next;
         obj_count++;
     }
-    *checkpoint = (char *)malloc(*checkpoint_size);
+    *checkpoint = (char *)PDC_malloc(*checkpoint_size);
     ptr         = *checkpoint;
     memcpy(ptr, &obj_count, sizeof(int));
     ptr += sizeof(int);
@@ -245,15 +247,15 @@ transfer_request_metadata_query_checkpoint(char **checkpoint, uint64_t *checkpoi
 static uint64_t
 metadata_query_buf_create(pdc_obj_region_metadata *regions, int size, uint64_t *total_buf_size_ptr)
 {
-    pdc_obj_metadata_pkg *   temp;
+    pdc_obj_metadata_pkg    *temp;
     pdc_region_metadata_pkg *region_metadata;
     int                      i;
     uint64_t                 total_data_size;
-    pdc_metadata_query_buf * query_buf;
+    pdc_metadata_query_buf  *query_buf;
     uint64_t                 query_id;
-    uint64_t *               overlap_offset, *overlap_size;
-    char *                   ptr;
-    int *                    transfer_request_counters;
+    uint64_t                *overlap_offset, *overlap_size;
+    char                    *ptr;
+    int                     *transfer_request_counters;
     int                      transfer_request_counter_total;
 
     FUNC_ENTER(NULL);
@@ -296,9 +298,9 @@ metadata_query_buf_create(pdc_obj_region_metadata *regions, int size, uint64_t *
         goto done;
     }
 
-    query_buf = (pdc_metadata_query_buf *)malloc(sizeof(pdc_metadata_query_buf));
+    query_buf = (pdc_metadata_query_buf *)PDC_malloc(sizeof(pdc_metadata_query_buf));
     // Free query_buf->buf in transfer_request_metadata_query2_bulk_transfer_cb.
-    query_buf->buf  = (char *)malloc(total_data_size);
+    query_buf->buf  = (char *)PDC_malloc(total_data_size);
     query_buf->next = NULL;
     query_buf->id   = query_id_g;
     query_id_g++;
@@ -334,7 +336,7 @@ metadata_query_buf_create(pdc_obj_region_metadata *regions, int size, uint64_t *
                     ptr += sizeof(uint64_t) * regions[i].ndim;
                 }
                 // overlap_size is freed together.
-                free(overlap_offset);
+                overlap_offset  = (uint64_t *)PDC_free(overlap_offset);
                 region_metadata = region_metadata->next;
             }
         }
@@ -351,14 +353,13 @@ metadata_query_buf_create(pdc_obj_region_metadata *regions, int size, uint64_t *
 done:
     *total_buf_size_ptr = total_data_size;
 
-    free(transfer_request_counters);
+    transfer_request_counters = (int *)PDC_free(transfer_request_counters);
     FUNC_LEAVE(query_id);
 }
 
 /**
  * Find previously stored query buffer and return the buffer. Delete the entry from the linked list.
  */
-
 perr_t
 transfer_request_metadata_query_lookup_query_buf(uint64_t query_id, char **buf_ptr)
 {
@@ -383,7 +384,7 @@ transfer_request_metadata_query_lookup_query_buf(uint64_t query_id, char **buf_p
             if (metadata_query_buf_end == metadata_query) {
                 metadata_query_buf_end = previous;
             }
-            free(metadata_query);
+            metadata_query = (pdc_metadata_query_buf *)PDC_free(metadata_query);
             goto done;
         }
         i++;
@@ -406,7 +407,7 @@ uint64_t
 transfer_request_metadata_query_parse(int32_t n_objs, char *buf, uint8_t is_write,
                                       uint64_t *total_buf_size_ptr)
 {
-    char *                   ptr = buf;
+    char                    *ptr = buf;
     int                      i;
     uint64_t                 query_id = 0;
     size_t                   unit;
@@ -415,9 +416,8 @@ transfer_request_metadata_query_parse(int32_t n_objs, char *buf, uint8_t is_writ
     pdc_obj_region_metadata *region_metadata;
 
     FUNC_ENTER(NULL);
-    /* pthread_mutex_lock(&metadata_query_mutex); */
 
-    region_metadata = (pdc_obj_region_metadata *)malloc(sizeof(pdc_obj_region_metadata) * n_objs);
+    region_metadata = (pdc_obj_region_metadata *)PDC_malloc(sizeof(pdc_obj_region_metadata) * n_objs);
 
     for (i = 0; i < n_objs; ++i) {
         region_metadata[i].obj_id = *((uint64_t *)ptr);
@@ -440,9 +440,8 @@ transfer_request_metadata_query_parse(int32_t n_objs, char *buf, uint8_t is_writ
                                                    unit, data_server_id, region_partition);
         }
     }
-    query_id = metadata_query_buf_create(region_metadata, n_objs, total_buf_size_ptr);
-    free(region_metadata);
-    /* pthread_mutex_unlock(&metadata_query_mutex); */
+    query_id        = metadata_query_buf_create(region_metadata, n_objs, total_buf_size_ptr);
+    region_metadata = (pdc_obj_region_metadata *)PDC_free(region_metadata);
     fflush(stdout);
     FUNC_LEAVE(query_id);
 }
@@ -461,7 +460,7 @@ transfer_request_metadata_reg_append(pdc_region_metadata_pkg *regions, int ndim,
 
     regions->next = NULL;
 
-    regions->reg_offset = (uint64_t *)malloc(sizeof(uint64_t) * ndim * 2);
+    regions->reg_offset = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim * 2);
     regions->reg_size   = regions->reg_offset + ndim;
 
     memcpy(regions->reg_offset, reg_offset, sizeof(uint64_t) * ndim);
@@ -497,7 +496,7 @@ static uint64_t
 transfer_request_metadata_query_append(uint64_t obj_id, int ndim, uint64_t *reg_offset, uint64_t *reg_size,
                                        size_t unit, uint32_t data_server_id, uint8_t region_partition)
 {
-    pdc_obj_metadata_pkg *   temp;
+    pdc_obj_metadata_pkg    *temp;
     pdc_region_metadata_pkg *region_metadata;
     pdc_region_metadata_pkg *temp_region_metadata;
 
@@ -510,7 +509,7 @@ transfer_request_metadata_query_append(uint64_t obj_id, int ndim, uint64_t *reg_
         temp = temp->next;
     }
     if (temp == NULL) {
-        temp = (pdc_obj_metadata_pkg *)malloc(sizeof(pdc_obj_metadata_pkg));
+        temp = (pdc_obj_metadata_pkg *)PDC_malloc(sizeof(pdc_obj_metadata_pkg));
         if (metadata_server_objs) {
             metadata_server_objs_end->next = temp;
             metadata_server_objs_end       = temp;
@@ -534,7 +533,7 @@ transfer_request_metadata_query_append(uint64_t obj_id, int ndim, uint64_t *reg_
         region_metadata = region_metadata->next;
     }
     // Reaching this line means that we are creating a new region and append it to the end of the object list.
-    temp_region_metadata = (pdc_region_metadata_pkg *)malloc(sizeof(pdc_region_metadata_pkg));
+    temp_region_metadata = (pdc_region_metadata_pkg *)PDC_malloc(sizeof(pdc_region_metadata_pkg));
     if (temp->regions) {
         temp->regions_end->next = temp_region_metadata;
         temp->regions_end       = temp_region_metadata;

--- a/src/server/pdc_server_region/pdc_server_region_transfer_metadata_query.c
+++ b/src/server/pdc_server_region/pdc_server_region_transfer_metadata_query.c
@@ -7,8 +7,8 @@
 #include "pdc_malloc.h"
 
 typedef struct pdc_region_metadata_pkg {
-    uint64_t                       *reg_offset;
-    uint64_t                       *reg_size;
+    uint64_t *                      reg_offset;
+    uint64_t *                      reg_size;
     uint32_t                        data_server_id;
     struct pdc_region_metadata_pkg *next;
 } pdc_region_metadata_pkg;
@@ -16,8 +16,8 @@ typedef struct pdc_region_metadata_pkg {
 typedef struct pdc_obj_metadata_pkg {
     int                          ndim;
     uint64_t                     obj_id;
-    pdc_region_metadata_pkg     *regions;
-    pdc_region_metadata_pkg     *regions_end;
+    pdc_region_metadata_pkg *    regions;
+    pdc_region_metadata_pkg *    regions_end;
     struct pdc_obj_metadata_pkg *next;
 } pdc_obj_metadata_pkg;
 
@@ -30,13 +30,13 @@ typedef struct pdc_obj_region_metadata {
 
 typedef struct pdc_metadata_query_buf {
     uint64_t                       id;
-    char                          *buf;
+    char *                         buf;
     struct pdc_metadata_query_buf *next;
 } pdc_metadata_query_buf;
 
-static pdc_obj_metadata_pkg   *metadata_server_objs;
-static pdc_obj_metadata_pkg   *metadata_server_objs_end;
-static uint64_t               *data_server_bytes;
+static pdc_obj_metadata_pkg *  metadata_server_objs;
+static pdc_obj_metadata_pkg *  metadata_server_objs_end;
+static uint64_t *              data_server_bytes;
 static int                     pdc_server_size;
 static uint64_t                query_id_g;
 static pdc_metadata_query_buf *metadata_query_buf_head;
@@ -60,7 +60,7 @@ perr_t
 transfer_request_metadata_query_init(int pdc_server_size_input, char *checkpoint)
 {
     hg_return_t ret_value = HG_SUCCESS;
-    char       *ptr;
+    char *      ptr;
     int         n_objs, reg_count;
     int         i, j;
     FUNC_ENTER(NULL);
@@ -141,7 +141,7 @@ perr_t
 transfer_request_metadata_query_finalize()
 {
     hg_return_t              ret_value = HG_SUCCESS;
-    pdc_obj_metadata_pkg    *obj_temp, *obj_temp2;
+    pdc_obj_metadata_pkg *   obj_temp, *obj_temp2;
     pdc_region_metadata_pkg *region_temp, *region_temp2;
     FUNC_ENTER(NULL);
 
@@ -179,9 +179,9 @@ perr_t
 transfer_request_metadata_query_checkpoint(char **checkpoint, uint64_t *checkpoint_size)
 {
     hg_return_t              ret_value = HG_SUCCESS;
-    pdc_obj_metadata_pkg    *obj_temp;
+    pdc_obj_metadata_pkg *   obj_temp;
     pdc_region_metadata_pkg *region_temp;
-    char                    *ptr;
+    char *                   ptr;
     int                      reg_count, obj_count;
     FUNC_ENTER(NULL);
     pthread_mutex_lock(&metadata_query_mutex);
@@ -247,15 +247,15 @@ transfer_request_metadata_query_checkpoint(char **checkpoint, uint64_t *checkpoi
 static uint64_t
 metadata_query_buf_create(pdc_obj_region_metadata *regions, int size, uint64_t *total_buf_size_ptr)
 {
-    pdc_obj_metadata_pkg    *temp;
+    pdc_obj_metadata_pkg *   temp;
     pdc_region_metadata_pkg *region_metadata;
     int                      i;
     uint64_t                 total_data_size;
-    pdc_metadata_query_buf  *query_buf;
+    pdc_metadata_query_buf * query_buf;
     uint64_t                 query_id;
-    uint64_t                *overlap_offset, *overlap_size;
-    char                    *ptr;
-    int                     *transfer_request_counters;
+    uint64_t *               overlap_offset, *overlap_size;
+    char *                   ptr;
+    int *                    transfer_request_counters;
     int                      transfer_request_counter_total;
 
     FUNC_ENTER(NULL);
@@ -407,7 +407,7 @@ uint64_t
 transfer_request_metadata_query_parse(int32_t n_objs, char *buf, uint8_t is_write,
                                       uint64_t *total_buf_size_ptr)
 {
-    char                    *ptr = buf;
+    char *                   ptr = buf;
     int                      i;
     uint64_t                 query_id = 0;
     size_t                   unit;
@@ -496,7 +496,7 @@ static uint64_t
 transfer_request_metadata_query_append(uint64_t obj_id, int ndim, uint64_t *reg_offset, uint64_t *reg_size,
                                        size_t unit, uint32_t data_server_id, uint8_t region_partition)
 {
-    pdc_obj_metadata_pkg    *temp;
+    pdc_obj_metadata_pkg *   temp;
     pdc_region_metadata_pkg *region_metadata;
     pdc_region_metadata_pkg *temp_region_metadata;
 

--- a/src/server/pdc_server_region/pdc_server_region_transfer_metadata_query.c
+++ b/src/server/pdc_server_region/pdc_server_region_transfer_metadata_query.c
@@ -70,7 +70,7 @@ transfer_request_metadata_query_init(int pdc_server_size_input, char *checkpoint
     metadata_query_buf_head  = NULL;
     metadata_query_buf_end   = NULL;
     pdc_server_size          = pdc_server_size_input;
-    data_server_bytes        = (uint64_t *)calloc(pdc_server_size, sizeof(uint64_t));
+    data_server_bytes        = (uint64_t *)PDC_calloc(pdc_server_size, sizeof(uint64_t));
     query_id_g               = 100000;
     ptr                      = checkpoint;
     pthread_mutex_init(&metadata_query_mutex, NULL);
@@ -262,7 +262,7 @@ metadata_query_buf_create(pdc_obj_region_metadata *regions, int size, uint64_t *
     // Iterate through all input regions. We compute the total buf size in this loop
     total_data_size                = sizeof(int);
     transfer_request_counter_total = 0;
-    transfer_request_counters      = (int *)calloc(size, sizeof(int));
+    transfer_request_counters      = (int *)PDC_calloc(size, sizeof(int));
     for (i = 0; i < size; ++i) {
         temp = metadata_server_objs;
         // First check which obj list

--- a/src/tests/dart/dart_test.c
+++ b/src/tests/dart/dart_test.c
@@ -73,15 +73,10 @@ read_words_from_text(const char *fileName, int *word_count, int *total_word_coun
 
 #ifdef ENABLE_MPI
         if (i % (mpi_rank + 1) != 0) {
-            // char *trash_skip_buf=(char *)calloc(max_line_len, sizeof(char));
             char trash_skip_buf[512];
             if (fgets(trash_skip_buf, max_line_len - 1, file) == NULL) {
-                // free(trash_skip_buf);
                 break;
             }
-            // println("skip '%s'", trash_skip_buf);
-            // free(trash_skip_buf);
-            // i++;
             continue;
         }
 #endif

--- a/src/tests/misc/llsm_idioms_bench.c
+++ b/src/tests/misc/llsm_idioms_bench.c
@@ -309,7 +309,6 @@ read_csv_from_buffer(char *data, char ***csv_header, char ****csv_data, int *num
         line = strtok(NULL, "\n");
         if (line == NULL) {
             LOG_ERROR("Error reading data from CSV\n");
-            // free(buffer);
             return -1;
         }
         if (data_line_count % proc_num == my_rank) {
@@ -397,15 +396,15 @@ int
 main(int argc, char *argv[])
 {
     pdcid_t     pdc, cont_prop, cont, obj_prop;
-    pdcid_t *   obj_ids;
+    pdcid_t    *obj_ids;
     int         n_obj, my_csv_rows, num_columns;
     int         proc_num, my_rank, i, v, iter, round, csv_expand_factor, is_using_dart, query_type, comm_type;
     double      stime, total_time;
     pdc_kvtag_t kvtag;
-    uint64_t *  pdc_ids;
+    uint64_t   *pdc_ids;
     int         nres, ntotal;
-    int *       my_cnt_round;
-    int *       total_cnt_round;
+    int        *my_cnt_round;
+    int        *total_cnt_round;
 
 #ifdef ENABLE_MPI
     MPI_Init(&argc, &argv);
@@ -437,7 +436,7 @@ main(int argc, char *argv[])
     }
 
     // ********************** Read and Broadcast first few rows of CSV file **********************
-    char * data      = NULL;
+    char  *data      = NULL;
     size_t data_size = 0;
 
     if (my_rank == 0) {
@@ -466,7 +465,7 @@ main(int argc, char *argv[])
 
     // ********************** Parse these rows of CSV file **********************
     // read the CSV file and parse into data
-    char ** csv_header = (char **)calloc(MAX_COLUMNS, sizeof(char *));
+    char  **csv_header = (char **)calloc(MAX_COLUMNS, sizeof(char *));
     char ***csv_data   = NULL;
     my_csv_rows =
         read_csv_from_buffer(data, &csv_header, &csv_data, &num_columns, rows_to_read, my_rank, proc_num);
@@ -556,7 +555,7 @@ main(int argc, char *argv[])
             }
 #endif
         } // end query type
-    }     // end comm type
+    } // end comm type
 
     if (my_rank == 0) {
         println("Rank %d: All queries are done.", my_rank);

--- a/src/tests/misc/llsm_idioms_bench.c
+++ b/src/tests/misc/llsm_idioms_bench.c
@@ -396,15 +396,15 @@ int
 main(int argc, char *argv[])
 {
     pdcid_t     pdc, cont_prop, cont, obj_prop;
-    pdcid_t    *obj_ids;
+    pdcid_t *   obj_ids;
     int         n_obj, my_csv_rows, num_columns;
     int         proc_num, my_rank, i, v, iter, round, csv_expand_factor, is_using_dart, query_type, comm_type;
     double      stime, total_time;
     pdc_kvtag_t kvtag;
-    uint64_t   *pdc_ids;
+    uint64_t *  pdc_ids;
     int         nres, ntotal;
-    int        *my_cnt_round;
-    int        *total_cnt_round;
+    int *       my_cnt_round;
+    int *       total_cnt_round;
 
 #ifdef ENABLE_MPI
     MPI_Init(&argc, &argv);
@@ -436,7 +436,7 @@ main(int argc, char *argv[])
     }
 
     // ********************** Read and Broadcast first few rows of CSV file **********************
-    char  *data      = NULL;
+    char * data      = NULL;
     size_t data_size = 0;
 
     if (my_rank == 0) {
@@ -465,7 +465,7 @@ main(int argc, char *argv[])
 
     // ********************** Parse these rows of CSV file **********************
     // read the CSV file and parse into data
-    char  **csv_header = (char **)calloc(MAX_COLUMNS, sizeof(char *));
+    char ** csv_header = (char **)calloc(MAX_COLUMNS, sizeof(char *));
     char ***csv_data   = NULL;
     my_csv_rows =
         read_csv_from_buffer(data, &csv_header, &csv_data, &num_columns, rows_to_read, my_rank, proc_num);
@@ -555,7 +555,7 @@ main(int argc, char *argv[])
             }
 #endif
         } // end query type
-    } // end comm type
+    }     // end comm type
 
     if (my_rank == 0) {
         println("Rank %d: All queries are done.", my_rank);

--- a/src/tests/misc/read_write_col_perf.c
+++ b/src/tests/misc/read_write_col_perf.c
@@ -119,7 +119,6 @@ main(int argc, char **argv)
 
     char hostname[256];
     gethostname(hostname, 256);
-    strcpy(hostname, "eno1");
 
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);

--- a/src/tests/misc/read_write_col_perf.c
+++ b/src/tests/misc/read_write_col_perf.c
@@ -119,6 +119,7 @@ main(int argc, char **argv)
 
     char hostname[256];
     gethostname(hostname, 256);
+    strcpy(hostname, "eno1");
 
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);

--- a/src/tests/misc/read_write_col_perf.c
+++ b/src/tests/misc/read_write_col_perf.c
@@ -123,7 +123,7 @@ main(int argc, char **argv)
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);
-        LOG_ERROR("First dim has size %" PRIu64 "\n", dims[0]);
+        LOG_INFO("First dim has size %" PRIu64 "\n", dims[0]);
         if (ndim >= 2) {
             LOG_INFO("second dim has size %" PRIu64 "\n", dims[1]);
         }

--- a/src/tests/misc/read_write_perf.c
+++ b/src/tests/misc/read_write_perf.c
@@ -113,6 +113,7 @@ main(int argc, char **argv)
 #endif
     char hostname[256];
     gethostname(hostname, 256);
+    strcpy(hostname, "eno1");
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);

--- a/src/tests/misc/read_write_perf.c
+++ b/src/tests/misc/read_write_perf.c
@@ -113,7 +113,6 @@ main(int argc, char **argv)
 #endif
     char hostname[256];
     gethostname(hostname, 256);
-    strcpy(hostname, "eno1");
     if (rank == 0) {
         LOG_INFO("number of dimensions in this test is %d\n", ndim);
         LOG_INFO("data size = %llu\n", (long long unsigned)data_size);

--- a/src/utils/pdc_region_utils.c
+++ b/src/utils/pdc_region_utils.c
@@ -1,5 +1,6 @@
 #include "pdc_region.h"
 #include "pdc_private.h"
+#include "pdc_malloc.h"
 #include "pdc_logger.h"
 #include <string.h>
 
@@ -30,12 +31,12 @@ PDC_region_overlap_detect(int ndim, uint64_t *offset1, uint64_t *size1, uint64_t
         goto done;
     }
     // Overlapping exist.
-    *output_offset = (uint64_t *)malloc(sizeof(uint64_t) * ndim * 2);
+    *output_offset = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim * 2);
     *output_size   = *output_offset + ndim;
     for (i = 0; i < ndim; ++i) {
         output_offset[0][i] = offset2[i] < offset1[i] ? offset1[i] : offset2[i];
         output_size[0][i]   = ((offset2[i] + size2[i] < offset1[i] + size1[i]) ? (offset2[i] + size2[i])
-                                                                             : (offset1[i] + size1[i])) -
+                                                                               : (offset1[i] + size1[i])) -
                             output_offset[0][i];
     }
 
@@ -51,7 +52,7 @@ memcpy_subregion(int ndim, uint64_t unit, pdc_access_t access_type, char *buf, u
                  uint64_t *sub_offset, uint64_t *sub_size)
 {
     uint64_t i, j;
-    char *   ptr, *target_buf, *src_buf;
+    char    *ptr, *target_buf, *src_buf;
 
     if (ndim == 1) {
         target_buf = sub_buf;
@@ -107,7 +108,7 @@ memcpy_overlap_subregion(int ndim, uint64_t unit, char *buf, uint64_t *offset, u
                          uint64_t *offset2, uint64_t *size2, uint64_t *overlap_offset, uint64_t *overlap_size)
 {
     uint64_t i, j;
-    char *   target_buf, *src_buf;
+    char    *target_buf, *src_buf;
 
     switch (ndim) {
         case 1: {

--- a/src/utils/pdc_region_utils.c
+++ b/src/utils/pdc_region_utils.c
@@ -36,7 +36,7 @@ PDC_region_overlap_detect(int ndim, uint64_t *offset1, uint64_t *size1, uint64_t
     for (i = 0; i < ndim; ++i) {
         output_offset[0][i] = offset2[i] < offset1[i] ? offset1[i] : offset2[i];
         output_size[0][i]   = ((offset2[i] + size2[i] < offset1[i] + size1[i]) ? (offset2[i] + size2[i])
-                                                                               : (offset1[i] + size1[i])) -
+                                                                             : (offset1[i] + size1[i])) -
                             output_offset[0][i];
     }
 
@@ -52,7 +52,7 @@ memcpy_subregion(int ndim, uint64_t unit, pdc_access_t access_type, char *buf, u
                  uint64_t *sub_offset, uint64_t *sub_size)
 {
     uint64_t i, j;
-    char    *ptr, *target_buf, *src_buf;
+    char *   ptr, *target_buf, *src_buf;
 
     if (ndim == 1) {
         target_buf = sub_buf;
@@ -108,7 +108,7 @@ memcpy_overlap_subregion(int ndim, uint64_t unit, char *buf, uint64_t *offset, u
                          uint64_t *offset2, uint64_t *size2, uint64_t *overlap_offset, uint64_t *overlap_size)
 {
     uint64_t i, j;
-    char    *target_buf, *src_buf;
+    char *   target_buf, *src_buf;
 
     switch (ndim) {
         case 1: {


### PR DESCRIPTION
Issue: https://github.com/hpc-io/pdc/issues/264

1. Changed `PDCprop_create` to default `ndim` to `1` when using `PDC_OBJ_CREATE`.
2. Changed `PDCprop_set_obj_dims` to return an error if `ndim <= 0`.
3. Only free `hostname` if we `PDC_malloc` the string. This bug comes from: https://github.com/hpc-io/pdc/pull/255

# Checklist:
- [x] New and existing unit tests pass locally with my changes
- [x] Updated docs