### PR TITLE
Fix metrics CI binary and bump version for release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -464,7 +464,7 @@ perlmutter-metrics:
         PDC_CLIENT_LOOKUP: "NONE"
         PDC_SERVER: "${PDC_BUILD_PATH}/perlmutter/metrics/bin/pdc_server"
         PDC_SERVER_CLOSE: "${PDC_BUILD_PATH}/perlmutter/metrics/bin/close_server"
-        PDC_CLIENT: "${PDC_BUILD_PATH}/perlmutter/metrics/bin/vpicio_mts"
+        PDC_CLIENT: "${PDC_BUILD_PATH}/perlmutter/metrics/bin/vpicio"
         PDC_JOB_OUTPUT: "pdc-metrics.log"
     script: 
         - hostname

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 # Version information
 #------------------------------------------------------------------------------
 set(PDC_VERSION_MAJOR "0")
-set(PDC_VERSION_MINOR "6")
+set(PDC_VERSION_MINOR "7")
 set(PDC_VERSION_PATCH "0")
 set(PDC_PACKAGE "pdc")
 set(PDC_PACKAGE_NAME "PDC")


### PR DESCRIPTION
# Description

Fix metrics CI binary by renaming `vpicio_mts` to `vpicio` per https://github.com/hpc-io/pdc/pull/297
Bump version to 0.7 in cmake for release

# What changes are proposed in this pull request?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
