### PR TITLE
Standardize Collective Client Calls

### DIFF
--- a/docs/source/client_api.rst
+++ b/docs/source/client_api.rst
@@ -95,7 +95,7 @@ quickly navigate to each subsection:
 .. doxygenfunction:: PDCcont_create
    :project: PDC
 
-.. doxygenfunction:: PDCcont_create_col
+.. doxygenfunction:: PDCcont_create_coll
    :project: PDC
 
 .. doxygenfunction:: PDCcont_open

--- a/docs/source/using_pdc.rst
+++ b/docs/source/using_pdc.rst
@@ -72,7 +72,7 @@ This is shown in the example below:
     pdcid_t cont_id = PDCcont_create("cont", cont_prop_id)
 
     // Collective container creation
-    pdcid_t cont_col_id = PDCcont_create_col("cont", cont_prop_id);
+    pdcid_t cont_col_id = PDCcont_create_coll("cont", cont_prop_id, MPI_COMM_WORLD);
 
 To open an existing container:
 
@@ -115,7 +115,7 @@ Below is an example of setting up an object property and creating objects:
     pdcid_t obj_id = PDCobj_create(cont_id, "obj", obj_prop_id);
 
     // Collective object creation
-    pdcid_t obj_col_id = PDCobj_create_col(cont_id, "obj", obj_prop_id, my_rank, comm);
+    pdcid_t obj_col_id = PDCobj_create_coll(cont_id, "obj", obj_prop_id, my_rank, comm);
 
 To open an existing object by name within a container:
 
@@ -141,7 +141,7 @@ Regions define logical subranges within a PDC object and are used to specify wha
 Transfers can be performed in three main modes:
 
 - Individually, with ``PDCregion_transfer_start()``
-- Collectively, with ``PDCregion_transfer_start_mpi()`` across MPI processes
+- Collectively, with ``PDCregion_transfer_start_coll()`` across MPI processes
 - In batches, with ``PDCregion_transfer_start_all()`` and ``PDCregion_transfer_wait_all()``
 
 Basic Region Transfer
@@ -177,7 +177,7 @@ If the transfer is intended to be performed collectively across MPI ranks, use:
 
 .. code-block:: C
 
-    PDCregion_transfer_start_mpi(xfer);
+    PDCregion_transfer_start_coll(transfer_request_id, comm);
 
 This function should be called by all processes participating in 
 the transfer and is useful for coordinated I/O in distributed 

--- a/docs/source/using_pdc.rst
+++ b/docs/source/using_pdc.rst
@@ -177,7 +177,8 @@ If the transfer is intended to be performed collectively across MPI ranks, use:
 
 .. code-block:: C
 
-    PDCregion_transfer_start_coll(transfer_request_id, comm);
+    MPI_Comm comm = MPI_COMM_WORLD;
+    PDCregion_transfer_start_coll(xfer, comm);
 
 This function should be called by all processes participating in 
 the transfer and is useful for coordinated I/O in distributed 

--- a/examples/bdcats.c
+++ b/examples/bdcats.c
@@ -103,7 +103,7 @@ main(int argc, char **argv)
 
         // open objects
 #ifdef ENABLE_MPI
-    obj_xx = PDCobj_open_col("obj-var-xx", pdc_id);
+    obj_xx = PDCobj_open_coll("obj-var-xx", pdc_id, MPI_COMM_WORLD);
 #else
     obj_xx   = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -112,7 +112,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_yy = PDCobj_open_col("obj-var-yy", pdc_id);
+    obj_yy = PDCobj_open_coll("obj-var-yy", pdc_id, MPI_COMM_WORLD);
 #else
     obj_yy   = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -121,7 +121,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_zz = PDCobj_open_col("obj-var-zz", pdc_id);
+    obj_zz = PDCobj_open_coll("obj-var-zz", pdc_id, MPI_COMM_WORLD);
 #else
     obj_zz   = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -130,7 +130,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_pxx = PDCobj_open_col("obj-var-pxx", pdc_id);
+    obj_pxx = PDCobj_open_coll("obj-var-pxx", pdc_id, MPI_COMM_WORLD);
 #else
     obj_pxx  = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -139,7 +139,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_pyy = PDCobj_open_col("obj-var-pyy", pdc_id);
+    obj_pyy = PDCobj_open_coll("obj-var-pyy", pdc_id, MPI_COMM_WORLD);
 #else
     obj_pyy  = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -148,7 +148,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_pzz = PDCobj_open_col("obj-var-pzz", pdc_id);
+    obj_pzz = PDCobj_open_coll("obj-var-pzz", pdc_id, MPI_COMM_WORLD);
 #else
     obj_pzz  = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -157,7 +157,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_id11 = PDCobj_open_col("id11", pdc_id);
+    obj_id11 = PDCobj_open_coll("id11", pdc_id, MPI_COMM_WORLD);
 #else
     obj_id11 = PDCobj_open("obj-var-xx", pdc_id);
 #endif
@@ -166,7 +166,7 @@ main(int argc, char **argv)
         exit(-1);
     }
 #ifdef ENABLE_MPI
-    obj_id22 = PDCobj_open_col("id22", pdc_id);
+    obj_id22 = PDCobj_open_coll("id22", pdc_id, MPI_COMM_WORLD);
 #else
     obj_id22 = PDCobj_open("obj-var-xx", pdc_id);
 #endif

--- a/examples/bdcats_batch.c
+++ b/examples/bdcats_batch.c
@@ -175,7 +175,7 @@ main(int argc, char **argv)
     for (i = 0; i < timestep; ++i) {
         sprintf(obj_name, "obj-var-xx %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_xx[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_xx[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_xx[i]   = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -185,7 +185,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "obj-var-yy %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_yy[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_yy[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_yy[i]   = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -195,7 +195,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "obj-var-zz %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_zz[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_zz[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_zz[i]   = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -205,7 +205,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "obj-var-pxx %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_pxx[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_pxx[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_pxx[i]  = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -215,7 +215,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "obj-var-pyy %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_pyy[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_pyy[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_pyy[i]  = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -225,7 +225,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "obj-var-pzz %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_pzz[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_pzz[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_pzz[i]  = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -235,7 +235,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "id11 %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_id11[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_id11[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_id11[i] = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -245,7 +245,7 @@ main(int argc, char **argv)
         }
         sprintf(obj_name, "id22 %" PRIu64 "", i);
 #ifdef ENABLE_MPI
-        obj_id22[i] = PDCobj_open_col(obj_name, pdc_id);
+        obj_id22[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
         obj_id22[i] = PDCobj_open(obj_name, pdc_id);
 #endif

--- a/examples/haccio.c
+++ b/examples/haccio.c
@@ -75,7 +75,7 @@ create_pdc_object(pdcid_t pdc_id, pdcid_t cont_id, const char *obj_name, pdc_var
     PDCprop_set_obj_user_id(*obj_prop, getuid());
     PDCprop_set_obj_app_name(*obj_prop, "HACCIO");
 
-    pdcid_t obj_id = PDCobj_create_mpi(cont_id, obj_name, *obj_prop, 0, comm);
+    pdcid_t obj_id = PDCobj_create_coll(cont_id, obj_name, *obj_prop, 0, comm);
     if (obj_id == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
@@ -117,7 +117,7 @@ main(int argc, char **argv)
     cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc_id);
 
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
 
     uint64_t offset = 0, offset_remote = mpi_rank * NUM_PARTICLES, mysize = NUM_PARTICLES;
 

--- a/examples/haccio_v2.c
+++ b/examples/haccio_v2.c
@@ -76,7 +76,7 @@ create_pdc_object(pdcid_t pdc_id, pdcid_t cont_id, const char *obj_name, pdc_var
     PDCprop_set_obj_app_name(*obj_prop, "HACCIO");
     PDCprop_set_obj_consistency_semantics(*obj_prop, PDC_CONSISTENCY_POSIX);
 
-    pdcid_t obj_id = PDCobj_create_mpi(cont_id, obj_name, *obj_prop, 0, comm);
+    pdcid_t obj_id = PDCobj_create_coll(cont_id, obj_name, *obj_prop, 0, comm);
     if (obj_id == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
@@ -119,7 +119,7 @@ main(int argc, char **argv)
     cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc_id);
 
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
 
     uint64_t offset = 0, offset_remote = mpi_rank * NUM_PARTICLES, mysize = NUM_PARTICLES;
 

--- a/examples/read_write_col_perf.c
+++ b/examples/read_write_col_perf.c
@@ -171,7 +171,7 @@ main(int argc, char **argv)
         // create first object
         sprintf(obj_name1, "o1_%d", i);
 #ifdef ENABLE_MPI
-        obj1 = PDCobj_create_mpi(cont, obj_name1, obj_prop, 0, MPI_COMM_WORLD);
+        obj1 = PDCobj_create_coll(cont, obj_name1, obj_prop, 0, MPI_COMM_WORLD);
 #else
         obj1 = PDCobj_create(cont, obj_name1, obj_prop);
 #endif

--- a/examples/tileio.c
+++ b/examples/tileio.c
@@ -43,7 +43,7 @@ create_pdc_object(pdcid_t pdc_id, pdcid_t cont_id, const char *obj_name, pdcid_t
     PDCprop_set_obj_app_name(*obj_prop, "mpi-tile-io");
     PDCprop_set_obj_tags(*obj_prop, "tag0=1");
 
-    pdcid_t obj_id = PDCobj_create_mpi(cont_id, obj_name, *obj_prop, 0, g_mpi_comm);
+    pdcid_t obj_id = PDCobj_create_coll(cont_id, obj_name, *obj_prop, 0, g_mpi_comm);
     if (obj_id == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
@@ -112,7 +112,7 @@ main(int argc, char **argv)
 
     // Create containter
     cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc_id);
-    cont_id   = PDCcont_create_col("c1", cont_prop);
+    cont_id   = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
 
     // Craete object (and its prop)
     obj_id = create_pdc_object(pdc_id, cont_id, "tile_io_obj", &obj_prop);

--- a/examples/tileio_v2.c
+++ b/examples/tileio_v2.c
@@ -43,7 +43,7 @@ create_pdc_object(pdcid_t pdc_id, pdcid_t cont_id, const char *obj_name, pdcid_t
     PDCprop_set_obj_app_name(*obj_prop, "mpi-tile-io");
     PDCprop_set_obj_tags(*obj_prop, "tag0=1");
 
-    pdcid_t obj_id = PDCobj_create_mpi(cont_id, obj_name, *obj_prop, 0, g_mpi_comm);
+    pdcid_t obj_id = PDCobj_create_coll(cont_id, obj_name, *obj_prop, 0, g_mpi_comm);
     if (obj_id == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
@@ -115,7 +115,7 @@ main(int argc, char **argv)
     // Init PDC
     pdc_id    = PDCinit("pdc");
     cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc_id);
-    cont_id   = PDCcont_create_col("c1", cont_prop);
+    cont_id   = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     obj_id    = create_pdc_object(pdc_id, cont_id, "tile_io_obj", &obj_prop);
 
     // Create region

--- a/examples/vpicio.c
+++ b/examples/vpicio.c
@@ -116,7 +116,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;
@@ -152,44 +152,44 @@ main(int argc, char **argv)
     obj_prop_id22 = PDCprop_obj_dup(obj_prop_xx);
     PDCprop_set_obj_type(obj_prop_id22, PDC_INT);
 
-    obj_xx = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
+    obj_xx = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
     if (obj_xx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
     }
 
-    obj_yy = PDCobj_create_mpi(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
+    obj_yy = PDCobj_create_coll(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
     if (obj_yy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-yy");
         exit(-1);
     }
-    obj_zz = PDCobj_create_mpi(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
+    obj_zz = PDCobj_create_coll(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
     if (obj_zz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-zz");
         exit(-1);
     }
-    obj_pxx = PDCobj_create_mpi(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
+    obj_pxx = PDCobj_create_coll(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
     if (obj_pxx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pxx");
         exit(-1);
     }
-    obj_pyy = PDCobj_create_mpi(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
+    obj_pyy = PDCobj_create_coll(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
     if (obj_pyy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pyy");
         exit(-1);
     }
-    obj_pzz = PDCobj_create_mpi(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
+    obj_pzz = PDCobj_create_coll(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
     if (obj_pzz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pzz");
         exit(-1);
     }
 
-    obj_id11 = PDCobj_create_mpi(cont_id, "id11", obj_prop_id11, 0, comm);
+    obj_id11 = PDCobj_create_coll(cont_id, "id11", obj_prop_id11, 0, comm);
     if (obj_id11 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id11");
         exit(-1);
     }
-    obj_id22 = PDCobj_create_mpi(cont_id, "id22", obj_prop_id22, 0, comm);
+    obj_id22 = PDCobj_create_coll(cont_id, "id22", obj_prop_id22, 0, comm);
     if (obj_id22 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id22");
         exit(-1);

--- a/examples/vpicio.c
+++ b/examples/vpicio.c
@@ -117,7 +117,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
+    cont_id = PDCcont_create_coll("c1", cont_prop, comm);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;

--- a/examples/vpicio_batch.c
+++ b/examples/vpicio_batch.c
@@ -149,7 +149,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;
@@ -250,49 +250,49 @@ main(int argc, char **argv)
 
     for (i = 0; i < timestamps; ++i) {
         sprintf(obj_name, "obj-var-xx %" PRIu64 "", i);
-        obj_xx[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_xx, 0, comm);
+        obj_xx[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_xx, 0, comm);
         if (obj_xx[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
             exit(-1);
         }
         sprintf(obj_name, "obj-var-yy %" PRIu64 "", i);
-        obj_yy[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_yy, 0, comm);
+        obj_yy[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_yy, 0, comm);
         if (obj_yy[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-yy");
             exit(-1);
         }
         sprintf(obj_name, "obj-var-zz %" PRIu64 "", i);
-        obj_zz[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_zz, 0, comm);
+        obj_zz[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_zz, 0, comm);
         if (obj_zz[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-zz");
             exit(-1);
         }
         sprintf(obj_name, "obj-var-pxx %" PRIu64 "", i);
-        obj_pxx[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_pxx, 0, comm);
+        obj_pxx[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_pxx, 0, comm);
         if (obj_pxx[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pxx");
             exit(-1);
         }
         sprintf(obj_name, "obj-var-pyy %" PRIu64 "", i);
-        obj_pyy[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_pyy, 0, comm);
+        obj_pyy[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_pyy, 0, comm);
         if (obj_pyy[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pyy");
             exit(-1);
         }
         sprintf(obj_name, "obj-var-pzz %" PRIu64 "", i);
-        obj_pzz[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_pzz, 0, comm);
+        obj_pzz[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_pzz, 0, comm);
         if (obj_pzz[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pzz");
             exit(-1);
         }
         sprintf(obj_name, "id11 %" PRIu64 "", i);
-        obj_id11[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_id11, 0, comm);
+        obj_id11[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_id11, 0, comm);
         if (obj_id11[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id11");
             exit(-1);
         }
         sprintf(obj_name, "id22 %" PRIu64 "", i);
-        obj_id22[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop_id22, 0, comm);
+        obj_id22[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop_id22, 0, comm);
         if (obj_id22[i] == 0) {
             LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id22");
             exit(-1);

--- a/examples/vpicio_batch.c
+++ b/examples/vpicio_batch.c
@@ -150,7 +150,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
+    cont_id = PDCcont_create_coll("c1", cont_prop, comm);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;

--- a/examples/vpicio_old.c
+++ b/examples/vpicio_old.c
@@ -113,7 +113,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;
@@ -149,44 +149,44 @@ main(int argc, char **argv)
     obj_prop_id22 = PDCprop_obj_dup(obj_prop_xx);
     PDCprop_set_obj_type(obj_prop_id22, PDC_INT);
 
-    obj_xx = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
+    obj_xx = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
     if (obj_xx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
     }
 
-    obj_yy = PDCobj_create_mpi(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
+    obj_yy = PDCobj_create_coll(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
     if (obj_yy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-yy");
         exit(-1);
     }
-    obj_zz = PDCobj_create_mpi(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
+    obj_zz = PDCobj_create_coll(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
     if (obj_zz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-zz");
         exit(-1);
     }
-    obj_pxx = PDCobj_create_mpi(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
+    obj_pxx = PDCobj_create_coll(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
     if (obj_pxx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pxx");
         exit(-1);
     }
-    obj_pyy = PDCobj_create_mpi(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
+    obj_pyy = PDCobj_create_coll(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
     if (obj_pyy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pyy");
         exit(-1);
     }
-    obj_pzz = PDCobj_create_mpi(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
+    obj_pzz = PDCobj_create_coll(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
     if (obj_pzz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pzz");
         exit(-1);
     }
 
-    obj_id11 = PDCobj_create_mpi(cont_id, "id11", obj_prop_id11, 0, comm);
+    obj_id11 = PDCobj_create_coll(cont_id, "id11", obj_prop_id11, 0, comm);
     if (obj_id11 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id11");
         exit(-1);
     }
-    obj_id22 = PDCobj_create_mpi(cont_id, "id22", obj_prop_id22, 0, comm);
+    obj_id22 = PDCobj_create_coll(cont_id, "id22", obj_prop_id22, 0, comm);
     if (obj_id22 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id22");
         exit(-1);

--- a/examples/vpicio_old.c
+++ b/examples/vpicio_old.c
@@ -119,7 +119,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
+    cont_id = PDCcont_create_coll("c1", cont_prop, comm);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;

--- a/src/api/include/pdc.h
+++ b/src/api/include/pdc.h
@@ -30,10 +30,7 @@
 #include "pdc_prop.h"
 #include "pdc_cont.h"
 #include "pdc_logger.h"
-
-#ifdef ENABLE_MPI
 #include "pdc_mpi.h"
-#endif
 
 #include "pdc_obj.h"
 #include "pdc_region.h"

--- a/src/api/pdc_obj/include/pdc_cont.h
+++ b/src/api/pdc_obj/include/pdc_cont.h
@@ -26,8 +26,8 @@
 #define PDC_CONT_H
 
 #include "pdc_public.h"
-#include "pdc_mpi.h"
 #ifdef ENABLE_MPI
+#include "pdc_mpi.h"
 #include <mpi.h>
 #endif
 

--- a/src/api/pdc_obj/include/pdc_cont.h
+++ b/src/api/pdc_obj/include/pdc_cont.h
@@ -26,6 +26,7 @@
 #define PDC_CONT_H
 
 #include "pdc_public.h"
+#include "pdc_mpi.h"
 #ifdef ENABLE_MPI
 #include <mpi.h>
 #endif
@@ -65,12 +66,7 @@ pdcid_t PDCcont_create(const char *cont_name, pdcid_t cont_create_prop);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, 
-#ifdef ENABLE_MPI
-  MPI_Comm comm);
-#else 
-  int comm);
-#endif
+pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, MPI_Comm comm);
 
 /**
  * Open a container
@@ -90,12 +86,7 @@ pdcid_t PDCcont_open(const char *cont_name, pdcid_t pdc_id);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_open_coll(const char *cont_name, pdcid_t pdc_id, 
-#ifdef ENABLE_MPI
-  MPI_Comm comm);
-#else 
-  int comm);
-#endif
+pdcid_t PDCcont_open_coll(const char *cont_name, pdcid_t pdc_id, MPI_Comm comm);
 
 /**
  * Close a container

--- a/src/api/pdc_obj/include/pdc_cont.h
+++ b/src/api/pdc_obj/include/pdc_cont.h
@@ -26,6 +26,9 @@
 #define PDC_CONT_H
 
 #include "pdc_public.h"
+#ifdef ENABLE_MPI
+#include <mpi.h>
+#endif
 
 typedef struct _pdc_id_info cont_handle;
 
@@ -62,7 +65,12 @@ pdcid_t PDCcont_create(const char *cont_name, pdcid_t cont_create_prop);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_create_col(const char *cont_name, pdcid_t cont_prop_id);
+pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, 
+#ifdef ENABLE_MPI
+  MPI_Comm comm);
+#else 
+  int comm);
+#endif
 
 /**
  * Open a container
@@ -82,7 +90,12 @@ pdcid_t PDCcont_open(const char *cont_name, pdcid_t pdc_id);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_open_col(const char *cont_name, pdcid_t pdc_id);
+pdcid_t PDCcont_open_coll(const char *cont_name, pdcid_t pdc_id, 
+#ifdef ENABLE_MPI
+  MPI_Comm comm);
+#else 
+  int comm);
+#endif
 
 /**
  * Close a container

--- a/src/api/pdc_obj/include/pdc_cont.h
+++ b/src/api/pdc_obj/include/pdc_cont.h
@@ -66,13 +66,13 @@ pdcid_t PDCcont_create(const char *cont_name, pdcid_t cont_create_prop);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, 
+pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id,
 #ifdef ENABLE_MPI
-		MPI_Comm
-#else 
-		int
+                            MPI_Comm
+#else
+                            int
 #endif
-		comm);
+                                comm);
 
 /**
  * Open a container
@@ -94,11 +94,11 @@ pdcid_t PDCcont_open(const char *cont_name, pdcid_t pdc_id);
  */
 pdcid_t PDCcont_open_coll(const char *cont_name, pdcid_t pdc_id,
 #ifdef ENABLE_MPI
-		MPI_Comm
-#else 
-		int
+                          MPI_Comm
+#else
+                          int
 #endif
-		comm);
+                              comm);
 
 /**
  * Close a container

--- a/src/api/pdc_obj/include/pdc_cont.h
+++ b/src/api/pdc_obj/include/pdc_cont.h
@@ -66,7 +66,13 @@ pdcid_t PDCcont_create(const char *cont_name, pdcid_t cont_create_prop);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, MPI_Comm comm);
+pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, 
+#ifdef ENABLE_MPI
+		MPI_Comm
+#else 
+		int
+#endif
+		comm);
 
 /**
  * Open a container
@@ -86,7 +92,13 @@ pdcid_t PDCcont_open(const char *cont_name, pdcid_t pdc_id);
  *
  * \return Container id on success/Zero on failure
  */
-pdcid_t PDCcont_open_coll(const char *cont_name, pdcid_t pdc_id, MPI_Comm comm);
+pdcid_t PDCcont_open_coll(const char *cont_name, pdcid_t pdc_id,
+#ifdef ENABLE_MPI
+		MPI_Comm
+#else 
+		int
+#endif
+		comm);
 
 /**
  * Close a container

--- a/src/api/pdc_obj/include/pdc_mpi.h
+++ b/src/api/pdc_obj/include/pdc_mpi.h
@@ -41,7 +41,7 @@
  *
  * \return Object ID on success/Zero on failure
  */
-pdcid_t PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_create_prop, int rank_id,
+pdcid_t PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_create_prop, int rank_id,
                           MPI_Comm comm);
 
 #endif /* PDC_MPI_H */

--- a/src/api/pdc_obj/include/pdc_mpi.h
+++ b/src/api/pdc_obj/include/pdc_mpi.h
@@ -42,6 +42,6 @@
  * \return Object ID on success/Zero on failure
  */
 pdcid_t PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_create_prop, int rank_id,
-                          MPI_Comm comm);
+                           MPI_Comm comm);
 
 #endif /* PDC_MPI_H */

--- a/src/api/pdc_obj/include/pdc_mpi.h
+++ b/src/api/pdc_obj/include/pdc_mpi.h
@@ -25,7 +25,9 @@
 #ifndef PDC_MPI_H
 #define PDC_MPI_H
 
+#ifdef ENABLE_MPI
 #include "mpi.h"
+#endif
 
 /*********************/
 /* Public Prototypes */
@@ -41,7 +43,12 @@
  *
  * \return Object ID on success/Zero on failure
  */
+#ifdef ENABLE_MPI
 pdcid_t PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_create_prop, int rank_id,
                            MPI_Comm comm);
+#else
+pdcid_t PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_create_prop, int rank_id,
+                           int comm);
+#endif
 
 #endif /* PDC_MPI_H */

--- a/src/api/pdc_obj/include/pdc_obj.h
+++ b/src/api/pdc_obj/include/pdc_obj.h
@@ -130,11 +130,11 @@ pdcid_t PDCobj_open(const char *obj_name, pdcid_t pdc_id);
  *
  * \return Object id on success/Zero on failure
  */
-pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id, 
+pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id,
 #ifdef ENABLE_MPI
-    MPI_Comm comm);
-#else 
-    int comm);
+                         MPI_Comm comm);
+#else
+                         int comm);
 #endif
 
 /**

--- a/src/api/pdc_obj/include/pdc_obj.h
+++ b/src/api/pdc_obj/include/pdc_obj.h
@@ -136,7 +136,7 @@ pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id,
 #else
                          int
 #endif
-			 comm);
+                             comm);
 
 /**
 

--- a/src/api/pdc_obj/include/pdc_obj.h
+++ b/src/api/pdc_obj/include/pdc_obj.h
@@ -132,10 +132,11 @@ pdcid_t PDCobj_open(const char *obj_name, pdcid_t pdc_id);
  */
 pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id,
 #ifdef ENABLE_MPI
-                         MPI_Comm comm);
+                         MPI_Comm
 #else
-                         int comm);
+                         int
 #endif
+			 comm);
 
 /**
 

--- a/src/api/pdc_obj/include/pdc_obj.h
+++ b/src/api/pdc_obj/include/pdc_obj.h
@@ -26,6 +26,9 @@
 #define PDC_OBJ_H
 
 #include "pdc_public.h"
+#ifdef ENABLE_MPI
+#include <mpi.h>
+#endif
 
 /*******************/
 /* Public Typedefs */
@@ -127,7 +130,12 @@ pdcid_t PDCobj_open(const char *obj_name, pdcid_t pdc_id);
  *
  * \return Object id on success/Zero on failure
  */
-pdcid_t PDCobj_open_col(const char *obj_name, pdcid_t pdc_id);
+pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id, 
+#ifdef ENABLE_MPI
+    MPI_Comm comm);
+#else 
+    int comm);
+#endif
 
 /**
 

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -114,8 +114,6 @@ PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id,
     struct _pdc_cont_prop *cont_prop = NULL;
     struct _pdc_id_info *  id_info   = NULL;
 
-    FUNC_ENTER(NULL);
-
     p = (struct _pdc_cont_info *)PDC_malloc(sizeof(struct _pdc_cont_info));
     if (!p)
         PGOTO_ERROR(0, "PDC container memory allocation failed");
@@ -305,7 +303,7 @@ PDCcont_open_coll(const char *cont_name, pdcid_t pdc,
     pdcid_t cont_meta_id;
 
     ret = PDC_Client_query_container_name_col(cont_name, &cont_meta_id);
-    if (ret == FAIL)
+    if (ret == FAIL || cont_meta_id == 0)
         PGOTO_ERROR(0, "Query container name failed");
     cont_id   = PDC_cont_create_local(pdc, cont_name, cont_meta_id);
     ret_value = cont_id;

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -98,8 +98,12 @@ done:
     FUNC_LEAVE(ret_value);
 }
 
-pdcid_t
-PDCcont_create_col(const char *cont_name, pdcid_t cont_prop_id)
+pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, 
+#ifdef ENABLE_MPI
+  MPI_Comm comm)
+#else 
+  int comm)
+#endif
 {
     FUNC_ENTER(NULL);
 
@@ -284,7 +288,13 @@ done:
 }
 
 pdcid_t
-PDCcont_open_col(const char *cont_name, pdcid_t pdc)
+PDCcont_open_coll(const char *cont_name, pdcid_t pdc, 
+#ifdef ENABLE_MPI
+    MPI_Comm comm
+#else 
+    int comm
+ #endif
+)
 {
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -98,11 +98,12 @@ done:
     FUNC_LEAVE(ret_value);
 }
 
-pdcid_t PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id, 
+pdcid_t
+PDCcont_create_coll(const char *cont_name, pdcid_t cont_prop_id,
 #ifdef ENABLE_MPI
-  MPI_Comm comm)
-#else 
-  int comm)
+                    MPI_Comm comm)
+#else
+                    int comm)
 #endif
 {
     FUNC_ENTER(NULL);
@@ -288,12 +289,12 @@ done:
 }
 
 pdcid_t
-PDCcont_open_coll(const char *cont_name, pdcid_t pdc, 
+PDCcont_open_coll(const char *cont_name, pdcid_t pdc,
 #ifdef ENABLE_MPI
-    MPI_Comm comm
-#else 
-    int comm
- #endif
+                  MPI_Comm comm
+#else
+                  int   comm
+#endif
 )
 {
     FUNC_ENTER(NULL);

--- a/src/api/pdc_obj/pdc_cont.c
+++ b/src/api/pdc_obj/pdc_cont.c
@@ -22,6 +22,7 @@
  * perform publicly and display publicly, and to permit other to do so.
  */
 
+#include "pdc_config.h"
 #include "pdc_cont.h"
 #include "pdc_cont_pkg.h"
 #include "pdc_malloc.h"

--- a/src/api/pdc_obj/pdc_mpi.c
+++ b/src/api/pdc_obj/pdc_mpi.c
@@ -30,7 +30,7 @@
 #include "pdc_mpi.h"
 
 pdcid_t
-PDCobj_create_mpi(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, int rank_id, MPI_Comm comm)
+PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, int rank_id, MPI_Comm comm)
 {
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_obj/pdc_mpi.c
+++ b/src/api/pdc_obj/pdc_mpi.c
@@ -29,6 +29,7 @@
 #include "pdc_client_connect.h"
 #include "pdc_mpi.h"
 
+#ifdef ENABLE_MPI
 pdcid_t
 PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, int rank_id, MPI_Comm comm)
 {
@@ -61,7 +62,27 @@ PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, i
 done:
     FUNC_LEAVE(ret_value);
 }
+#else
+pdcid_t
+PDCobj_create_coll(pdcid_t cont_id, const char *obj_name, pdcid_t obj_prop_id, int rank_id, int comm)
+{
+    FUNC_ENTER(NULL);
 
+    pdcid_t ret_value;
+
+    (void)rank_id;
+    (void)comm;
+
+    ret_value = PDC_obj_create(cont_id, obj_name, obj_prop_id, PDC_OBJ_GLOBAL);
+    if (ret_value == 0)
+        PGOTO_ERROR(0, "PDC_obj_create failed");
+
+done:
+    FUNC_LEAVE(ret_value);
+}
+#endif
+
+#ifdef ENABLE_MPI
 perr_t
 PDCobj_encode(pdcid_t obj_id, pdcid_t *meta_id)
 {
@@ -116,3 +137,4 @@ PDCobj_decode(pdcid_t obj_id, pdcid_t meta_id)
 done:
     FUNC_LEAVE(ret_value);
 }
+#endif

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -530,11 +530,12 @@ PDCobj_open(const char *obj_name, pdcid_t pdc)
     FUNC_LEAVE(ret_value);
 }
 
-pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id, 
+pdcid_t
+PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id,
 #ifdef ENABLE_MPI
-    MPI_Comm comm
-#else 
-    int comm
+                 MPI_Comm comm
+#else
+                 int comm
 #endif
 )
 {

--- a/src/api/pdc_obj/pdc_obj.c
+++ b/src/api/pdc_obj/pdc_obj.c
@@ -530,13 +530,18 @@ PDCobj_open(const char *obj_name, pdcid_t pdc)
     FUNC_LEAVE(ret_value);
 }
 
-pdcid_t
-PDCobj_open_col(const char *obj_name, pdcid_t pdc)
+pdcid_t PDCobj_open_coll(const char *obj_name, pdcid_t pdc_id, 
+#ifdef ENABLE_MPI
+    MPI_Comm comm
+#else 
+    int comm
+#endif
+)
 {
     FUNC_ENTER(NULL);
 
     pdcid_t ret_value;
-    ret_value = PDCobj_open_common(obj_name, pdc, 1);
+    ret_value = PDCobj_open_common(obj_name, pdc_id, 1);
 
     FUNC_LEAVE(ret_value);
 }

--- a/src/api/pdc_region/include/pdc_region.h
+++ b/src/api/pdc_region/include/pdc_region.h
@@ -152,7 +152,7 @@ perr_t PDCregion_transfer_start_all(pdcid_t *transfer_request_id, int size);
  *
  * \return Non-negative on success/Negative on failure
  */
-perr_t PDCregion_transfer_start_mpi(pdcid_t transfer_request_id, MPI_Comm comm);
+perr_t PDCregion_transfer_start_coll(pdcid_t transfer_request_id, MPI_Comm comm);
 
 /**
  * Start several region transfer requests (asynchronously), MPI collective version for better performance at
@@ -164,7 +164,7 @@ perr_t PDCregion_transfer_start_mpi(pdcid_t transfer_request_id, MPI_Comm comm);
  *
  * \return Non-negative on success/Negative on failure
  */
-perr_t PDCregion_transfer_start_all_mpi(pdcid_t *transfer_request_id, int size, MPI_Comm comm);
+perr_t PDCregion_transfer_start_all_coll(pdcid_t *transfer_request_id, int size, MPI_Comm comm);
 #endif
 
 /**

--- a/src/api/pdc_region/pdc_region.c
+++ b/src/api/pdc_region/pdc_region.c
@@ -39,7 +39,9 @@
 #include "pdc_transforms_pkg.h"
 #include "pdc_client_connect.h"
 #include "pdc_analysis_pkg.h"
+#ifdef ENABLE_MPI
 #include <mpi.h>
+#endif
 
 static perr_t pdc_region_close(struct pdc_region_info *op);
 static perr_t pdc_transfer_request_close();

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -1533,7 +1533,7 @@ PDCregion_transfer_start_all(pdcid_t *transfer_request_id, int size)
 
 #ifdef ENABLE_MPI
 perr_t
-PDCregion_transfer_start_all_mpi(pdcid_t *transfer_request_id, int size, MPI_Comm comm)
+PDCregion_transfer_start_all_coll(pdcid_t *transfer_request_id, int size, MPI_Comm comm)
 {
     FUNC_ENTER(NULL);
 
@@ -1575,7 +1575,7 @@ PDCregion_transfer_start_common(pdcid_t transfer_request_id,
     if (transfer_request->region_partition == PDC_REGION_DYNAMIC ||
         transfer_request->region_partition == PDC_REGION_LOCAL) {
 #ifdef ENABLE_MPI
-        PDCregion_transfer_start_all_mpi(&transfer_request_id, 1, comm);
+        PDCregion_transfer_start_all_coll(&transfer_request_id, 1, comm);
 #else
         PDCregion_transfer_start_all(&transfer_request_id, 1);
 #endif
@@ -1671,7 +1671,7 @@ PDCregion_transfer_start(pdcid_t transfer_request_id)
 
 #ifdef ENABLE_MPI
 perr_t
-PDCregion_transfer_start_mpi(pdcid_t transfer_request_id, MPI_Comm comm)
+PDCregion_transfer_start_coll(pdcid_t transfer_request_id, MPI_Comm comm)
 {
     FUNC_ENTER(NULL);
 

--- a/src/api/pdc_region/pdc_region_transfer.c
+++ b/src/api/pdc_region/pdc_region_transfer.c
@@ -43,7 +43,9 @@
 #include "pdc_client_connect.h"
 #include "pdc_analysis_pkg.h"
 #include "pdc_logger.h"
+#ifdef ENABLE_MPI
 #include <mpi.h>
+#endif
 
 #define PDC_MERGE_TRANSFER_MIN_COUNT 50
 
@@ -1282,7 +1284,12 @@ PDC_Client_pack_all_requests(int n_objs, pdc_transfer_request_start_all_pkg **tr
 }
 
 static perr_t
-PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requests, int size, MPI_Comm comm)
+PDC_Client_start_all_requests(pdc_transfer_request_start_all_pkg **transfer_requests, int size,
+#ifdef ENABLE_MPI
+                              MPI_Comm comm)
+#else
+                              int comm)
+#endif
 {
     FUNC_ENTER(NULL);
 

--- a/src/commons/utils/pdc_timing.c
+++ b/src/commons/utils/pdc_timing.c
@@ -4,7 +4,9 @@
 #include "pdc_malloc.h"
 #include "pdc_logger.h"
 #include "assert.h"
+#ifdef ENABLE_MPI
 #include "mpi.h"
+#endif
 
 #ifdef PDC_TIMING
 static double pdc_base_time;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -101,7 +101,6 @@ set(PROGRAMS
   region/region_transfer_set_dims_2D
   region/region_transfer_set_dims_3D
   query/query_data
-  misc/producer_waitall
 )
 
 # TODO: Check if import_vpic.c is needed. If yes, we have to add the following :
@@ -136,6 +135,7 @@ if(BUILD_MPI_TESTING)
     tags/kvtag_affix_query_scale
     tags/kvtag_add_get_benchmark
     tags/kvtag_add_get_scale
+    misc/producer_waitall
   )
 
 if(PDC_ENABLE_IDIOMS)

--- a/src/tests/cont/cont_getid.c
+++ b/src/tests/cont/cont_getid.c
@@ -57,10 +57,10 @@ main(int argc, char **argv)
 
 #ifdef ENABLE_MPI
     // create a container
-    TASSERT((cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
+    TASSERT((cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
     MPI_Barrier(MPI_COMM_WORLD);
-#else 
+#else
     // create a container
     TASSERT((cont_id = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
             "Call to PDCcont_create failed");

--- a/src/tests/cont/cont_getid.c
+++ b/src/tests/cont/cont_getid.c
@@ -54,12 +54,16 @@ main(int argc, char **argv)
     }
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc_id)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
-    // create a container
-    TASSERT((cont_id = PDCcont_create_col("c1", cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
 
 #ifdef ENABLE_MPI
+    // create a container
+    TASSERT((cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
     MPI_Barrier(MPI_COMM_WORLD);
+#else 
+    // create a container
+    TASSERT((cont_id = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
 #endif
     TASSERT((cont_id2 = PDCcont_open("c1", pdc_id)) > 0, "Call to PDCcont_open succeeded",
             "Call to PDCcont_open failed");

--- a/src/tests/cont/create_cont_coll.c
+++ b/src/tests/cont/create_cont_coll.c
@@ -49,8 +49,8 @@ main(int argc, char **argv)
     TASSERT((create_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
-    TASSERT((cont = PDCcont_create_coll("c1", create_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
+    TASSERT((cont = PDCcont_create_coll("c1", create_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
     // close a container
     TASSERT(PDCcont_close(cont) >= 0, "Call to PDCcont_close succeeded", "Call to PDCcont_close failed");
     // close a container property

--- a/src/tests/cont/create_cont_coll.c
+++ b/src/tests/cont/create_cont_coll.c
@@ -49,8 +49,8 @@ main(int argc, char **argv)
     TASSERT((create_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
-    TASSERT((cont = PDCcont_create_col("c1", create_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+    TASSERT((cont = PDCcont_create_coll("c1", create_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
     // close a container
     TASSERT(PDCcont_close(cont) >= 0, "Call to PDCcont_close succeeded", "Call to PDCcont_close failed");
     // close a container property

--- a/src/tests/cont/create_cont_coll.c
+++ b/src/tests/cont/create_cont_coll.c
@@ -49,8 +49,13 @@ main(int argc, char **argv)
     TASSERT((create_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
+#ifdef ENABLE_MPI
     TASSERT((cont = PDCcont_create_coll("c1", create_prop, MPI_COMM_WORLD)) != 0,
             "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
+#else
+    TASSERT((cont = PDCcont_create("c1", create_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
+#endif
     // close a container
     TASSERT(PDCcont_close(cont) >= 0, "Call to PDCcont_close succeeded", "Call to PDCcont_close failed");
     // close a container property

--- a/src/tests/cont/open_cont.c
+++ b/src/tests/cont/open_cont.c
@@ -51,10 +51,14 @@ main(int argc, char **argv)
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc_id)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
-    TASSERT((cont_id = PDCcont_create_col("c1", cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+
 #ifdef ENABLE_MPI
+    TASSERT((cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
     MPI_Barrier(MPI_COMM_WORLD);
+#else 
+    TASSERT((cont_id = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
 #endif
 
     TASSERT((cont_id2 = PDCcont_open("c1", pdc_id)) > 0, "Call to PDCcont_open succeeded",

--- a/src/tests/cont/open_cont.c
+++ b/src/tests/cont/open_cont.c
@@ -53,10 +53,10 @@ main(int argc, char **argv)
     // create a container
 
 #ifdef ENABLE_MPI
-    TASSERT((cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
+    TASSERT((cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
     MPI_Barrier(MPI_COMM_WORLD);
-#else 
+#else
     TASSERT((cont_id = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
             "Call to PDCcont_create failed");
 #endif

--- a/src/tests/deprecated/blocked_lock.c
+++ b/src/tests/deprecated/blocked_lock.c
@@ -89,7 +89,7 @@ main(int argc, char **argv)
     PDCprop_set_obj_app_name(obj_prop2, "VPICIO");
     PDCprop_set_obj_tags(obj_prop2, "tag0=1");
 
-    obj2 = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop2, 0);
+    obj2 = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop2, 0);
     if (obj2 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);

--- a/src/tests/deprecated/blocked_lock.c
+++ b/src/tests/deprecated/blocked_lock.c
@@ -89,7 +89,11 @@ main(int argc, char **argv)
     PDCprop_set_obj_app_name(obj_prop2, "VPICIO");
     PDCprop_set_obj_tags(obj_prop2, "tag0=1");
 
-    obj2 = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop2, 0);
+#ifdef ENABLE_MPI
+    obj2 = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop2, 0, MPI_COMM_WORLD);
+#else
+    obj2 = PDCobj_create(cont_id, "obj-var-xx", obj_prop2);
+#endif
     if (obj2 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);

--- a/src/tests/deprecated/buf_map_mpi_v2.c
+++ b/src/tests/deprecated/buf_map_mpi_v2.c
@@ -105,7 +105,7 @@ main(int argc, char **argv)
     obj2 = PDCobj_open("obj-var-xx", pdc_id);
     if (obj2 == 0) {
 #ifdef ENABLE_MPI
-        obj2 = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop2, 0, comm);
+        obj2 = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop2, 0, comm);
 #else
         obj2 = PDCobj_create(cont_id, "obj-var-xx", obj_prop2);
 #endif

--- a/src/tests/deprecated/buf_obj_map_mpi.c
+++ b/src/tests/deprecated/buf_obj_map_mpi.c
@@ -94,7 +94,7 @@ main(int argc, char **argv)
     PDCprop_set_obj_tags(obj_prop2, "tag0=1");
 
 #ifdef ENABLE_MPI
-    obj2 = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop2, 0, comm);
+    obj2 = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop2, 0, comm);
 #else
     obj2     = PDCobj_create(cont_id, "obj-var-xx", obj_prop2);
 #endif

--- a/src/tests/deprecated/obj_transformation.c
+++ b/src/tests/deprecated/obj_transformation.c
@@ -140,43 +140,43 @@ main(int argc, char **argv)
     PDCprop_set_obj_type(obj_prop_id22, PDC_INT);
 
 #ifdef ENABLE_MPI
-    obj_xx = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop_xx, 0, MPI_COMM_WORLD);
+    obj_xx = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop_xx, 0, MPI_COMM_WORLD);
     if (obj_xx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
     }
 
-    obj_yy = PDCobj_create_mpi(cont_id, "obj-var-yy", obj_prop_yy, 0, MPI_COMM_WORLD);
+    obj_yy = PDCobj_create_coll(cont_id, "obj-var-yy", obj_prop_yy, 0, MPI_COMM_WORLD);
     if (obj_yy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-yy");
         exit(-1);
     }
-    obj_zz = PDCobj_create_mpi(cont_id, "obj-var-zz", obj_prop_zz, 0, MPI_COMM_WORLD);
+    obj_zz = PDCobj_create_coll(cont_id, "obj-var-zz", obj_prop_zz, 0, MPI_COMM_WORLD);
     if (obj_zz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-zz");
         exit(-1);
     }
-    obj_pxx = PDCobj_create_mpi(cont_id, "obj-var-pxx", obj_prop_pxx, 0, MPI_COMM_WORLD);
+    obj_pxx = PDCobj_create_coll(cont_id, "obj-var-pxx", obj_prop_pxx, 0, MPI_COMM_WORLD);
     if (obj_pxx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pxx");
         exit(-1);
     }
-    obj_pyy = PDCobj_create_mpi(cont_id, "obj-var-pyy", obj_prop_pyy, 0, MPI_COMM_WORLD);
+    obj_pyy = PDCobj_create_coll(cont_id, "obj-var-pyy", obj_prop_pyy, 0, MPI_COMM_WORLD);
     if (obj_pyy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pyy");
         exit(-1);
     }
-    obj_pzz = PDCobj_create_mpi(cont_id, "obj-var-pzz", obj_prop_pzz, 0, MPI_COMM_WORLD);
+    obj_pzz = PDCobj_create_coll(cont_id, "obj-var-pzz", obj_prop_pzz, 0, MPI_COMM_WORLD);
     if (obj_pzz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pzz");
         exit(-1);
     }
-    obj_id11 = PDCobj_create_mpi(cont_id, "id11", obj_prop_id11, 0, MPI_COMM_WORLD);
+    obj_id11 = PDCobj_create_coll(cont_id, "id11", obj_prop_id11, 0, MPI_COMM_WORLD);
     if (obj_id11 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id11");
         exit(-1);
     }
-    obj_id22 = PDCobj_create_mpi(cont_id, "id22", obj_prop_id22, 0, MPI_COMM_WORLD);
+    obj_id22 = PDCobj_create_coll(cont_id, "id22", obj_prop_id22, 0, MPI_COMM_WORLD);
     if (obj_id22 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id22");
         exit(-1);

--- a/src/tests/deprecated/vpicio_old.c
+++ b/src/tests/deprecated/vpicio_old.c
@@ -113,7 +113,7 @@ main(int argc, char **argv)
         return 1;
     }
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return 1;
@@ -149,44 +149,44 @@ main(int argc, char **argv)
     obj_prop_id22 = PDCprop_obj_dup(obj_prop_xx);
     PDCprop_set_obj_type(obj_prop_id22, PDC_INT);
 
-    obj_xx = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
+    obj_xx = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
     if (obj_xx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
     }
 
-    obj_yy = PDCobj_create_mpi(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
+    obj_yy = PDCobj_create_coll(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
     if (obj_yy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-yy");
         exit(-1);
     }
-    obj_zz = PDCobj_create_mpi(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
+    obj_zz = PDCobj_create_coll(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
     if (obj_zz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-zz");
         exit(-1);
     }
-    obj_pxx = PDCobj_create_mpi(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
+    obj_pxx = PDCobj_create_coll(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
     if (obj_pxx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pxx");
         exit(-1);
     }
-    obj_pyy = PDCobj_create_mpi(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
+    obj_pyy = PDCobj_create_coll(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
     if (obj_pyy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pyy");
         exit(-1);
     }
-    obj_pzz = PDCobj_create_mpi(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
+    obj_pzz = PDCobj_create_coll(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
     if (obj_pzz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pzz");
         exit(-1);
     }
 
-    obj_id11 = PDCobj_create_mpi(cont_id, "id11", obj_prop_id11, 0, comm);
+    obj_id11 = PDCobj_create_coll(cont_id, "id11", obj_prop_id11, 0, comm);
     if (obj_id11 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id11");
         exit(-1);
     }
-    obj_id22 = PDCobj_create_mpi(cont_id, "id22", obj_prop_id22, 0, comm);
+    obj_id22 = PDCobj_create_coll(cont_id, "id22", obj_prop_id22, 0, comm);
     if (obj_id22 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id22");
         exit(-1);

--- a/src/tests/deprecated/vpicio_v2.c
+++ b/src/tests/deprecated/vpicio_v2.c
@@ -108,7 +108,7 @@ main(int argc, char **argv)
         LOG_ERROR("Failed to create container property");
 
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     if (cont_id <= 0)
         LOG_ERROR("Failed to create container");
 
@@ -144,44 +144,44 @@ main(int argc, char **argv)
     PDCprop_set_obj_type(obj_prop_id22, PDC_INT);
 
 #ifdef ENABLE_MPI
-    obj_xx = PDCobj_create_mpi(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
+    obj_xx = PDCobj_create_coll(cont_id, "obj-var-xx", obj_prop_xx, 0, comm);
     if (obj_xx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-xx");
         exit(-1);
     }
 
-    obj_yy = PDCobj_create_mpi(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
+    obj_yy = PDCobj_create_coll(cont_id, "obj-var-yy", obj_prop_yy, 0, comm);
     if (obj_yy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-yy");
         exit(-1);
     }
-    obj_zz = PDCobj_create_mpi(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
+    obj_zz = PDCobj_create_coll(cont_id, "obj-var-zz", obj_prop_zz, 0, comm);
     if (obj_zz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-zz");
         exit(-1);
     }
-    obj_pxx = PDCobj_create_mpi(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
+    obj_pxx = PDCobj_create_coll(cont_id, "obj-var-pxx", obj_prop_pxx, 0, comm);
     if (obj_pxx == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pxx");
         exit(-1);
     }
-    obj_pyy = PDCobj_create_mpi(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
+    obj_pyy = PDCobj_create_coll(cont_id, "obj-var-pyy", obj_prop_pyy, 0, comm);
     if (obj_pyy == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pyy");
         exit(-1);
     }
-    obj_pzz = PDCobj_create_mpi(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
+    obj_pzz = PDCobj_create_coll(cont_id, "obj-var-pzz", obj_prop_pzz, 0, comm);
     if (obj_pzz == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj-var-pzz");
         exit(-1);
     }
 
-    obj_id11 = PDCobj_create_mpi(cont_id, "id11", obj_prop_id11, 0, comm);
+    obj_id11 = PDCobj_create_coll(cont_id, "id11", obj_prop_id11, 0, comm);
     if (obj_id11 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id11");
         exit(-1);
     }
-    obj_id22 = PDCobj_create_mpi(cont_id, "id22", obj_prop_id22, 0, comm);
+    obj_id22 = PDCobj_create_coll(cont_id, "id22", obj_prop_id22, 0, comm);
     if (obj_id22 == 0) {
         LOG_ERROR("Error getting an object id of %s from server, exit...\n", "obj_id22");
         exit(-1);

--- a/src/tests/misc/bdcats.c
+++ b/src/tests/misc/bdcats.c
@@ -124,7 +124,7 @@ main(int argc, char **argv)
         for (int i = 0; i < 8; i++) {
             sprintf(obj_name, "%s-%d", obj_names[i], iter);
 #ifdef ENABLE_MPI
-            obj_ids[i] = PDCobj_open_col(obj_name, pdc_id);
+            obj_ids[i] = PDCobj_open_coll(obj_name, pdc_id, MPI_COMM_WORLD);
 #else
             obj_ids[i] = PDCobj_open(obj_name, pdc_id);
 #endif
@@ -158,7 +158,7 @@ main(int argc, char **argv)
 #endif
 
 #ifdef ENABLE_MPI
-        if (PDCregion_transfer_start_all_mpi(transfer_requests, 8, MPI_COMM_WORLD) != SUCCEED) {
+        if (PDCregion_transfer_start_all_coll(transfer_requests, 8, MPI_COMM_WORLD) != SUCCEED) {
 #else
         if (PDCregion_transfer_start_all(transfer_requests, 8) != SUCCEED) {
 #endif

--- a/src/tests/misc/producer_waitall.c
+++ b/src/tests/misc/producer_waitall.c
@@ -155,7 +155,7 @@ main(int argc, char **argv)
         LOG_ERROR("Failed to create container property");
     }
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
     }

--- a/src/tests/misc/read_write_col_perf.c
+++ b/src/tests/misc/read_write_col_perf.c
@@ -175,7 +175,7 @@ main(int argc, char **argv)
         sprintf(obj_name1, "o1_%d", i);
 
 #ifdef ENABLE_MPI
-        obj1 = PDCobj_create_mpi(cont, obj_name1, obj_prop, 0, MPI_COMM_WORLD);
+        obj1 = PDCobj_create_coll(cont, obj_name1, obj_prop, 0, MPI_COMM_WORLD);
 #else
         obj1 = PDCobj_create(cont, obj_name1, obj_prop);
 #endif
@@ -194,17 +194,25 @@ main(int argc, char **argv)
             ret_value = 1;
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_start(transfer_request);
+#ifdef ENABLE_MPI
         write_reg_transfer_start_time += MPI_Wtime() - start;
+#endif
         if (ret != SUCCEED) {
             LOG_INFO("PDCregion_transfer_start failed");
             ret_value = 1;
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_wait(transfer_request);
+#ifdef ENABLE_MPI
         write_reg_transfer_wait_time += MPI_Wtime() - start;
+#endif
         if (ret != SUCCEED) {
             LOG_INFO("PDCregion_transfer_wait failed");
             ret_value = 1;
@@ -254,18 +262,26 @@ main(int argc, char **argv)
             ret_value = 1;
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_start(transfer_request);
+#ifdef ENABLE_MPI
         read_reg_transfer_start_time += MPI_Wtime() - start;
+#endif
 
         if (ret != SUCCEED) {
             LOG_ERROR("PDCregion_transfer_start failed");
             exit(-1);
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_wait(transfer_request);
+#ifdef ENABLE_MPI
         read_reg_transfer_wait_time += MPI_Wtime() - start;
+#endif
 
         if (ret != SUCCEED) {
             LOG_ERROR("PDCregion_transfer_wait failed");

--- a/src/tests/misc/read_write_col_perf.c
+++ b/src/tests/misc/read_write_col_perf.c
@@ -197,7 +197,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_start(transfer_request);
+        ret = PDCregion_transfer_start(transfer_request);
 #ifdef ENABLE_MPI
         write_reg_transfer_start_time += MPI_Wtime() - start;
 #endif
@@ -209,7 +209,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_wait(transfer_request);
+        ret = PDCregion_transfer_wait(transfer_request);
 #ifdef ENABLE_MPI
         write_reg_transfer_wait_time += MPI_Wtime() - start;
 #endif
@@ -265,7 +265,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_start(transfer_request);
+        ret = PDCregion_transfer_start(transfer_request);
 #ifdef ENABLE_MPI
         read_reg_transfer_start_time += MPI_Wtime() - start;
 #endif
@@ -278,7 +278,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_wait(transfer_request);
+        ret = PDCregion_transfer_wait(transfer_request);
 #ifdef ENABLE_MPI
         read_reg_transfer_wait_time += MPI_Wtime() - start;
 #endif

--- a/src/tests/misc/read_write_perf.c
+++ b/src/tests/misc/read_write_perf.c
@@ -186,7 +186,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_start(transfer_request);
+        ret = PDCregion_transfer_start(transfer_request);
 #ifdef ENABLE_MPI
         write_reg_transfer_start_time += MPI_Wtime() - start;
 #endif
@@ -199,7 +199,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_wait(transfer_request);
+        ret = PDCregion_transfer_wait(transfer_request);
 #ifdef ENABLE_MPI
         write_reg_transfer_wait_time += MPI_Wtime() - start;
 #endif
@@ -257,7 +257,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_start(transfer_request);
+        ret = PDCregion_transfer_start(transfer_request);
 #ifdef ENABLE_MPI
         read_reg_transfer_start_time += MPI_Wtime() - start;
 #endif
@@ -270,7 +270,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_MPI
         start = MPI_Wtime();
 #endif
-        ret   = PDCregion_transfer_wait(transfer_request);
+        ret = PDCregion_transfer_wait(transfer_request);
 #ifdef ENABLE_MPI
         read_reg_transfer_wait_time += MPI_Wtime() - start;
 #endif

--- a/src/tests/misc/read_write_perf.c
+++ b/src/tests/misc/read_write_perf.c
@@ -183,18 +183,26 @@ main(int argc, char **argv)
             ret_value = 1;
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_start(transfer_request);
+#ifdef ENABLE_MPI
         write_reg_transfer_start_time += MPI_Wtime() - start;
+#endif
 
         if (ret != SUCCEED) {
             LOG_ERROR("PDCregion_transfer_start failed");
             ret_value = 1;
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_wait(transfer_request);
+#ifdef ENABLE_MPI
         write_reg_transfer_wait_time += MPI_Wtime() - start;
+#endif
 
         if (ret != SUCCEED) {
             LOG_ERROR("PDCregion_transfer_wait failed");
@@ -246,18 +254,26 @@ main(int argc, char **argv)
             ret_value = 1;
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_start(transfer_request);
+#ifdef ENABLE_MPI
         read_reg_transfer_start_time += MPI_Wtime() - start;
+#endif
 
         if (ret != SUCCEED) {
             LOG_INFO("PDCregion_transfer_start failed");
             exit(-1);
         }
 
+#ifdef ENABLE_MPI
         start = MPI_Wtime();
+#endif
         ret   = PDCregion_transfer_wait(transfer_request);
+#ifdef ENABLE_MPI
         read_reg_transfer_wait_time += MPI_Wtime() - start;
+#endif
 
         if (ret != SUCCEED) {
             LOG_ERROR("PDCregion_transfer_wait failed");

--- a/src/tests/misc/vpicio.c
+++ b/src/tests/misc/vpicio.c
@@ -109,7 +109,7 @@ main(int argc, char **argv)
     // create a container
 #ifdef ENABLE_MPI
     cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
-#else 
+#else
     cont_id = PDCcont_create("c1", cont_prop);
 #endif
     if (cont_id <= 0) {

--- a/src/tests/misc/vpicio.c
+++ b/src/tests/misc/vpicio.c
@@ -107,7 +107,11 @@ main(int argc, char **argv)
         return FAIL;
     }
     // create a container
-    cont_id = PDCcont_create_col("c1", cont_prop);
+#ifdef ENABLE_MPI
+    cont_id = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD);
+#else 
+    cont_id = PDCcont_create("c1", cont_prop);
+#endif
     if (cont_id <= 0) {
         LOG_ERROR("Failed to create container");
         return FAIL;
@@ -160,7 +164,7 @@ main(int argc, char **argv)
             sprintf(obj_name, "%s-%d", obj_names[i], iter);
             pdcid_t obj_prop = (i < 7) ? obj_prop_float : obj_prop_int;
 #ifdef ENABLE_MPI
-            obj_ids[i] = PDCobj_create_mpi(cont_id, obj_name, obj_prop, 0, MPI_COMM_WORLD);
+            obj_ids[i] = PDCobj_create_coll(cont_id, obj_name, obj_prop, 0, MPI_COMM_WORLD);
 #else
             obj_ids[i] = PDCobj_create(cont_id, obj_name, obj_prop);
 #endif
@@ -194,7 +198,7 @@ main(int argc, char **argv)
 #endif
 
 #ifdef ENABLE_MPI
-        if (PDCregion_transfer_start_all_mpi(transfer_requests, 8, MPI_COMM_WORLD) != SUCCEED) {
+        if (PDCregion_transfer_start_all_coll(transfer_requests, 8, MPI_COMM_WORLD) != SUCCEED) {
 #else
         if (PDCregion_transfer_start_all(transfer_requests, 8) != SUCCEED) {
 #endif

--- a/src/tests/obj/create_obj_coll.c
+++ b/src/tests/obj/create_obj_coll.c
@@ -58,7 +58,7 @@ main(int argc, char **argv)
     // create first object
     sprintf(obj_name1, "o1");
 #ifdef ENABLE_MPI
-    TASSERT((obj1 = PDCobj_create_mpi(cont, obj_name1, obj_prop, 0, MPI_COMM_WORLD)) != 0,
+    TASSERT((obj1 = PDCobj_create_coll(cont, obj_name1, obj_prop, 0, MPI_COMM_WORLD)) != 0,
             "Call to PDCobj_create succeeded", "Call to PDCobj_create failed");
 #else
     TASSERT((obj1 = PDCobj_create(cont, obj_name1, obj_prop)) != 0, "Call to PDCobj_create succeeded",
@@ -68,7 +68,7 @@ main(int argc, char **argv)
     // create second object
     sprintf(obj_name2, "o2");
 #ifdef ENABLE_MPI
-    TASSERT((obj2 = PDCobj_create_mpi(cont, obj_name2, obj_prop, 0, MPI_COMM_WORLD)) != 0,
+    TASSERT((obj2 = PDCobj_create_coll(cont, obj_name2, obj_prop, 0, MPI_COMM_WORLD)) != 0,
             "Call to PDCobj_create succeeded", "Call to PDCobj_create failed");
 #else
     TASSERT((obj2 = PDCobj_create(cont, obj_name2, obj_prop)) != 0, "Call to PDCobj_create succeeded",

--- a/src/tests/obj/create_obj_scale.c
+++ b/src/tests/obj/create_obj_scale.c
@@ -123,8 +123,8 @@ main(int argc, char **argv)
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
-    TASSERT((cont = PDCcont_create_col("c1", cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
 
     char *cont_tags = "cont_tags0=123";
     if (rank == 0) {

--- a/src/tests/obj/create_obj_scale.c
+++ b/src/tests/obj/create_obj_scale.c
@@ -123,8 +123,8 @@ main(int argc, char **argv)
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
-    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
+    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
 
     char *cont_tags = "cont_tags0=123";
     if (rank == 0) {

--- a/src/tests/obj/create_obj_scale.c
+++ b/src/tests/obj/create_obj_scale.c
@@ -123,8 +123,13 @@ main(int argc, char **argv)
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
+#ifdef ENABLE_MPI
     TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0,
             "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
+#else
+    TASSERT((cont = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
+#endif
 
     char *cont_tags = "cont_tags0=123";
     if (rank == 0) {

--- a/src/tests/obj/obj_life.c
+++ b/src/tests/obj/obj_life.c
@@ -47,9 +47,9 @@ main(int argc, char **argv)
             "Call to PDCprop_create failed");
 #ifdef ENABLE_MPI
     // create a container
-    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
-#else 
+    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
+#else
     TASSERT((cont = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
             "Call to PDCcont_create failed");
 #endif

--- a/src/tests/obj/obj_life.c
+++ b/src/tests/obj/obj_life.c
@@ -45,9 +45,14 @@ main(int argc, char **argv)
     // create a container property
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
+#ifdef ENABLE_MPI
     // create a container
-    TASSERT((cont = PDCcont_create_col("c1", cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
+#else 
+    TASSERT((cont = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
+#endif
     // close a container
     TASSERT(PDCcont_close(cont) >= 0, "Call to PDCcont_close succeeded", "Call to PDCcont_close failed");
     // close a container property

--- a/src/tests/obj/obj_round_robin_io.c
+++ b/src/tests/obj/obj_round_robin_io.c
@@ -123,9 +123,9 @@ main(int argc, char **argv)
     // create a container
     sprintf(cont_name, "c");
 #ifdef ENABLE_MPI
-    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
-#else 
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
+#else
     TASSERT((cont = PDCcont_create(cont_name, cont_prop)) != 0, "Call to PDCcont_create succeeded",
             "Call to PDCcont_create failed");
 #endif

--- a/src/tests/obj/obj_round_robin_io.c
+++ b/src/tests/obj/obj_round_robin_io.c
@@ -122,8 +122,13 @@ main(int argc, char **argv)
             "Call to PDCprop_create failed");
     // create a container
     sprintf(cont_name, "c");
-    TASSERT((cont = PDCcont_create_col(cont_name, cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+#ifdef ENABLE_MPI
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
+#else 
+    TASSERT((cont = PDCcont_create(cont_name, cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
+#endif
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");

--- a/src/tests/obj/obj_round_robin_io_all.c
+++ b/src/tests/obj/obj_round_robin_io_all.c
@@ -128,9 +128,9 @@ main(int argc, char **argv)
     // create a container
     sprintf(cont_name, "c");
 #ifdef ENABLE_MPI
-    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
-#else 
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
+#else
     TASSERT((cont = PDCcont_create(cont_name, cont_prop)) != 0, "Call to PDCcont_create succeeded",
             "Call to PDCcont_create failed");
 #endif

--- a/src/tests/obj/obj_round_robin_io_all.c
+++ b/src/tests/obj/obj_round_robin_io_all.c
@@ -127,8 +127,13 @@ main(int argc, char **argv)
             "Call to PDCprop_create failed");
     // create a container
     sprintf(cont_name, "c");
-    TASSERT((cont = PDCcont_create_col(cont_name, cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+#ifdef ENABLE_MPI
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
+#else 
+    TASSERT((cont = PDCcont_create(cont_name, cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
+#endif
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");

--- a/src/tests/obj/open_obj_round_robin.c
+++ b/src/tests/obj/open_obj_round_robin.c
@@ -64,7 +64,7 @@ main(int argc, char **argv)
     }
     // create a container
     sprintf(cont_name, "c");
-    cont = PDCcont_create_col(cont_name, cont_prop);
+    cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD);
     // cont = PDCcont_create(cont_name, cont_prop);
     if (cont > 0) {
         LOG_INFO("Rank %d Create a container %s\n", rank, cont_name);

--- a/src/tests/obj/open_obj_round_robin.c
+++ b/src/tests/obj/open_obj_round_robin.c
@@ -64,8 +64,11 @@ main(int argc, char **argv)
     }
     // create a container
     sprintf(cont_name, "c");
+#ifdef ENABLE_MPI
     cont = PDCcont_create_coll(cont_name, cont_prop, MPI_COMM_WORLD);
-    // cont = PDCcont_create(cont_name, cont_prop);
+#else
+    cont = PDCcont_create(cont_name, cont_prop);
+#endif
     if (cont > 0) {
         LOG_INFO("Rank %d Create a container %s\n", rank, cont_name);
     }

--- a/src/tests/obj/read_obj.c
+++ b/src/tests/obj/read_obj.c
@@ -118,8 +118,8 @@ main(int argc, char **argv)
             "Call to PDCprop_create failed");
     // create a container
     sprintf(cont_name, "c%d", rank);
-    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, comm)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, comm)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");

--- a/src/tests/obj/read_obj.c
+++ b/src/tests/obj/read_obj.c
@@ -118,8 +118,8 @@ main(int argc, char **argv)
             "Call to PDCprop_create failed");
     // create a container
     sprintf(cont_name, "c%d", rank);
-    TASSERT((cont = PDCcont_create_col(cont_name, cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, comm)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
@@ -144,7 +144,7 @@ main(int argc, char **argv)
 
     // Create a object
 #ifdef ENABLE_MPI
-    global_obj = PDCobj_create_mpi(cont, obj_name, obj_prop, 0, comm);
+    global_obj = PDCobj_create_coll(cont, obj_name, obj_prop, 0, comm);
 #else
     global_obj = PDCobj_create(cont, obj_name, obj_prop);
 #endif

--- a/src/tests/obj/read_obj_shared.c
+++ b/src/tests/obj/read_obj_shared.c
@@ -114,8 +114,8 @@ main(int argc, char **argv)
     // create a container
     /* sprintf(cont_name, "c%d", rank); */
     sprintf(cont_name, "c");
-    TASSERT((cont = PDCcont_create_col(cont_name, cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, comm)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
@@ -140,7 +140,7 @@ main(int argc, char **argv)
 
     // Create a object
 #ifdef ENABLE_MPI
-    TASSERT((global_obj = PDCobj_create_mpi(cont, obj_name, obj_prop, 0, comm)) != 0,
+    TASSERT((global_obj = PDCobj_create_coll(cont, obj_name, obj_prop, 0, comm)) != 0,
             "Call to PDCobj_create succeeded", "Call to PDCobj_create failed");
 #else
     TASSERT((global_obj = PDCobj_create(cont, obj_name, obj_prop)) != 0, "Call to PDCobj_create succeeded",

--- a/src/tests/obj/read_obj_shared.c
+++ b/src/tests/obj/read_obj_shared.c
@@ -114,8 +114,8 @@ main(int argc, char **argv)
     // create a container
     /* sprintf(cont_name, "c%d", rank); */
     sprintf(cont_name, "c");
-    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, comm)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
+    TASSERT((cont = PDCcont_create_coll(cont_name, cont_prop, comm)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");

--- a/src/tests/obj/write_obj_shared.c
+++ b/src/tests/obj/write_obj_shared.c
@@ -148,7 +148,7 @@ main(int argc, char **argv)
     PDCprop_set_obj_tags(obj_prop, "tag0=1");
 
     // Create a object
-    global_obj = PDCobj_create_mpi(cont, obj_name, obj_prop, 0, comm);
+    global_obj = PDCobj_create_coll(cont, obj_name, obj_prop, 0, comm);
     // global_obj = PDCobj_create(cont, obj_name, obj_prop);
 
     if (global_obj <= 0) {

--- a/src/tests/tags/kvtag_query.c
+++ b/src/tests/tags/kvtag_query.c
@@ -116,8 +116,13 @@ main(int argc, char *argv[])
     TASSERT((cont_prop = PDCprop_create(PDC_CONT_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");
     // create a container
-    TASSERT((cont = PDCcont_create_col("c1", cont_prop)) != 0, "Call to PDCcont_create_col succeeded",
-            "Call to PDCcont_create_col failed");
+#ifdef ENABLE_MPI
+    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
+            "Call to PDCcont_create_coll failed");
+#else 
+    TASSERT((cont = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
+            "Call to PDCcont_create failed");
+#endif
     // create an object property
     TASSERT((obj_prop = PDCprop_create(PDC_OBJ_CREATE, pdc)) != 0, "Call to PDCprop_create succeeded",
             "Call to PDCprop_create failed");

--- a/src/tests/tags/kvtag_query.c
+++ b/src/tests/tags/kvtag_query.c
@@ -117,9 +117,9 @@ main(int argc, char *argv[])
             "Call to PDCprop_create failed");
     // create a container
 #ifdef ENABLE_MPI
-    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0, "Call to PDCcont_create_coll succeeded",
-            "Call to PDCcont_create_coll failed");
-#else 
+    TASSERT((cont = PDCcont_create_coll("c1", cont_prop, MPI_COMM_WORLD)) != 0,
+            "Call to PDCcont_create_coll succeeded", "Call to PDCcont_create_coll failed");
+#else
     TASSERT((cont = PDCcont_create("c1", cont_prop)) != 0, "Call to PDCcont_create succeeded",
             "Call to PDCcont_create failed");
 #endif

--- a/src/tools/pdc_access_eqsim.c
+++ b/src/tools/pdc_access_eqsim.c
@@ -47,7 +47,12 @@ main(int argc, char **argv)
 
     pdc = PDCinit("pdc");
 
+#ifdef ENABLE_MPI
     obj = PDCobj_open_coll("run1", pdc, MPI_COMM_WORLD);
+#else
+    obj = PDCobj_open("run1", pdc);
+#endif
+
     if (obj <= 0)
         LOG_ERROR("Failed to open object");
 

--- a/src/tools/pdc_access_eqsim.c
+++ b/src/tools/pdc_access_eqsim.c
@@ -47,7 +47,7 @@ main(int argc, char **argv)
 
     pdc = PDCinit("pdc");
 
-    obj = PDCobj_open_col("run1", pdc);
+    obj = PDCobj_open_coll("run1", pdc, MPI_COMM_WORLD);
     if (obj <= 0)
         LOG_ERROR("Failed to open object");
 

--- a/src/tools/pdc_import_eqsim.c
+++ b/src/tools/pdc_import_eqsim.c
@@ -146,7 +146,7 @@ main(int argc, char **argv)
     PDCprop_set_obj_app_name(obj_prop, "EQSIM");
     PDCprop_set_obj_transfer_region_type(obj_prop, PDC_REGION_LOCAL);
 
-    obj = PDCobj_create_mpi(cont, "run1", obj_prop, 0, MPI_COMM_WORLD);
+    obj = PDCobj_create_coll(cont, "run1", obj_prop, 0, MPI_COMM_WORLD);
     if (obj <= 0)
         LOG_ERROR("Failed to create object");
 

--- a/src/tools/pdc_import_eqsim.c
+++ b/src/tools/pdc_import_eqsim.c
@@ -146,7 +146,11 @@ main(int argc, char **argv)
     PDCprop_set_obj_app_name(obj_prop, "EQSIM");
     PDCprop_set_obj_transfer_region_type(obj_prop, PDC_REGION_LOCAL);
 
+#ifdef ENABLE_MPI
     obj = PDCobj_create_coll(cont, "run1", obj_prop, 0, MPI_COMM_WORLD);
+#else
+    obj = PDCobj_create(cont, "run1", obj_prop);
+#endif
     if (obj <= 0)
         LOG_ERROR("Failed to create object");
 

--- a/src/tools/pdc_query_eqsim.c
+++ b/src/tools/pdc_query_eqsim.c
@@ -139,7 +139,7 @@ main(int argc, char **argv)
     PDCprop_set_obj_app_name(obj_prop, "EQSIM");
     /* PDCprop_set_obj_transfer_region_type(obj_prop, PDC_REGION_LOCAL); */
 
-    obj = PDCobj_create_mpi(cont, "run1", obj_prop, 0, MPI_COMM_WORLD);
+    obj = PDCobj_create_coll(cont, "run1", obj_prop, 0, MPI_COMM_WORLD);
     /* obj = PDCobj_create(cont, "run1", obj_prop); */
     if (obj <= 0)
         LOG_ERROR("Failed to create object\n");

--- a/src/tools/pdc_query_eqsim.c
+++ b/src/tools/pdc_query_eqsim.c
@@ -139,8 +139,11 @@ main(int argc, char **argv)
     PDCprop_set_obj_app_name(obj_prop, "EQSIM");
     /* PDCprop_set_obj_transfer_region_type(obj_prop, PDC_REGION_LOCAL); */
 
+#ifdef ENABLE_MPI
     obj = PDCobj_create_coll(cont, "run1", obj_prop, 0, MPI_COMM_WORLD);
-    /* obj = PDCobj_create(cont, "run1", obj_prop); */
+#else
+    obj = PDCobj_create(cont, "run1", obj_prop);
+#endif
     if (obj <= 0)
         LOG_ERROR("Failed to create object\n");
 


### PR DESCRIPTION
# Related Issues / Pull Requests

List all related issues and/or pull requests if there are any
https://github.com/hpc-io/pdc/issues/288#issue-3298042097
https://github.com/hpc-io/pdc/pull/290#issue-3423430275

## Summary

This PR standardizes the naming and signature of all collective MPI operations in the PDC client API across 47 files. The convention is now consistent: collective variants use a `_coll` suffix and always take an MPI communicator (MPI_Comm comm) as their last parameter.

## Changes

**API standardization (src/api/):**
- All collective functions renamed to use _coll suffix where missing
- MPI_Comm comm added as the last parameter to all collective function signatures in pdc_cont.h, pdc_obj.h, and pdc_region.h
- pdc_mpi.h and pdc_mpi.c updated to match new signatures
- Implementations in pdc_cont.c, pdc_obj.c, and pdc_region_transfer.c updated accordingly

**Examples updated (examples/):**
- bdcats.c, bdcats_batch.c, haccio.c, haccio_v2.c, read_write_col_perf.c, tileio.c, tileio_v2.c, vpicio.c, vpicio_batch.c, vpicio_old.c updated to use new signatures

**Tests updated (src/tests/):**
- All collective test programs updated to pass MPI communicator explicitly
- Affected: cont/, obj/, misc/, deprecated/, tags/

**Tools updated (src/tools/):**
- pdc_access_eqsim.c, pdc_import_eqsim.c, pdc_query_eqsim.c updated

**Docs updated (docs/):**
- client_api.rst and using_pdc.rst updated to reflect new API signatures

## Convention

Before this PR, collective calls were inconsistently named and some did not expose the MPI communicator to the caller. The new standard is:

- Collective functions end in _coll
- The MPI communicator is always the last parameter
- When built without ENABLE_MPI, the comm parameter is int

Example:
  Before: PDCcont_create(name, prop)
  After:  PDCcont_create_coll(name, prop, comm)

Include a brief summary of the proposed changes.

# What changes are proposed in this pull request?

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [X] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [X] My code requires documentation updates, and I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
