### PR TITLE
BDCATS: call collective open if MPI enabled

### DIFF
--- a/src/tests/misc/bdcats.c
+++ b/src/tests/misc/bdcats.c
@@ -123,7 +123,11 @@ main(int argc, char **argv)
 #endif
         for (int i = 0; i < 8; i++) {
             sprintf(obj_name, "%s-%d", obj_names[i], iter);
+#ifdef ENABLE_MPI
+            obj_ids[i] = PDCobj_open_col(obj_name, pdc_id);
+#else
             obj_ids[i] = PDCobj_open(obj_name, pdc_id);
+#endif
             if (obj_ids[i] == 0) {
                 LOG_ERROR("Error getting an object id of %s from server\n", obj_name);
                 return FAIL;


### PR DESCRIPTION
Switch the collective open call if `ENABLE_MPI` is defined.

# What changes are proposed in this pull request?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
