### PR TITLE
Fix segmentation fault of calling `PDCobj_create_mpi` twice with duplicate object name

### DIFF
--- a/src/api/pdc_obj/include/pdc_mpi.h
+++ b/src/api/pdc_obj/include/pdc_mpi.h
@@ -39,7 +39,7 @@
  *                              returned by PDCprop_create(PDC_OBJ_CREATE)
  * \param rank_id [IN]          MPI process rank
  *
- * \return Object ID on success/Negative on failure
+ * \return Object ID on success/Zero on failure
  */
 pdcid_t PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_create_prop, int rank_id,
                           MPI_Comm comm);

--- a/src/api/pdc_obj/pdc_mpi.c
+++ b/src/api/pdc_obj/pdc_mpi.c
@@ -33,7 +33,7 @@ pdcid_t
 PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, int rank_id, MPI_Comm comm)
 {
     struct _pdc_obj_info *p       = NULL;
-    struct _pdc_id_info  *id_info = NULL;
+    struct _pdc_id_info * id_info = NULL;
     int                   rank;
     pdcid_t               ret_value;
 
@@ -68,7 +68,7 @@ perr_t
 PDCobj_encode(pdcid_t obj_id, pdcid_t *meta_id)
 {
     perr_t                ret_value = FAIL;
-    struct _pdc_id_info  *objinfo;
+    struct _pdc_id_info * objinfo;
     struct _pdc_obj_info *obj;
     int                   client_rank, client_size;
 
@@ -98,7 +98,7 @@ pdcid_t
 PDCobj_decode(pdcid_t obj_id, pdcid_t meta_id)
 {
     pdcid_t               ret_value = 0;
-    struct _pdc_id_info  *objinfo;
+    struct _pdc_id_info * objinfo;
     struct _pdc_obj_info *obj;
     int                   client_rank, client_size;
 

--- a/src/api/pdc_obj/pdc_mpi.c
+++ b/src/api/pdc_obj/pdc_mpi.c
@@ -32,10 +32,10 @@
 pdcid_t
 PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, int rank_id, MPI_Comm comm)
 {
-    pdcid_t               ret_value = SUCCEED;
-    struct _pdc_obj_info *p         = NULL;
-    struct _pdc_id_info * id_info   = NULL;
+    struct _pdc_obj_info *p       = NULL;
+    struct _pdc_id_info  *id_info = NULL;
     int                   rank;
+    pdcid_t               ret_value;
 
     FUNC_ENTER(NULL);
 
@@ -46,14 +46,21 @@ PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, in
     else
         ret_value = PDC_obj_create(cont_id, obj_name, obj_prop_id, PDC_OBJ_LOCAL);
 
+    if (ret_value == 0)
+        PGOTO_ERROR(ret_value, "PDC_obj_create failed");
+
     id_info = PDC_find_id(ret_value);
-    p       = (struct _pdc_obj_info *)(id_info->obj_ptr);
+    if (id_info == NULL)
+        PGOTO_ERROR(0, "PDC_find_id failed for object id: %d", ret_value);
+
+    p = (struct _pdc_obj_info *)(id_info->obj_ptr);
 
     MPI_Bcast(&(p->obj_info_pub->meta_id), 1, MPI_LONG_LONG, rank_id, comm);
     MPI_Bcast(&(p->obj_info_pub->metadata_server_id), 1, MPI_UINT32_T, rank_id, comm);
     MPI_Bcast(&(((pdc_metadata_t *)p->metadata)->data_server_id), 1, MPI_UINT32_T, rank_id, comm);
     MPI_Bcast(&(((pdc_metadata_t *)p->metadata)->region_partition), 1, MPI_UINT8_T, rank_id, comm);
 
+done:
     FUNC_LEAVE(ret_value);
 }
 
@@ -61,7 +68,7 @@ perr_t
 PDCobj_encode(pdcid_t obj_id, pdcid_t *meta_id)
 {
     perr_t                ret_value = FAIL;
-    struct _pdc_id_info * objinfo;
+    struct _pdc_id_info  *objinfo;
     struct _pdc_obj_info *obj;
     int                   client_rank, client_size;
 
@@ -91,7 +98,7 @@ pdcid_t
 PDCobj_decode(pdcid_t obj_id, pdcid_t meta_id)
 {
     pdcid_t               ret_value = 0;
-    struct _pdc_id_info * objinfo;
+    struct _pdc_id_info  *objinfo;
     struct _pdc_obj_info *obj;
     int                   client_rank, client_size;
 

--- a/src/tests/obj/read_obj.c
+++ b/src/tests/obj/read_obj.c
@@ -27,7 +27,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
     MPI_Comm comm;
 #else
-    int comm = 1;
+    int comm   = 1;
 #endif
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -39,7 +39,7 @@ main(int argc, char **argv)
     uint64_t *offset, *local_offset;
     uint64_t *mysize;
     int       i, j;
-    char     *mydata;
+    char *    mydata;
     char      obj_name[128], cont_name[128];
 
     uint64_t my_data_size;

--- a/src/tests/obj/read_obj.c
+++ b/src/tests/obj/read_obj.c
@@ -27,7 +27,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
     MPI_Comm comm;
 #else
-    int comm   = 1;
+    int comm = 1;
 #endif
     struct timeval pdc_timer_start;
     struct timeval pdc_timer_end;
@@ -39,7 +39,7 @@ main(int argc, char **argv)
     uint64_t *offset, *local_offset;
     uint64_t *mysize;
     int       i, j;
-    char *    mydata;
+    char     *mydata;
     char      obj_name[128], cont_name[128];
 
     uint64_t my_data_size;
@@ -157,6 +157,7 @@ main(int argc, char **argv)
     if (global_obj <= 0) {
         LOG_ERROR("Error creating an object [%s], exit...\n", obj_name);
         ret_value = 1;
+        goto done;
     }
 
     offset          = (uint64_t *)malloc(sizeof(uint64_t) * ndim);
@@ -293,6 +294,8 @@ main(int argc, char **argv)
         LOG_ERROR("Failed to close PDC");
         ret_value = 1;
     }
+
+done:
 #ifdef ENABLE_MPI
     MPI_Finalize();
 #endif


### PR DESCRIPTION
# What changes are proposed in this pull request?

To test run the `pdc_server.exe` and run `read_obj` twice without closing the server. The `PDCobj_create_mpi` seg faults. As it doesn't validate the pointer returned by  `PDC_find_id`.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:
- [x] My code requires documentation updates, and I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
