### PR TITLE
Fix seg fault when mercury initialization fails

### DIFF
--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -539,9 +539,9 @@ hash_table_num_entries(HashTable *hash_table)
 {
     FUNC_ENTER(NULL);
 
-    if(hash_table == NULL) {
-	    LOG_WARNING("hash_table was NULL\n");
-	    FUNC_LEAVE(0);
+    if (hash_table == NULL) {
+        LOG_WARNING("hash_table was NULL\n");
+        FUNC_LEAVE(0);
     };
 
     FUNC_LEAVE(hash_table->entries);
@@ -554,13 +554,13 @@ hash_table_iterate(HashTable *hash_table, HashTableIterator *iterator)
 
     unsigned int chain;
 
-    if(hash_table == NULL) {
-	LOG_WARNING("hash_table was NULL\n");
-	FUNC_LEAVE_VOID();
+    if (hash_table == NULL) {
+        LOG_WARNING("hash_table was NULL\n");
+        FUNC_LEAVE_VOID();
     }
-    if(iterator == NULL) {
-	LOG_WARNING("iterator was NULL\n");
-	FUNC_LEAVE_VOID();
+    if (iterator == NULL) {
+        LOG_WARNING("iterator was NULL\n");
+        FUNC_LEAVE_VOID();
     }
 
     iterator->hash_table = hash_table;

--- a/src/commons/collections/pdc_hash_table.c
+++ b/src/commons/collections/pdc_hash_table.c
@@ -538,6 +538,12 @@ unsigned int
 hash_table_num_entries(HashTable *hash_table)
 {
     FUNC_ENTER(NULL);
+
+    if(hash_table == NULL) {
+	    LOG_WARNING("hash_table was NULL\n");
+	    FUNC_LEAVE(0);
+    };
+
     FUNC_LEAVE(hash_table->entries);
 }
 
@@ -547,6 +553,15 @@ hash_table_iterate(HashTable *hash_table, HashTableIterator *iterator)
     FUNC_ENTER(NULL);
 
     unsigned int chain;
+
+    if(hash_table == NULL) {
+	LOG_WARNING("hash_table was NULL\n");
+	FUNC_LEAVE_VOID();
+    }
+    if(iterator == NULL) {
+	LOG_WARNING("iterator was NULL\n");
+	FUNC_LEAVE_VOID();
+    }
 
     iterator->hash_table = hash_table;
 


### PR DESCRIPTION
Prevents segmentation fault that occurs when initialization of mercury fails.

```
[18:09:46.671414] [ERROR] [pdc_server.c:837] PDC_SERVER[0]: Error with HG_Init()
[18:09:46.671422] [ERROR] [pdc_server.c:2164] PDC_SERVER[0]: Error with PDC_Server_init
[ta1-pc:137951:0:137951] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x30)
==== backtrace (tid: 137951) ====
 0  /lib/x86_64-linux-gnu/libucs.so.0(ucs_handle_error+0x2ec) [0x741926849f2c]
 1  /lib/x86_64-linux-gnu/libucs.so.0(+0x3530d) [0x74192684b30d]
 2  /lib/x86_64-linux-gnu/libucs.so.0(+0x35619) [0x74192684b619]
 3  /lib/x86_64-linux-gnu/libc.so.6(+0x458d0) [0x7419270458d0]
 4  /home/ta1/src/workspace/source/pdc/build/bin/libpdc_commons.so(hash_table_num_entries+0x10) [0x741927453de1]
 5  /home/ta1/src/workspace/source/pdc/build/bin/libpdc_server_lib.so(PDC_Server_metadata_duplicate_check+0x58) [0x7419274b1a6a]
 6  /home/ta1/src/workspace/source/pdc/build/bin/libpdc_server_lib.so(PDC_Server_finalize+0x4d) [0x7419274a7cdd]
 7  /home/ta1/src/workspace/source/pdc/build/bin/libpdc_server_lib.so(server_run+0x2e9) [0x7419274abd10]
 8  ./pdc_server(main+0x24) [0x58ac12f6b8fe]
 9  /lib/x86_64-linux-gnu/libc.so.6(+0x2a578) [0x74192702a578]
10  /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x74192702a63b]
11  ./pdc_server(_start+0x25) [0x58ac12f6a1e5]
=================================
```

Here is the first seg fault backtrace:

```
Thread 1 "pdc_server" received signal SIGSEGV, Segmentation fault.
0x00007ffff7edfde1 in hash_table_num_entries (hash_table=0x0)
    at /home/ta1/src/workspace/source/pdc/src/commons/collections/pdc_hash_table.c:541
541	    FUNC_LEAVE(hash_table->entries);
(gdb) bt
#0  0x00007ffff7edfde1 in hash_table_num_entries (hash_table=0x0)
    at /home/ta1/src/workspace/source/pdc/src/commons/collections/pdc_hash_table.c:541
#1  0x00007ffff7f3da6a in PDC_Server_metadata_duplicate_check () at /home/ta1/src/workspace/source/pdc/src/server/pdc_server_metadata.c:1353
#2  0x00007ffff7f33cdd in PDC_Server_finalize () at /home/ta1/src/workspace/source/pdc/src/server/pdc_server.c:1022
#3  0x00007ffff7f37d10 in server_run (argc=1, argv=0x7fffffffdc08) at /home/ta1/src/workspace/source/pdc/src/server/pdc_server.c:2313
#4  0x00005555555578fe in main (argc=1, argv=0x7fffffffdc08) at /home/ta1/src/workspace/source/pdc/src/server/pdc_server_main.c:8
```

After fixing the first seg fault there was a second seg fault backtrace later in the codepath:

```
Thread 1 "pdc_server" received signal SIGSEGV, Segmentation fault.
0x00007ffff7edfeb1 in hash_table_iterate (hash_table=0x0, iterator=0x7fffffffda40)
    at /home/ta1/src/workspace/source/pdc/src/commons/collections/pdc_hash_table.c:563
563	    for (chain = 0; chain < hash_table->table_size; ++chain) {
(gdb) br
Breakpoint 1 at 0x7ffff7edfeb1: file /home/ta1/src/workspace/source/pdc/src/commons/collections/pdc_hash_table.c, line 563.
(gdb) bt
#0  0x00007ffff7edfeb1 in hash_table_iterate (hash_table=0x0, iterator=0x7fffffffda40)
    at /home/ta1/src/workspace/source/pdc/src/commons/collections/pdc_hash_table.c:563
#1  0x00007ffff7f3dc00 in PDC_Server_metadata_duplicate_check () at /home/ta1/src/workspace/source/pdc/src/server/pdc_server_metadata.c:1370
#2  0x00007ffff7f33cdd in PDC_Server_finalize () at /home/ta1/src/workspace/source/pdc/src/server/pdc_server.c:1022
#3  0x00007ffff7f37d10 in server_run (argc=1, argv=0x7fffffffdc08) at /home/ta1/src/workspace/source/pdc/src/server/pdc_server.c:2313
#4  0x00005555555578fe in main (argc=1, argv=0x7fffffffdc08) at /home/ta1/src/workspace/source/pdc/src/server/pdc_server_main.c:8
```

We now log warnings for these NULL pointers and exit without seg faulting:

```
~/src/workspace/source/pdc/build/bin ~/src/workspace/source/pdc
[INFO] PDC_SERVER[0]: PDC_DEBUG set to 1
[INFO] PDC_SERVER[0]: Using [./pdc_tmp/] as tmp dir, 1 OSTs, 1 OSTs per data file, 0% to BB
[INFO] PDC_SERVER[0]: Environment variable HG_TRANSPORT was NOT set
[INFO] PDC_SERVER[0]: Environment variable HG_HOST was NOT set
[INFO] PDC_SERVER[0]: Connection string: ofi+tcp://ta1-pc:7000
# [6336.845375] mercury->fatal: [error] /home/ta1/src/workspace/source/mercury/src/na/na_ofi.c:2832
 # na_ofi_verify_info(): No provider found for "tcp;ofi_rxm" provider on domain "ta1-pc"
[17:53:40.706707] [ERROR] [pdc_server.c:837] PDC_SERVER[0]: Error with HG_Init()
[17:53:40.706713] [ERROR] [pdc_server.c:2164] PDC_SERVER[0]: Error with PDC_Server_init
[WARNING] PDC_CLIENT[0]: hash_table was NULL
[INFO] PDC_SERVER[0]: Bloom filter says maybe 0 times out of 0
[INFO] PDC_SERVER[0]: Metadata duplicate check with 0 hash entries
[WARNING] PDC_CLIENT[0]: hash_table was NULL
[INFO] PDC_SERVER[0]:   ...No duplicates found
[17:53:40.706777] [ERROR] [pdc_server.c:990] PDC_SERVER[0]: pdc_remote_server_info_g was NULL
[17:53:40.706782] [ERROR] [pdc_server.c:1047] PDC_SERVER[0]: Error with PDC_Server_destroy_client_info
```