### PR TITLE
guard MPI rank lookup with MPI_Initialized() in logger

### DIFF
--- a/src/commons/logging/pdc_logger.c
+++ b/src/commons/logging/pdc_logger.c
@@ -133,8 +133,12 @@ _log_message(bool is_server, PDC_LogLevel level, const char *file, const char *f
 
 #ifdef ENABLE_MPI
         static int my_rank = -1;
-        if (my_rank == -1)
-            my_rank = PDC_get_rank();
+        if (my_rank == -1) {
+            int mpi_initialized = 0;
+            MPI_Initialized(&mpi_initialized);
+            if (mpi_initialized)
+                my_rank = PDC_get_rank();
+        }
 #endif
 
         // Print differently based on log level


### PR DESCRIPTION
# Related Issues / Pull Requests

Fixes #277

### Problem
When logging functions are called before `MPI_Init()` (e.g. during early startup), the logger unconditionally calls `PDC_get_rank()` -> `MPI_Comm_rank()`. This violates the MPI standard and causes an immediate job abort:

*** The MPI_Comm_rank() function was called before MPI_INIT was invoked.
*** This is disallowed by the MPI standard.
*** Your MPI job will now abort.

### Fix
In `_log_message`, wrap the `PDC_get_rank()` call with an `MPI_Initialized()` check before attempting to populate the cached rank.

### Why this is correct
- `MPI_Initialized()` is one of the handful of MPI routines explicitly permitted before `MPI_Init()` (MPI standard §8.7).
- The existing `static` caching is preserved: once the rank is fetched it is never looked up again, so there is no per-call overhead on the hot path.
- Before MPI is initialized, `my_rank` stays `-1` and log lines print `PDC_CLIENT[-1]` / `PDC_SERVER[-1]`, making pre-MPI log output clearly identifiable rather than silently wrong or fatal.

### Testing
Call any logging macro before `MPI_Init()` with `ENABLE_MPI` defined and confirm the process no longer aborts.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected; for instance, examples in this repository must be updated too)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code modifies existing public API, or introduces new public API, and I updated or wrote docstrings
- [ ] I have commented my code
- [ ] My code requires documentation updates, and I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
