### PR TITLE
Obj open fix

### DIFF
--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -2424,8 +2424,17 @@ PDC_Client_query_metadata_name_timestep(const char *obj_name, int time_step, pdc
     hg_atomic_set32(&atomic_work_todo_g, 1);
     PDC_Client_check_response(&send_context_g);
     *out = lookup_args.data;
-    LOG_DEBUG("rank = %d, PDC_Client_query_metadata_name_timestep = %u\n", pdc_client_mpi_rank_g,
-              out[0]->data_server_id);
+
+    /**
+     * Not necessarily an error. If the obj does not exist
+     * then this will be NULL. Still need to return as FAIL
+     * otherwise calling code will expect *out to be non-NULL.
+     */
+    if(*out == NULL) {
+        LOG_INFO("Metadata not found\n");
+        PGOTO_DONE(FAIL);
+    }
+
 done:
     HG_Destroy(metadata_query_handle);
 

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -2430,8 +2430,10 @@ PDC_Client_query_metadata_name_timestep(const char *obj_name, int time_step, pdc
      * then this will be NULL. Still need to return as FAIL
      * otherwise calling code will expect *out to be non-NULL.
      */
-    if (*out == NULL)
+    if (*out == NULL) {
+        LOG_INFO("Object metadata does not exist\n");
         PGOTO_DONE(FAIL);
+    }
 
 done:
     HG_Destroy(metadata_query_handle);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -2430,7 +2430,7 @@ PDC_Client_query_metadata_name_timestep(const char *obj_name, int time_step, pdc
      * then this will be NULL. Still need to return as FAIL
      * otherwise calling code will expect *out to be non-NULL.
      */
-    if(*out == NULL) {
+    if (*out == NULL) {
         LOG_INFO("Metadata not found\n");
         PGOTO_DONE(FAIL);
     }

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -2430,10 +2430,8 @@ PDC_Client_query_metadata_name_timestep(const char *obj_name, int time_step, pdc
      * then this will be NULL. Still need to return as FAIL
      * otherwise calling code will expect *out to be non-NULL.
      */
-    if (*out == NULL) {
-        LOG_INFO("Metadata not found\n");
+    if (*out == NULL)
         PGOTO_DONE(FAIL);
-    }
 
 done:
     HG_Destroy(metadata_query_handle);


### PR DESCRIPTION
This enables:

```
obj1 = PDCobj_open("obj", pdc);

if(obj1 == 0){
    LOG_INFO("obj failed to open creating new obj1...\n");
    obj1 = PDCobj_create(cont, "obj", obj_prop);

    if(obj1 == 0)
        TGOTO_ERROR(FAIL, "failed to create obj1");
} else
    LOG_INFO("obj1 was opened without creation\n");
```

Currently seg faults.

Relevant issue: https://github.com/hpc-io/pdc/issues/278