### PR TITLE
Standardize ID Lookup Null Checks and Error Handling

### DIFF
--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -4597,9 +4597,8 @@ PDC_Client_write_id(pdcid_t local_obj_id, struct pdc_region_info *region, void *
     pdc_metadata_t *      meta;
     perr_t                ret_value = SUCCEED;
 
-    info = PDC_find_id(local_obj_id);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "obj_id %" PRIu64 " invalid", local_obj_id);
+    if ((info = PDC_find_id(local_obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_obj_id);
 
     object = (struct _pdc_obj_info *)(info->obj_ptr);
     meta   = object->metadata;
@@ -4820,15 +4819,20 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 
     obj_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * nobj);
     for (i = 0; i < nobj; i++) {
-        id_info    = PDC_find_id(local_obj_ids[i]);
+        if((id_info    = PDC_find_id(local_obj_ids[i])) == NULL) {
+            LOG_ERROR("Failed to find PDC ID: %d\n", local_obj_ids[i]);
+            continue;
+        }
         obj_ids[i] = ((struct _pdc_obj_info *)(id_info->obj_ptr))->obj_info_pub->meta_id;
     }
 
-    id_info      = PDC_find_id(local_cont_id);
+    if((id_info      = PDC_find_id(local_cont_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_cont_id);
     cont_meta_id = ((struct _pdc_cont_info *)(id_info->obj_ptr))->cont_info_pub->meta_id;
 
     ret_value = PDC_Client_add_del_objects_to_container(nobj, obj_ids, cont_meta_id, ADD_OBJ);
 
+done:
     FUNC_LEAVE(ret_value);
 }
 
@@ -4846,15 +4850,20 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 
     obj_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * nobj);
     for (i = 0; i < nobj; i++) {
-        id_info    = PDC_find_id(local_obj_ids[i]);
+        if((id_info    = PDC_find_id(local_obj_ids[i])) == NULL) {
+            LOG_ERROR("Failed to find PDC ID: %d\n", local_obj_ids[i]);
+            continue;
+        }
         obj_ids[i] = ((struct _pdc_obj_info *)(id_info->obj_ptr))->obj_info_pub->meta_id;
     }
 
-    id_info      = PDC_find_id(local_cont_id);
+    if((id_info      = PDC_find_id(local_cont_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_cont_id);
     cont_meta_id = ((struct _pdc_cont_info *)(id_info->obj_ptr))->cont_info_pub->meta_id;
 
     ret_value = PDC_Client_add_del_objects_to_container(nobj, obj_ids, cont_meta_id, DEL_OBJ);
 
+done:
     FUNC_LEAVE(ret_value);
 }
 
@@ -4873,9 +4882,8 @@ PDC_Client_add_tags_to_container(pdcid_t cont_id, char *tags)
     uint64_t               cont_meta_id;
     cont_add_tags_rpc_in_t add_tag_rpc_in;
 
-    info = PDC_find_id(cont_id);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "cont_id %" PRIu64 " invalid", cont_id);
+    if ((info = PDC_find_id(cont_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", cont_id);
 
     object       = (struct _pdc_cont_info *)(info->obj_ptr);
     cont_meta_id = object->cont_info_pub->meta_id;
@@ -6937,7 +6945,8 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     struct _pdc_id_info *  id_info = NULL;
     pdcid_t                transfer_request;
 
-    id_info = PDC_find_id(cont_id);
+    if((id_info = PDC_find_id(cont_id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_id);
     info    = (struct _pdc_cont_info *)(id_info->obj_ptr);
 
     obj_prop = PDCprop_create(PDC_OBJ_CREATE, info->cont_pt->pdc->local_id);

--- a/src/api/pdc_client_connect.c
+++ b/src/api/pdc_client_connect.c
@@ -4819,14 +4819,14 @@ PDC_Client_add_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 
     obj_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * nobj);
     for (i = 0; i < nobj; i++) {
-        if((id_info    = PDC_find_id(local_obj_ids[i])) == NULL) {
+        if ((id_info = PDC_find_id(local_obj_ids[i])) == NULL) {
             LOG_ERROR("Failed to find PDC ID: %d\n", local_obj_ids[i]);
             continue;
         }
         obj_ids[i] = ((struct _pdc_obj_info *)(id_info->obj_ptr))->obj_info_pub->meta_id;
     }
 
-    if((id_info      = PDC_find_id(local_cont_id)) == NULL)
+    if ((id_info = PDC_find_id(local_cont_id)) == NULL)
         PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_cont_id);
     cont_meta_id = ((struct _pdc_cont_info *)(id_info->obj_ptr))->cont_info_pub->meta_id;
 
@@ -4850,14 +4850,14 @@ PDC_Client_del_objects_to_container(int nobj, pdcid_t *local_obj_ids, pdcid_t lo
 
     obj_ids = (uint64_t *)PDC_malloc(sizeof(uint64_t) * nobj);
     for (i = 0; i < nobj; i++) {
-        if((id_info    = PDC_find_id(local_obj_ids[i])) == NULL) {
+        if ((id_info = PDC_find_id(local_obj_ids[i])) == NULL) {
             LOG_ERROR("Failed to find PDC ID: %d\n", local_obj_ids[i]);
             continue;
         }
         obj_ids[i] = ((struct _pdc_obj_info *)(id_info->obj_ptr))->obj_info_pub->meta_id;
     }
 
-    if((id_info      = PDC_find_id(local_cont_id)) == NULL)
+    if ((id_info = PDC_find_id(local_cont_id)) == NULL)
         PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_cont_id);
     cont_meta_id = ((struct _pdc_cont_info *)(id_info->obj_ptr))->cont_info_pub->meta_id;
 
@@ -6945,9 +6945,9 @@ PDCobj_put_data(const char *obj_name, void *data, uint64_t size, pdcid_t cont_id
     struct _pdc_id_info *  id_info = NULL;
     pdcid_t                transfer_request;
 
-    if((id_info = PDC_find_id(cont_id)) == NULL)
+    if ((id_info = PDC_find_id(cont_id)) == NULL)
         PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_id);
-    info    = (struct _pdc_cont_info *)(id_info->obj_ptr);
+    info = (struct _pdc_cont_info *)(id_info->obj_ptr);
 
     obj_prop = PDCprop_create(PDC_OBJ_CREATE, info->cont_pt->pdc->local_id);
     PDCprop_set_obj_type(obj_prop, PDC_CHAR);

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -69,7 +69,7 @@ PDCcont_create(const char *cont_name, pdcid_t cont_prop_id)
         PGOTO_ERROR(0, "PDC pub container memory allocation failed");
     p->cont_info_pub->name = strdup(cont_name);
 
-    if((id_info   = PDC_find_id(cont_prop_id)) == NULL)
+    if ((id_info = PDC_find_id(cont_prop_id)) == NULL)
         PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_prop_id);
     cont_prop = (struct _pdc_cont_prop *)(id_info->obj_ptr);
 
@@ -120,7 +120,7 @@ PDCcont_create_col(const char *cont_name, pdcid_t cont_prop_id)
         PGOTO_ERROR(0, "PDC pub container memory allocation failed");
     p->cont_info_pub->name = strdup(cont_name);
 
-    if((id_info = PDC_find_id(cont_prop_id)) == NULL)
+    if ((id_info = PDC_find_id(cont_prop_id)) == NULL)
         PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_prop_id);
     cont_prop = (struct _pdc_cont_prop *)(id_info->obj_ptr);
 
@@ -170,7 +170,7 @@ PDC_cont_create_local(pdcid_t pdc, const char *cont_name, uint64_t cont_meta_id)
 
     cont_prop_id = PDCprop_create(PDC_CONT_CREATE, pdc);
 
-    if((id_info = PDC_find_id(cont_prop_id)) == NULL)
+    if ((id_info = PDC_find_id(cont_prop_id)) == NULL)
         PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_prop_id);
     cont_prop  = (struct _pdc_cont_prop *)(id_info->obj_ptr);
     p->cont_pt = (struct _pdc_cont_prop *)PDC_calloc(1, sizeof(struct _pdc_cont_prop));

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -69,7 +69,8 @@ PDCcont_create(const char *cont_name, pdcid_t cont_prop_id)
         PGOTO_ERROR(0, "PDC pub container memory allocation failed");
     p->cont_info_pub->name = strdup(cont_name);
 
-    id_info   = PDC_find_id(cont_prop_id);
+    if((id_info   = PDC_find_id(cont_prop_id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_prop_id);
     cont_prop = (struct _pdc_cont_prop *)(id_info->obj_ptr);
 
     p->cont_pt = (struct _pdc_cont_prop *)PDC_calloc(1, sizeof(struct _pdc_cont_prop));
@@ -119,7 +120,8 @@ PDCcont_create_col(const char *cont_name, pdcid_t cont_prop_id)
         PGOTO_ERROR(0, "PDC pub container memory allocation failed");
     p->cont_info_pub->name = strdup(cont_name);
 
-    id_info   = PDC_find_id(cont_prop_id);
+    if((id_info = PDC_find_id(cont_prop_id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_prop_id);
     cont_prop = (struct _pdc_cont_prop *)(id_info->obj_ptr);
 
     p->cont_pt = (struct _pdc_cont_prop *)PDC_calloc(1, sizeof(struct _pdc_cont_prop));
@@ -168,7 +170,8 @@ PDC_cont_create_local(pdcid_t pdc, const char *cont_name, uint64_t cont_meta_id)
 
     cont_prop_id = PDCprop_create(PDC_CONT_CREATE, pdc);
 
-    id_info    = PDC_find_id(cont_prop_id);
+    if((id_info = PDC_find_id(cont_prop_id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_prop_id);
     cont_prop  = (struct _pdc_cont_prop *)(id_info->obj_ptr);
     p->cont_pt = (struct _pdc_cont_prop *)PDC_calloc(1, sizeof(struct _pdc_cont_prop));
     if (!p->cont_pt)
@@ -309,9 +312,8 @@ PDC_cont_get_info(pdcid_t cont_id)
     struct _pdc_cont_info *info      = NULL;
     struct _pdc_id_info *  id_info   = NULL;
 
-    id_info = PDC_find_id(cont_id);
-    if (id_info == NULL)
-        PGOTO_ERROR(NULL, "Cannot locate object");
+    if ((id_info = PDC_find_id(cont_id)) == NULL)
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", cont_id);
 
     info      = (struct _pdc_cont_info *)(id_info->obj_ptr);
     ret_value = (struct _pdc_cont_info *)PDC_calloc(1, sizeof(struct _pdc_cont_info));
@@ -446,9 +448,8 @@ PDCcont_persist(pdcid_t cont_id)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(cont_id);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate container ID");
+    if ((info = PDC_find_id(cont_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", cont_id);
 
     ((struct _pdc_cont_info *)info->obj_ptr)->cont_pt->cont_life = PDC_PERSIST;
 
@@ -464,9 +465,8 @@ PDCprop_set_cont_lifetime(pdcid_t cont_prop, pdc_lifetime_t cont_lifetime)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(cont_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate container property ID");
+    if ((info = PDC_find_id(cont_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", cont_prop);
     ((struct _pdc_cont_prop *)(info->obj_ptr))->cont_life = cont_lifetime;
 
 done:

--- a/src/api/pdc_obj/pdc_mpi.c
+++ b/src/api/pdc_obj/pdc_mpi.c
@@ -47,11 +47,9 @@ PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, in
         ret_value = PDC_obj_create(cont_id, obj_name, obj_prop_id, PDC_OBJ_LOCAL);
 
     if (ret_value == 0)
-        PGOTO_ERROR(ret_value, "PDC_obj_create failed");
-
-    id_info = PDC_find_id(ret_value);
-    if (id_info == NULL)
-        PGOTO_ERROR(0, "PDC_find_id failed for object id: %d", ret_value);
+        PGOTO_ERROR(0, "PDC_obj_create failed");
+    if ((id_info = PDC_find_id(ret_value)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", ret_value);
 
     p = (struct _pdc_obj_info *)(id_info->obj_ptr);
 
@@ -69,21 +67,20 @@ PDCobj_encode(pdcid_t obj_id, pdcid_t *meta_id)
 {
     FUNC_ENTER(NULL);
 
-    perr_t                ret_value = FAIL;
+    perr_t                ret_value = SUCCEED;
     struct _pdc_id_info * objinfo;
     struct _pdc_obj_info *obj;
     int                   client_rank, client_size;
 
     MPI_Comm_size(MPI_COMM_WORLD, &client_size);
     if (client_size < 2)
-        PGOTO_ERROR(ret_value, "Requires at least two processes");
+        PGOTO_ERROR(FAIL, "Requires at least two processes");
 
     MPI_Comm_rank(MPI_COMM_WORLD, &client_rank);
 
     if (client_rank == 0) {
-        objinfo = PDC_find_id(obj_id);
-        if (objinfo == NULL)
-            PGOTO_ERROR(ret_value, "Cannot locate object ID");
+        if ((objinfo = PDC_find_id(obj_id)) == NULL)
+            PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_id);
         obj = (struct _pdc_obj_info *)(objinfo->obj_ptr);
         if (obj->location == PDC_OBJ_LOCAL)
             PGOTO_ERROR(FAIL, "Trying to encode local object");
@@ -110,9 +107,8 @@ PDCobj_decode(pdcid_t obj_id, pdcid_t meta_id)
 
     MPI_Comm_rank(MPI_COMM_WORLD, &client_rank);
     if (client_rank != 0) {
-        objinfo = PDC_find_id(obj_id);
-        if (objinfo == NULL)
-            PGOTO_ERROR(ret_value, "Cannot locate object ID");
+        if ((objinfo = PDC_find_id(obj_id)) == NULL)
+            PGOTO_ERROR(ret_value, "Failed to find PDC ID: %d", obj_id);
         obj                        = (struct _pdc_obj_info *)(objinfo->obj_ptr);
         obj->obj_info_pub->meta_id = meta_id;
     }

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -136,7 +136,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
         meta_id = 0;
     }
     else {
-        if((id_info = PDC_find_id(cont_id)) == NULL)
+        if ((id_info = PDC_find_id(cont_id)) == NULL)
             PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_id);
         /* struct _pdc_cont_info field */
         cont_info = (struct _pdc_cont_info *)(id_info->obj_ptr);
@@ -170,7 +170,7 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
         meta_id                         = p->cont->cont_info_pub->meta_id;
     }
 
-    if((id_info = PDC_find_id(obj_prop_id)) == NULL)
+    if ((id_info = PDC_find_id(obj_prop_id)) == NULL)
         PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_id);
     obj_prop = (struct _pdc_obj_prop *)(id_info->obj_ptr);
 

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -136,7 +136,8 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
         meta_id = 0;
     }
     else {
-        id_info = PDC_find_id(cont_id);
+        if((id_info = PDC_find_id(cont_id)) == NULL)
+            PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_id);
         /* struct _pdc_cont_info field */
         cont_info = (struct _pdc_cont_info *)(id_info->obj_ptr);
 
@@ -169,7 +170,8 @@ PDC_obj_create(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, _pdc_
         meta_id                         = p->cont->cont_info_pub->meta_id;
     }
 
-    id_info  = PDC_find_id(obj_prop_id);
+    if((id_info = PDC_find_id(obj_prop_id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", cont_id);
     obj_prop = (struct _pdc_obj_prop *)(id_info->obj_ptr);
 
     /* struct _pdc_obj_prop field */
@@ -639,9 +641,8 @@ PDCprop_set_obj_user_id(pdcid_t obj_prop, uint32_t user_id)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     ((struct _pdc_obj_prop *)(info->obj_ptr))->user_id = user_id;
 
 done:
@@ -656,9 +657,8 @@ PDCprop_set_obj_app_name(pdcid_t obj_prop, char *app_name)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     if (((struct _pdc_obj_prop *)(info->obj_ptr))->app_name != NULL) {
         ((struct _pdc_obj_prop *)(info->obj_ptr))->app_name =
             (char *)PDC_free(((struct _pdc_obj_prop *)(info->obj_ptr))->app_name);
@@ -677,9 +677,8 @@ PDCprop_set_obj_time_step(pdcid_t obj_prop, uint32_t time_step)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     ((struct _pdc_obj_prop *)(info->obj_ptr))->time_step = time_step;
 
 done:
@@ -694,9 +693,8 @@ PDCprop_set_obj_data_loc(pdcid_t obj_prop, char *loc)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     if (((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc != NULL) {
         ((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc =
             (char *)PDC_free(((struct _pdc_obj_prop *)(info->obj_ptr))->data_loc);
@@ -715,9 +713,8 @@ PDCprop_set_obj_tags(pdcid_t obj_prop, char *tags)
     perr_t               ret_value = SUCCEED;
     struct _pdc_id_info *info;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     if (((struct _pdc_obj_prop *)(info->obj_ptr))->tags != NULL) {
         ((struct _pdc_obj_prop *)(info->obj_ptr))->tags =
             (char *)PDC_free(((struct _pdc_obj_prop *)(info->obj_ptr))->tags);
@@ -740,9 +737,8 @@ PDCprop_set_obj_dims(pdcid_t obj_prop, PDC_int_t ndim, uint64_t *dims)
     if (ndim <= 0)
         PGOTO_ERROR(FAIL, "Invalid ndim size: %d", ndim);
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     prop = (struct _pdc_obj_prop *)(info->obj_ptr);
     if (ndim > (PDC_int_t)prop->obj_prop_pub->ndim) {
         if (prop->obj_prop_pub->ndim > 0)
@@ -765,9 +761,8 @@ PDCprop_set_obj_type(pdcid_t obj_prop, pdc_var_type_t type)
     struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     prop                     = (struct _pdc_obj_prop *)(info->obj_ptr);
     prop->obj_prop_pub->type = type;
 
@@ -784,9 +779,8 @@ PDCprop_set_obj_transfer_region_type(pdcid_t obj_prop, pdc_region_partition_t re
     struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     prop                                 = (struct _pdc_obj_prop *)(info->obj_ptr);
     prop->obj_prop_pub->region_partition = region_partition;
 
@@ -803,9 +797,8 @@ PDCprop_set_obj_consistency_semantics(pdcid_t obj_prop, pdc_consistency_t consis
     struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     prop                            = (struct _pdc_obj_prop *)(info->obj_ptr);
     prop->obj_prop_pub->consistency = consistency;
 
@@ -822,9 +815,8 @@ PDCprop_set_obj_buf(pdcid_t obj_prop, void *buf)
     struct _pdc_id_info * info;
     struct _pdc_obj_prop *prop;
 
-    info = PDC_find_id(obj_prop);
-    if (info == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object property ID");
+    if ((info = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_prop);
     prop      = (struct _pdc_obj_prop *)(info->obj_ptr);
     prop->buf = buf;
 
@@ -842,10 +834,8 @@ PDCobj_set_dims(pdcid_t obj_id, int ndim, uint64_t *dims)
     struct _pdc_obj_info *object;
     int                   reset;
 
-    info = PDC_find_id(obj_id);
-    if (info == NULL) {
-        LOG_ERROR("PDCobj_set_dims: cannnot find obj id");
-    }
+    if ((info = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_id);
     object = (struct _pdc_obj_info *)(info->obj_ptr);
     if (object->local_transfer_request_size) {
         // We do not allow setting obj dims while the region transfer requests are taking places.
@@ -879,15 +869,14 @@ PDCobj_get_dims(pdcid_t obj_id, int *ndim, uint64_t **dims)
     struct _pdc_id_info * info;
     struct _pdc_obj_info *object;
 
-    info = PDC_find_id(obj_id);
-    if (info == NULL) {
-        LOG_ERROR("PDCobj_set_dims: cannnot find obj id");
-    }
+    if ((info = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_id);
     object = (struct _pdc_obj_info *)(info->obj_ptr);
     *ndim  = object->obj_pt->obj_prop_pub->ndim;
     *dims  = (uint64_t *)PDC_malloc(sizeof(uint64_t) * ndim[0]);
     memcpy(*dims, object->obj_pt->obj_prop_pub->dims, sizeof(uint64_t) * ndim[0]);
 
+done:
     FUNC_LEAVE(ret_value);
 }
 
@@ -901,9 +890,8 @@ PDCobj_buf_retrieve(pdcid_t obj_id)
     struct _pdc_obj_info *object;
     void **               buffer;
 
-    info = PDC_find_id(obj_id);
-    if (info == NULL)
-        PGOTO_ERROR(NULL, "Cannot locate object ID");
+    if ((info = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", obj_id);
     object    = (struct _pdc_obj_info *)(info->obj_ptr);
     buffer    = &(object->obj_pt->buf);
     ret_value = buffer;
@@ -922,9 +910,8 @@ PDC_obj_get_info(pdcid_t obj_id)
     struct _pdc_id_info * obj;
     size_t                i;
 
-    obj = PDC_find_id(obj_id);
-    if (obj == NULL)
-        PGOTO_ERROR(NULL, "Cannot locate object");
+    if ((obj = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", obj_id);
 
     info      = (struct _pdc_obj_info *)(obj->obj_ptr);
     ret_value = (struct _pdc_obj_info *)PDC_calloc(1, sizeof(struct _pdc_obj_info));

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -73,10 +73,10 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
         p->cont_life    = PDC_PERSIST;
         new_id_c        = PDC_id_register(PDC_CONT_PROP, p);
         p->cont_prop_id = new_id_c;
-        if((id_info         = PDC_find_id(pdcid)) == NULL)
+        if ((id_info = PDC_find_id(pdcid)) == NULL)
             PGOTO_ERROR(0, "Failed to find PDC ID: %d", id_info);
-        pdc_class       = (struct _pdc_class *)(id_info->obj_ptr);
-        p->pdc          = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
+        pdc_class = (struct _pdc_class *)(id_info->obj_ptr);
+        p->pdc    = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
         if (p->pdc == NULL)
             PGOTO_ERROR(0, "PDC class allocation failed");
         if (pdc_class->name)
@@ -105,10 +105,10 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
         q->buf                            = NULL;
         new_id_o                          = PDC_id_register(PDC_OBJ_PROP, q);
         q->obj_prop_pub->obj_prop_id      = new_id_o;
-        if((id_info = PDC_find_id(pdcid)) == NULL)
+        if ((id_info = PDC_find_id(pdcid)) == NULL)
             PGOTO_ERROR(0, "Failed to find PDC ID: %d", pdcid);
-        pdc_class                         = (struct _pdc_class *)(id_info->obj_ptr);
-        q->pdc                            = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
+        pdc_class = (struct _pdc_class *)(id_info->obj_ptr);
+        q->pdc    = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
         if (q->pdc == NULL)
             PGOTO_ERROR(0, "PDC class allocation failed");
         if (pdc_class->name)
@@ -294,7 +294,7 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
     struct _pdc_cont_prop *info      = NULL;
     struct _pdc_id_info *  prop;
 
-    if((prop = PDC_find_id(cont_prop)) == NULL)
+    if ((prop = PDC_find_id(cont_prop)) == NULL)
         PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", cont_prop);
     info = (struct _pdc_cont_prop *)(prop->obj_ptr);
 
@@ -325,7 +325,7 @@ PDCobj_prop_get_info(pdcid_t obj_prop)
     struct _pdc_id_info * prop;
     size_t                i;
 
-    if((prop = PDC_find_id(obj_prop)) == NULL)
+    if ((prop = PDC_find_id(obj_prop)) == NULL)
         PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", obj_prop);
     info = (struct _pdc_obj_prop *)(prop->obj_ptr);
 
@@ -354,7 +354,7 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
     struct _pdc_id_info * prop;
     size_t                i;
 
-    if((prop = PDC_find_id(obj_prop)) == NULL)
+    if ((prop = PDC_find_id(obj_prop)) == NULL)
         PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", obj_prop);
     info = (struct _pdc_obj_prop *)(prop->obj_ptr);
 

--- a/src/api/pdc_obj/pdc_prop.c
+++ b/src/api/pdc_obj/pdc_prop.c
@@ -73,7 +73,8 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
         p->cont_life    = PDC_PERSIST;
         new_id_c        = PDC_id_register(PDC_CONT_PROP, p);
         p->cont_prop_id = new_id_c;
-        id_info         = PDC_find_id(pdcid);
+        if((id_info         = PDC_find_id(pdcid)) == NULL)
+            PGOTO_ERROR(0, "Failed to find PDC ID: %d", id_info);
         pdc_class       = (struct _pdc_class *)(id_info->obj_ptr);
         p->pdc          = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
         if (p->pdc == NULL)
@@ -104,7 +105,8 @@ PDCprop_create(pdc_prop_type_t type, pdcid_t pdcid)
         q->buf                            = NULL;
         new_id_o                          = PDC_id_register(PDC_OBJ_PROP, q);
         q->obj_prop_pub->obj_prop_id      = new_id_o;
-        id_info                           = PDC_find_id(pdcid);
+        if((id_info = PDC_find_id(pdcid)) == NULL)
+            PGOTO_ERROR(0, "Failed to find PDC ID: %d", pdcid);
         pdc_class                         = (struct _pdc_class *)(id_info->obj_ptr);
         q->pdc                            = (struct _pdc_class *)PDC_calloc(1, sizeof(struct _pdc_class));
         if (q->pdc == NULL)
@@ -136,9 +138,8 @@ PDCprop_obj_dup(pdcid_t prop_id)
     pdcid_t               new_id;
     size_t                i;
 
-    prop = PDC_find_id(prop_id);
-    if (prop == NULL)
-        PGOTO_ERROR(0, "Cannot locate object property");
+    if ((prop = PDC_find_id(prop_id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", prop_id);
     info = (struct _pdc_obj_prop *)(prop->obj_ptr);
 
     q = (struct _pdc_obj_prop *)PDC_calloc(1, sizeof(struct _pdc_obj_prop));
@@ -293,9 +294,8 @@ PDCcont_prop_get_info(pdcid_t cont_prop)
     struct _pdc_cont_prop *info      = NULL;
     struct _pdc_id_info *  prop;
 
-    prop = PDC_find_id(cont_prop);
-    if (prop == NULL)
-        PGOTO_ERROR(NULL, "Cannot allocate container property");
+    if((prop = PDC_find_id(cont_prop)) == NULL)
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", cont_prop);
     info = (struct _pdc_cont_prop *)(prop->obj_ptr);
 
     ret_value = (struct _pdc_cont_prop *)PDC_calloc(1, sizeof(struct _pdc_cont_prop));
@@ -325,9 +325,8 @@ PDCobj_prop_get_info(pdcid_t obj_prop)
     struct _pdc_id_info * prop;
     size_t                i;
 
-    prop = PDC_find_id(obj_prop);
-    if (prop == NULL)
-        PGOTO_ERROR(NULL, "Cannot locate object property");
+    if((prop = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", obj_prop);
     info = (struct _pdc_obj_prop *)(prop->obj_ptr);
 
     ret_value = (struct pdc_obj_prop *)PDC_calloc(1, sizeof(struct pdc_obj_prop));
@@ -355,9 +354,8 @@ PDC_obj_prop_get_info(pdcid_t obj_prop)
     struct _pdc_id_info * prop;
     size_t                i;
 
-    prop = PDC_find_id(obj_prop);
-    if (prop == NULL)
-        PGOTO_ERROR(NULL, "Cannot locate object property");
+    if((prop = PDC_find_id(obj_prop)) == NULL)
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", obj_prop);
     info = (struct _pdc_obj_prop *)(prop->obj_ptr);
 
     ret_value = (struct _pdc_obj_prop *)PDC_calloc(1, sizeof(struct _pdc_obj_prop));

--- a/src/api/pdc_query/pdc_query.c
+++ b/src/api/pdc_query/pdc_query.c
@@ -265,20 +265,10 @@ PDCquery_get_histogram(pdcid_t obj_id)
     FUNC_ENTER(NULL);
 
     perr_t ret_value = SUCCEED;
-    /*
-        struct _pdc_obj_info *obj_prop;
-        uint64_t              meta_id = 0;
-    */
-    if (PDC_find_id(obj_id) == NULL) {
-        ret_value = 1;
-    }
-    /*
-        if (PDC_find_id(obj_id) != NULL) {
-            obj_prop = PDC_obj_get_info(obj_id);
-            meta_id  = obj_prop->obj_info_pub->meta_id;
-        }
-        else
-            meta_id = obj_id;
-    */
+
+    if (PDC_find_id(obj_id) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", obj_id);
+
+done:
     FUNC_LEAVE(ret_value);
 }

--- a/src/api/pdc_region/pdc_region.c
+++ b/src/api/pdc_region/pdc_region.c
@@ -193,18 +193,18 @@ PDCbuf_obj_map(void *buf, pdc_var_type_t local_type, pdcid_t local_reg, pdcid_t 
     struct _pdc_id_info *   reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
 
-    reginfo1 = PDC_find_id(local_reg);
+    if((reginfo1 = PDC_find_id(local_reg)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_reg);
     reg1     = (struct pdc_region_info *)(reginfo1->obj_ptr);
 
-    objinfo2 = PDC_find_id(remote_obj);
-    if (objinfo2 == NULL)
-
-        PGOTO_ERROR(FAIL, "Cannot locate remote object ID");
+    if ((objinfo2 = PDC_find_id(remote_obj)) == NULL)
+        PGOTO_ERROR(FAIL,  "Failed to find PDC ID: %d", remote_obj);
     obj2           = (struct _pdc_obj_info *)(objinfo2->obj_ptr);
     remote_meta_id = obj2->obj_info_pub->meta_id;
     remote_type    = obj2->obj_pt->obj_prop_pub->type;
 
-    reginfo2 = PDC_find_id(remote_reg);
+    if((reginfo2 = PDC_find_id(remote_reg)) == NULL)
+        PGOTO_ERROR(0,  "Failed to find PDC ID: %d", remote_reg);
     reg2     = (struct pdc_region_info *)(reginfo2->obj_ptr);
     if (obj2->obj_pt->obj_prop_pub->ndim != reg2->ndim)
         PGOTO_ERROR(FAIL, "Remote object dimension and region dimension does not match");
@@ -239,9 +239,8 @@ PDCregion_get_info(pdcid_t reg_id)
     struct pdc_region_info *info      = NULL;
     struct _pdc_id_info *   region;
 
-    region = PDC_find_id(reg_id);
-    if (region == NULL)
-        PGOTO_ERROR(NULL, "Cannot locate region");
+    if ((region = PDC_find_id(reg_id)) == NULL)
+        PGOTO_ERROR(NULL,  "Failed to find PDC ID: %d", reg_id);
 
     info      = (struct pdc_region_info *)(region->obj_ptr);
     ret_value = info;
@@ -261,15 +260,13 @@ PDCbuf_obj_unmap(pdcid_t remote_obj_id, pdcid_t remote_reg_id)
     struct pdc_region_info *reginfo;
     pdc_var_type_t          data_type;
 
-    info1 = PDC_find_id(remote_obj_id);
-    if (info1 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object ID");
+    if ((info1 = PDC_find_id(remote_obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", remote_obj_id);
     object1   = (struct _pdc_obj_info *)(info1->obj_ptr);
     data_type = object1->obj_pt->obj_prop_pub->type;
 
-    info1 = PDC_find_id(remote_reg_id);
-    if (info1 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate region ID");
+    if ((info1 = PDC_find_id(remote_obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", remote_obj_id);
     reginfo = (struct pdc_region_info *)(info1->obj_ptr);
 
     ret_value =
@@ -296,9 +293,8 @@ PDCreg_obtain_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type, pdc
     pbool_t                 obtained;
     struct _pdc_id_info *   info1;
 
-    info1 = PDC_find_id(obj_id);
-    if (info1 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object ID");
+    if ((info1 = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_id);
     object_info = (struct _pdc_obj_info *)(info1->obj_ptr);
     // object_info = PDC_obj_get_info(obj_id);
     data_type   = object_info->obj_pt->obj_prop_pub->type;
@@ -323,9 +319,8 @@ PDCreg_release_lock(pdcid_t obj_id, pdcid_t reg_id, pdc_access_t access_type)
     pdc_var_type_t          data_type;
     struct _pdc_id_info *   info1;
 
-    info1 = PDC_find_id(obj_id);
-    if (info1 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate object ID");
+    if ((info1 = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_id);
     object_info = (struct _pdc_obj_info *)(info1->obj_ptr);
     // object_info = PDC_obj_get_info(obj_id);
     data_type   = object_info->obj_pt->obj_prop_pub->type;

--- a/src/api/pdc_region/pdc_region.c
+++ b/src/api/pdc_region/pdc_region.c
@@ -193,19 +193,19 @@ PDCbuf_obj_map(void *buf, pdc_var_type_t local_type, pdcid_t local_reg, pdcid_t 
     struct _pdc_id_info *   reginfo1, *reginfo2;
     struct pdc_region_info *reg1, *reg2;
 
-    if((reginfo1 = PDC_find_id(local_reg)) == NULL)
+    if ((reginfo1 = PDC_find_id(local_reg)) == NULL)
         PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_reg);
-    reg1     = (struct pdc_region_info *)(reginfo1->obj_ptr);
+    reg1 = (struct pdc_region_info *)(reginfo1->obj_ptr);
 
     if ((objinfo2 = PDC_find_id(remote_obj)) == NULL)
-        PGOTO_ERROR(FAIL,  "Failed to find PDC ID: %d", remote_obj);
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", remote_obj);
     obj2           = (struct _pdc_obj_info *)(objinfo2->obj_ptr);
     remote_meta_id = obj2->obj_info_pub->meta_id;
     remote_type    = obj2->obj_pt->obj_prop_pub->type;
 
-    if((reginfo2 = PDC_find_id(remote_reg)) == NULL)
-        PGOTO_ERROR(0,  "Failed to find PDC ID: %d", remote_reg);
-    reg2     = (struct pdc_region_info *)(reginfo2->obj_ptr);
+    if ((reginfo2 = PDC_find_id(remote_reg)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", remote_reg);
+    reg2 = (struct pdc_region_info *)(reginfo2->obj_ptr);
     if (obj2->obj_pt->obj_prop_pub->ndim != reg2->ndim)
         PGOTO_ERROR(FAIL, "Remote object dimension and region dimension does not match");
     for (i = 0; i < reg2->ndim; i++)
@@ -240,7 +240,7 @@ PDCregion_get_info(pdcid_t reg_id)
     struct _pdc_id_info *   region;
 
     if ((region = PDC_find_id(reg_id)) == NULL)
-        PGOTO_ERROR(NULL,  "Failed to find PDC ID: %d", reg_id);
+        PGOTO_ERROR(NULL, "Failed to find PDC ID: %d", reg_id);
 
     info      = (struct pdc_region_info *)(region->obj_ptr);
     ret_value = info;

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -870,7 +870,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     int                   set_output_buf = 0;
-    int ret_value = SUCCEED;
+    int                   ret_value      = SUCCEED;
 
     write_request_pkgs             = NULL;
     read_request_pkgs              = NULL;
@@ -1265,7 +1265,7 @@ merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merg
     pdc_transfer_request **all_transfer_request;
     uint64_t               new_buf_size = 0, copy_off = 0;
     uint64_t               offset_local[3], size_local[3], offset_remote[3], size_remote[3];
-    perr_t ret_value = SUCCEED;
+    perr_t                 ret_value = SUCCEED;
 
     all_transfer_request = (pdc_transfer_request **)PDC_calloc(size, sizeof(pdc_transfer_request *));
 
@@ -1704,7 +1704,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
         *temp;
 
     struct _pdc_id_info **transferinfos;
-    struct _pdc_id_info* transfer_info;
+    struct _pdc_id_info * transfer_info;
     pdc_transfer_request *transfer_request, *merged_request;
     pdcid_t *             my_transfer_request_id = transfer_request_id;
 
@@ -1721,7 +1721,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
 
     // Check if we merged the previous request
     if (size > PDC_MERGE_TRANSFER_MIN_COUNT) {
-        if((transferinfos[0] = PDC_find_id(transfer_request_id[0])) == NULL)
+        if ((transferinfos[0] = PDC_find_id(transfer_request_id[0])) == NULL)
             PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", transfer_request_id[0]);
         transfer_request = (pdc_transfer_request *)(transferinfos[0]->obj_ptr);
         if (transfer_request->merged_request_id != 0) {
@@ -1868,7 +1868,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     // Deal with merged read requests, need to copy a large buffer to each of the original request buf
     // TODO: Currently only supports 1D merging, so only consider 1D for now
     if (merged_xfer == 1) {
-        if((transfer_info = PDC_find_id(my_transfer_request_id[0])) == NULL)
+        if ((transfer_info = PDC_find_id(my_transfer_request_id[0])) == NULL)
             PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", my_transfer_request_id[0]);
         merged_request = (pdc_transfer_request *)(transfer_info->obj_ptr);
         for (i = 0; i < ori_size; ++i) {
@@ -1929,7 +1929,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     }
     transfer_requests = (pdc_transfer_request_wait_all_pkg **)PDC_free(transfer_requests);
     metadata_ids      = (uint64_t *)PDC_free(metadata_ids);
-    transferinfos      = (struct _pdc_id_info **)PDC_free(transferinfos);
+    transferinfos     = (struct _pdc_id_info **)PDC_free(transferinfos);
 
 done:
     FUNC_LEAVE(ret_value);

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -208,23 +208,16 @@ PDCregion_transfer_create(void *buf, pdc_access_t access_type, pdcid_t obj_id, p
 
     if (buf == NULL)
         PGOTO_ERROR(FAIL, "Client buffer was NULL");
-
-    reginfo1 = PDC_find_id(local_reg);
-    if (reginfo1 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate local region ID");
+    if ((reginfo1 = PDC_find_id(local_reg)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", local_reg);
     reg1 = (struct pdc_region_info *)(reginfo1->obj_ptr);
-
-    reginfo2 = PDC_find_id(remote_reg);
-    if (reginfo2 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate remote region ID");
+    if ((reginfo2 = PDC_find_id(remote_reg)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", remote_reg);
     reg2 = (struct pdc_region_info *)(reginfo2->obj_ptr);
-
-    objinfo2 = PDC_find_id(obj_id);
-    if (objinfo2 == NULL)
-        PGOTO_ERROR(FAIL, "Cannot locate remote object ID");
+    if ((objinfo2 = PDC_find_id(obj_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", obj_id);
 
     obj2 = (struct _pdc_obj_info *)(objinfo2->obj_ptr);
-    // remote_meta_id = obj2->obj_info_pub->meta_id;
 
     p                   = (pdc_transfer_request *)PDC_malloc(sizeof(pdc_transfer_request));
     p->obj_pointer      = obj2;
@@ -291,9 +284,8 @@ PDCregion_transfer_close(pdcid_t transfer_request_id)
     pdc_transfer_request *transfer_request;
     perr_t                ret_value = SUCCEED;
 
-    transferinfo = PDC_find_id(transfer_request_id);
-    if (transferinfo == NULL)
-        PGOTO_DONE(ret_value);
+    if ((transferinfo = PDC_find_id(transfer_request_id)) == NULL)
+        PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", transfer_request_id);
 
     transfer_request = (pdc_transfer_request *)(transferinfo->obj_ptr);
     if (transfer_request->local_region_offset)
@@ -878,6 +870,7 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     struct _pdc_id_info * transferinfo;
     pdc_transfer_request *transfer_request;
     int                   set_output_buf = 0;
+    int ret_value = SUCCEED;
 
     write_request_pkgs             = NULL;
     read_request_pkgs              = NULL;
@@ -887,14 +880,11 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     *posix_transfer_request_id_ptr = (pdcid_t *)PDC_malloc(sizeof(pdcid_t) * size);
 
     for (i = 0; i < size; ++i) {
-        transferinfo = PDC_find_id(transfer_request_id[i]);
-        if (NULL == transferinfo)
-            continue;
+        if ((transferinfo = PDC_find_id(transfer_request_id[i])) == NULL)
+            PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", transfer_request_id[i]);
         transfer_request = (pdc_transfer_request *)(transferinfo->obj_ptr);
-        if (transfer_request->metadata_id != NULL) {
-            LOG_ERROR("Cannot start transfer request\n");
-            FUNC_LEAVE(FAIL);
-        }
+        if (transfer_request->metadata_id != NULL)
+            PGOTO_ERROR(FAIL, "Cannot start transfer request");
         if (transfer_request->consistency == PDC_CONSISTENCY_POSIX) {
             posix_transfer_request_id_ptr[0][posix_size_ptr[0]] = transfer_request_id[i];
             posix_size_ptr[0]++;
@@ -918,10 +908,8 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
                                     &(transfer_request->n_obj_servers), &(transfer_request->obj_servers),
                                     &(transfer_request->sub_offsets), &(transfer_request->output_offsets),
                                     &(transfer_request->output_sizes), &(transfer_request->output_buf));
-            if (transfer_request->n_obj_servers == 0) {
-                LOG_ERROR("Error with static region partition, no server is selected");
-                FUNC_LEAVE(FAIL);
-            }
+            if (transfer_request->n_obj_servers == 0)
+                PGOTO_ERROR(FAIL, "Error with static region partition, no server is selected");
             for (j = 0; j < transfer_request->n_obj_servers; ++j) {
                 request_pkgs = (pdc_transfer_request_start_all_pkg *)PDC_malloc(
                     sizeof(pdc_transfer_request_start_all_pkg));
@@ -1046,7 +1034,9 @@ prepare_start_all_requests(pdcid_t *transfer_request_id, int size,
     else {
         *read_size_ptr = 0;
     }
-    FUNC_LEAVE(SUCCEED);
+
+done:
+    FUNC_LEAVE(ret_value);
 }
 
 static int
@@ -1275,32 +1265,22 @@ merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merg
     pdc_transfer_request **all_transfer_request;
     uint64_t               new_buf_size = 0, copy_off = 0;
     uint64_t               offset_local[3], size_local[3], offset_remote[3], size_remote[3];
+    perr_t ret_value = SUCCEED;
 
     all_transfer_request = (pdc_transfer_request **)PDC_calloc(size, sizeof(pdc_transfer_request *));
 
     for (i = 0; i < size; ++i) {
-        transferinfo = PDC_find_id(transfer_request_id[i]);
-        if (NULL == transferinfo) {
-            LOG_ERROR("Cannot find transfer request info\n");
-            FUNC_LEAVE(FAIL);
-        }
+        if ((transferinfo = PDC_find_id(transfer_request_id[i])) == NULL)
+            PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", transfer_request_id[i]);
         all_transfer_request[i] = (pdc_transfer_request *)(transferinfo->obj_ptr);
-        if (NULL == all_transfer_request[i]) {
-            LOG_ERROR("Transfer request is NULL\n");
-            FUNC_LEAVE(FAIL);
-        }
+        if (NULL == all_transfer_request[i])
+            PGOTO_ERROR(FAIL, "Transfer request is NULL\n");
 
         // Check if every requests are REGION_LOCAL
         if (all_transfer_request[i]->region_partition != PDC_REGION_LOCAL) {
             flag = 1;
             break;
         }
-
-        /* // Check if every requests are write operations */
-        /* if (all_transfer_request[i]->access_type != PDC_WRITE) { */
-        /*     flag = 1; */
-        /*     break; */
-        /* } */
 
         // Check if every requests are on the same object
         if (i == 0)
@@ -1361,6 +1341,7 @@ merge_transfer_request_ids(pdcid_t *transfer_request_id, int size, pdcid_t *merg
 
     all_transfer_request = (pdc_transfer_request **)PDC_free(all_transfer_request);
 
+done:
     FUNC_LEAVE(SUCCEED);
 }
 
@@ -1464,8 +1445,7 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
     size_t                unit;
     int                   i;
 
-    transferinfo = PDC_find_id(transfer_request_id);
-    if (NULL == transferinfo)
+    if ((transferinfo = PDC_find_id(transfer_request_id)) == NULL)
         PGOTO_DONE(ret_value);
 
     transfer_request = (pdc_transfer_request *)(transferinfo->obj_ptr);
@@ -1637,8 +1617,7 @@ PDCregion_transfer_status(pdcid_t transfer_request_id, pdc_transfer_status_t *co
     size_t                unit;
     int                   i;
 
-    transferinfo = PDC_find_id(transfer_request_id);
-    if (NULL == transferinfo) {
+    if ((transferinfo = PDC_find_id(transfer_request_id)) == NULL) {
         *completed = PDC_TRANSFER_STATUS_COMPLETE;
         PGOTO_DONE(ret_value);
     }
@@ -1724,7 +1703,8 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     pdc_transfer_request_wait_all_pkg **transfer_requests, *transfer_request_head, *transfer_request_end,
         *temp;
 
-    struct _pdc_id_info **transferinfo;
+    struct _pdc_id_info **transferinfos;
+    struct _pdc_id_info* transfer_info;
     pdc_transfer_request *transfer_request, *merged_request;
     pdcid_t *             my_transfer_request_id = transfer_request_id;
 
@@ -1733,7 +1713,7 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     if (!size)
         PGOTO_DONE(ret_value);
 
-    transferinfo = (struct _pdc_id_info **)PDC_malloc(size * sizeof(struct _pdc_id_info *));
+    transferinfos = (struct _pdc_id_info **)PDC_malloc(size * sizeof(struct _pdc_id_info *));
 
 #ifdef ENABLE_MPI
     t0 = MPI_Wtime();
@@ -1741,8 +1721,9 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
 
     // Check if we merged the previous request
     if (size > PDC_MERGE_TRANSFER_MIN_COUNT) {
-        transferinfo[0]  = PDC_find_id(transfer_request_id[0]);
-        transfer_request = (pdc_transfer_request *)(transferinfo[0]->obj_ptr);
+        if((transferinfos[0] = PDC_find_id(transfer_request_id[0])) == NULL)
+            PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", transfer_request_id[0]);
+        transfer_request = (pdc_transfer_request *)(transferinfos[0]->obj_ptr);
         if (transfer_request->merged_request_id != 0) {
             my_transfer_request_id = &transfer_request->merged_request_id;
             size                   = 1;
@@ -1753,10 +1734,9 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     total_requests        = 0;
     transfer_request_head = NULL;
     for (i = 0; i < size; ++i) {
-        transferinfo[i] = PDC_find_id(my_transfer_request_id[i]);
-        if (NULL == transferinfo[i])
+        if ((transferinfos[i] = PDC_find_id(my_transfer_request_id[i])) == NULL)
             continue;
-        transfer_request = (pdc_transfer_request *)(transferinfo[i]->obj_ptr);
+        transfer_request = (pdc_transfer_request *)(transferinfos[i]->obj_ptr);
         if (1 == transfer_request->is_done)
             continue;
         if (!transfer_request->metadata_id) {
@@ -1888,9 +1868,11 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     // Deal with merged read requests, need to copy a large buffer to each of the original request buf
     // TODO: Currently only supports 1D merging, so only consider 1D for now
     if (merged_xfer == 1) {
-        merged_request = (pdc_transfer_request *)(PDC_find_id(my_transfer_request_id[0])->obj_ptr);
+        if((transfer_info = PDC_find_id(my_transfer_request_id[0])) == NULL)
+            PGOTO_ERROR(FAIL, "Failed to find PDC ID: %d", my_transfer_request_id[0]);
+        merged_request = (pdc_transfer_request *)(transfer_info->obj_ptr);
         for (i = 0; i < ori_size; ++i) {
-            transfer_request = (pdc_transfer_request *)(PDC_find_id(transfer_request_id[i])->obj_ptr);
+            transfer_request = (pdc_transfer_request *)(transfer_info->obj_ptr);
             if (transfer_request->access_type == PDC_READ) {
                 if (is_first == 1)
                     merge_off = transfer_request->remote_region_offset[0];
@@ -1907,9 +1889,9 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     }
 
     for (i = 0; i < size; ++i) {
-        if (NULL == transferinfo[i])
+        if (NULL == transferinfos[i])
             continue;
-        transfer_request = (pdc_transfer_request *)(transferinfo[i]->obj_ptr);
+        transfer_request = (pdc_transfer_request *)(transferinfos[i]->obj_ptr);
         if (1 == transfer_request->is_done)
             continue;
         unit = transfer_request->unit;
@@ -1947,7 +1929,8 @@ PDCregion_transfer_wait_all(pdcid_t *transfer_request_id, int size)
     }
     transfer_requests = (pdc_transfer_request_wait_all_pkg **)PDC_free(transfer_requests);
     metadata_ids      = (uint64_t *)PDC_free(metadata_ids);
-    transferinfo      = (struct _pdc_id_info **)PDC_free(transferinfo);
+    transferinfos      = (struct _pdc_id_info **)PDC_free(transferinfos);
+
 done:
     FUNC_LEAVE(ret_value);
 }
@@ -1963,8 +1946,7 @@ PDCregion_transfer_wait(pdcid_t transfer_request_id)
     size_t                unit;
     int                   i;
 
-    transferinfo = PDC_find_id(transfer_request_id);
-    if (NULL == transferinfo)
+    if ((transferinfo = PDC_find_id(transfer_request_id)) == NULL)
         PGOTO_DONE(ret_value);
 
     transfer_request = (pdc_transfer_request *)(transferinfo->obj_ptr);

--- a/src/api/pdc_transform/pdc_transform.c
+++ b/src/api/pdc_transform/pdc_transform.c
@@ -234,7 +234,7 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
     thisFtn->readyState     = current_state;
     thisFtn->ftn_lastResult = 0;
     thisFtn->data           = buf;
-    id_info = PDC_find_id(dest_object_id);
+    id_info                 = PDC_find_id(dest_object_id);
     if (id_info)
         object1 = (struct _pdc_obj_info *)(id_info->obj_ptr);
     if (object1) {

--- a/src/api/pdc_transform/pdc_transform.c
+++ b/src/api/pdc_transform/pdc_transform.c
@@ -234,7 +234,7 @@ PDCbuf_map_transform_register(char *func, void *buf, pdcid_t src_region_id, pdci
     thisFtn->readyState     = current_state;
     thisFtn->ftn_lastResult = 0;
     thisFtn->data           = buf;
-    id_info                 = PDC_find_id(dest_object_id);
+    id_info = PDC_find_id(dest_object_id);
     if (id_info)
         object1 = (struct _pdc_obj_info *)(id_info->obj_ptr);
     if (object1) {

--- a/src/utils/pdc_interface.c
+++ b/src/utils/pdc_interface.c
@@ -156,8 +156,8 @@ PDC_dec_ref(pdcid_t id)
     struct PDC_id_type * type_ptr;
 
     /* General lookup of the ID */
-    if (NULL == (id_ptr = PDC_find_id(id)))
-        PGOTO_ERROR(FAIL, "Cannot locate ID");
+    if((id_ptr = PDC_find_id(id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", id);
 
     ret_value = hg_atomic_decr32(&(id_ptr->count));
     if (ret_value == 0) {
@@ -217,8 +217,8 @@ PDC_inc_ref(pdcid_t id)
     struct _pdc_id_info *id_ptr;
 
     /* General lookup of the ID */
-    if (NULL == (id_ptr = PDC_find_id(id)))
-        PGOTO_ERROR(0, "Cannot locate ID");
+    if ((id_ptr = PDC_find_id(id)) == NULL)
+        PGOTO_ERROR(0, "Failed to find PDC ID: %d", id);
 
     /* Set return value */
     ret_value = hg_atomic_incr32(&(id_ptr->count));

--- a/src/utils/pdc_interface.c
+++ b/src/utils/pdc_interface.c
@@ -156,7 +156,7 @@ PDC_dec_ref(pdcid_t id)
     struct PDC_id_type * type_ptr;
 
     /* General lookup of the ID */
-    if((id_ptr = PDC_find_id(id)) == NULL)
+    if ((id_ptr = PDC_find_id(id)) == NULL)
         PGOTO_ERROR(0, "Failed to find PDC ID: %d", id);
 
     ret_value = hg_atomic_decr32(&(id_ptr->count));


### PR DESCRIPTION
I kept getting segmentation faults stemming from the client code not checking `PDC_find_id`.
This pull request improves consistency and correctness by ensuring that all uses of `PDC_find_id()`:

- Immediately check for `NULL` return values to prevent invalid memory access.
- Use a standardized error message format when IDs are not found.

Error message changed to: "Failed to find PDC ID: id" where `id` is the `pdcid_t` that wasn't found.