### PR TITLE
Fix multithread

### DIFF
--- a/.github/workflows/ubuntu-cache-multithread.yaml
+++ b/.github/workflows/ubuntu-cache-multithread.yaml
@@ -1,0 +1,27 @@
+name: Ubuntu (multithread)
+
+on:
+  pull_request:
+    branches: [ stable, develop ]
+
+  push:
+    branches: [ stable, develop ]
+
+  workflow_dispatch:
+
+jobs:
+  PDC:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Dependencies
+        run: .github/workflows/dependencies-linux.sh
+
+      - name: Build PDC
+        run: |
+          mkdir build && cd build
+          cmake ../ -DBUILD_MPI_TESTING=ON -DBUILD_SHARED_LIBS=ON -DPDC_SERVER_CACHE=ON -DBUILD_TESTING=ON -DPDC_ENABLE_MPI=ON -DPDC_ENABLE_PROFILING=ON -DPDC_ENABLE_MULTITHREAD=ON -DCMAKE_C_COMPILER=mpicc -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          make -j2

--- a/src/commons/collections/include/pdc_hash_table.h
+++ b/src/commons/collections/include/pdc_hash_table.h
@@ -100,7 +100,7 @@ typedef struct _HashTablePair {
  */
 
 struct _HashTableIterator {
-    HashTable      *hash_table;
+    HashTable *     hash_table;
     HashTableEntry *next_entry;
     unsigned int    next_chain;
 };

--- a/src/commons/collections/include/pdc_hash_table.h
+++ b/src/commons/collections/include/pdc_hash_table.h
@@ -49,6 +49,12 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 extern "C" {
 #endif
 
+#ifdef ENABLE_MULTITHREAD
+#include "mercury_thread_mutex.h"
+
+extern hg_thread_mutex_t hash_table_new_mutex_g;
+#endif
+
 /**
  * A hash table structure.
  */
@@ -94,7 +100,7 @@ typedef struct _HashTablePair {
  */
 
 struct _HashTableIterator {
-    HashTable *     hash_table;
+    HashTable      *hash_table;
     HashTableEntry *next_entry;
     unsigned int    next_chain;
 };

--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -42,7 +42,7 @@ struct _HashTableEntry {
 };
 
 struct _HashTable {
-    HashTableEntry       **table;
+    HashTableEntry **      table;
     unsigned int           table_size;
     HashTableHashFunc      hash_func;
     HashTableEqualFunc     equal_func;
@@ -72,7 +72,7 @@ pdc_default_string_hash_func(HashTableKey value)
 {
     FUNC_ENTER(NULL);
 
-    char        *str  = (char *)value;
+    char *       str  = (char *)value;
     unsigned int hash = 5381;
     int          c;
 
@@ -314,9 +314,9 @@ hash_table_enlarge(HashTable *hash_table)
     HashTableEntry **old_table;
     unsigned int     old_table_size;
     unsigned int     old_prime_index;
-    HashTableEntry  *rover;
-    HashTablePair   *pair;
-    HashTableEntry  *next;
+    HashTableEntry * rover;
+    HashTablePair *  pair;
+    HashTableEntry * next;
     unsigned int     index;
     unsigned int     i;
 
@@ -373,7 +373,7 @@ hash_table_insert(HashTable *hash_table, HashTableKey key, HashTableValue value)
     FUNC_ENTER(NULL);
 
     HashTableEntry *rover;
-    HashTablePair  *pair;
+    HashTablePair * pair;
     HashTableEntry *newentry;
     unsigned int    index;
 
@@ -459,7 +459,7 @@ hash_table_lookup(HashTable *hash_table, HashTableKey key)
     FUNC_ENTER(NULL);
 
     HashTableEntry *rover;
-    HashTablePair  *pair;
+    HashTablePair * pair;
     unsigned int    index;
 
     /* Generate the hash of the key and hence the index into the table */
@@ -491,8 +491,8 @@ hash_table_remove(HashTable *hash_table, HashTableKey key)
     FUNC_ENTER(NULL);
 
     HashTableEntry **rover;
-    HashTableEntry  *entry;
-    HashTablePair   *pair;
+    HashTableEntry * entry;
+    HashTablePair *  pair;
     unsigned int     index;
     int              result;
 
@@ -583,7 +583,7 @@ hash_table_iter_next(HashTableIterator *iterator)
     FUNC_ENTER(NULL);
 
     HashTableEntry *current_entry;
-    HashTable      *hash_table;
+    HashTable *     hash_table;
     HashTablePair   pair = {NULL, NULL};
     unsigned int    chain;
 

--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -32,13 +32,17 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "alloc-testing.h"
 #endif
 
+#ifdef ENABLE_MULTITHREAD
+hg_thread_mutex_t hash_table_new_mutex_g;
+#endif
+
 struct _HashTableEntry {
     HashTablePair   pair;
     HashTableEntry *next;
 };
 
 struct _HashTable {
-    HashTableEntry **      table;
+    HashTableEntry       **table;
     unsigned int           table_size;
     HashTableHashFunc      hash_func;
     HashTableEqualFunc     equal_func;
@@ -68,7 +72,7 @@ pdc_default_string_hash_func(HashTableKey value)
 {
     FUNC_ENTER(NULL);
 
-    char *       str  = (char *)value;
+    char        *str  = (char *)value;
     unsigned int hash = 5381;
     int          c;
 
@@ -310,9 +314,9 @@ hash_table_enlarge(HashTable *hash_table)
     HashTableEntry **old_table;
     unsigned int     old_table_size;
     unsigned int     old_prime_index;
-    HashTableEntry * rover;
-    HashTablePair *  pair;
-    HashTableEntry * next;
+    HashTableEntry  *rover;
+    HashTablePair   *pair;
+    HashTableEntry  *next;
     unsigned int     index;
     unsigned int     i;
 
@@ -369,7 +373,7 @@ hash_table_insert(HashTable *hash_table, HashTableKey key, HashTableValue value)
     FUNC_ENTER(NULL);
 
     HashTableEntry *rover;
-    HashTablePair * pair;
+    HashTablePair  *pair;
     HashTableEntry *newentry;
     unsigned int    index;
 
@@ -455,7 +459,7 @@ hash_table_lookup(HashTable *hash_table, HashTableKey key)
     FUNC_ENTER(NULL);
 
     HashTableEntry *rover;
-    HashTablePair * pair;
+    HashTablePair  *pair;
     unsigned int    index;
 
     /* Generate the hash of the key and hence the index into the table */
@@ -487,8 +491,8 @@ hash_table_remove(HashTable *hash_table, HashTableKey key)
     FUNC_ENTER(NULL);
 
     HashTableEntry **rover;
-    HashTableEntry * entry;
-    HashTablePair *  pair;
+    HashTableEntry  *entry;
+    HashTablePair   *pair;
     unsigned int     index;
     int              result;
 
@@ -579,7 +583,7 @@ hash_table_iter_next(HashTableIterator *iterator)
     FUNC_ENTER(NULL);
 
     HashTableEntry *current_entry;
-    HashTable *     hash_table;
+    HashTable      *hash_table;
     HashTablePair   pair = {NULL, NULL};
     unsigned int    chain;
 

--- a/src/server/include/pdc_server.h
+++ b/src/server/include/pdc_server.h
@@ -71,7 +71,6 @@ extern int      use_sqlite3_g;
 /*****************************/
 /* Library-private Variables */
 /*****************************/
-hg_thread_mutex_t hash_table_new_mutex_g;
 hg_thread_mutex_t pdc_client_addr_mutex_g;
 hg_thread_mutex_t pdc_metadata_hash_table_mutex_g;
 hg_thread_mutex_t pdc_container_hash_table_mutex_g;


### PR DESCRIPTION
Fixed compilation of multithreading.

To reproduce just build with ` -DENABLE_MULTITHREAD=ON`.

This simply moves the mutex used when inserting a new element into the hash table to the hash table source files. It shouldn't have been in the `pdc_server.h` anyways since the hash table is in the `commons` folder which should be usable by both the client and the server.